### PR TITLE
feat: executive dashboard redesign

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,10 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
 }
 
 :root {
@@ -77,6 +81,10 @@
   --sidebar-accent-foreground: oklch(0.25 0.01 260);
   --sidebar-border: oklch(0.92 0.005 260);
   --sidebar-ring: oklch(0.55 0.2 270);
+  --success: oklch(0.50 0.18 155);
+  --success-foreground: oklch(0.98 0 0);
+  --warning: oklch(0.65 0.15 80);
+  --warning-foreground: oklch(0.25 0 0);
 }
 
 @layer base {
@@ -146,4 +154,26 @@
 }
 .stagger-5 {
   animation-delay: 200ms;
+}
+
+@keyframes pulse-attention {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+.animate-pulse-attention {
+  animation: pulse-attention 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-up,
+  .animate-slide-in,
+  .animate-badge-bounce,
+  .animate-pulse-attention {
+    animation: none;
+  }
 }

--- a/src/components/dashboard/__tests__/dashboard-summary.test.tsx
+++ b/src/components/dashboard/__tests__/dashboard-summary.test.tsx
@@ -17,17 +17,20 @@ const baseSummary: DashboardSummaryType = {
 };
 
 describe("DashboardSummary", () => {
-  it("renders three summary cards", () => {
+  it("renders four KPI cards", () => {
     render(<DashboardSummary summary={baseSummary} />);
     expect(screen.getByText("要フォロー")).toBeDefined();
     expect(screen.getByText("アクション完了率")).toBeDefined();
+    expect(screen.getByText("今月の1on1")).toBeDefined();
     expect(screen.getByText("期限超過")).toBeDefined();
   });
 
-  it("does not render meetings this month card", () => {
+  it("renders meetings this month card", () => {
     const summary = { ...baseSummary, meetingsThisMonth: 5 };
     render(<DashboardSummary summary={summary} />);
-    expect(screen.queryByText("今月の1on1")).toBeNull();
+    expect(screen.getByText("今月の1on1")).toBeDefined();
+    expect(screen.getByText("5")).toBeDefined();
+    expect(screen.getByText("回")).toBeDefined();
   });
 
   it("displays needsFollowUp count", () => {
@@ -54,5 +57,44 @@ describe("DashboardSummary", () => {
     render(<DashboardSummary summary={summary} />);
     expect(screen.getByText("2")).toBeDefined();
     expect(screen.getByText("件")).toBeDefined();
+  });
+
+  it("applies success border when needsFollowUp is 0", () => {
+    render(<DashboardSummary summary={baseSummary} />);
+    const card = screen.getByText("要フォロー").closest("[data-testid]");
+    expect(card?.className).toContain("border-l-4");
+    expect(card?.className).toContain("border-l-success");
+  });
+
+  it("applies warning border when needsFollowUp is 1-2", () => {
+    const summary = { ...baseSummary, needsFollowUp: 2 };
+    render(<DashboardSummary summary={summary} />);
+    const card = screen.getByText("要フォロー").closest("[data-testid]");
+    expect(card?.className).toContain("border-l-4");
+    expect(card?.className).toContain("border-l-warning");
+  });
+
+  it("applies destructive border when needsFollowUp is 3+", () => {
+    const summary = { ...baseSummary, needsFollowUp: 3 };
+    render(<DashboardSummary summary={summary} />);
+    const card = screen.getByText("要フォロー").closest("[data-testid]");
+    expect(card?.className).toContain("border-l-4");
+    expect(card?.className).toContain("border-l-destructive");
+  });
+
+  it("renders trend icons", () => {
+    const summary = { ...baseSummary, needsFollowUp: 1 };
+    render(<DashboardSummary summary={summary} />);
+    // Each card should have an icon (svg element)
+    const cards = screen.getAllByTestId(/^kpi-card-/);
+    cards.forEach((card) => {
+      expect(card.querySelector("svg")).not.toBeNull();
+    });
+  });
+
+  it("uses lg:grid-cols-4 layout", () => {
+    const { container } = render(<DashboardSummary summary={baseSummary} />);
+    const grid = container.firstElementChild;
+    expect(grid?.className).toContain("lg:grid-cols-4");
   });
 });

--- a/src/components/dashboard/dashboard-summary.tsx
+++ b/src/components/dashboard/dashboard-summary.tsx
@@ -1,75 +1,127 @@
+import {
+  CircleAlert,
+  TrendingUp,
+  Calendar,
+  CircleCheck,
+} from "lucide-react";
 import type { DashboardSummary as DashboardSummaryType } from "@/lib/actions/dashboard-actions";
 
 type Props = {
   readonly summary: DashboardSummaryType;
 };
 
-type SummaryCardProps = {
+type Variant = "success" | "warning" | "danger" | "info";
+
+type KPICardProps = {
   readonly title: string;
   readonly value: number;
   readonly unit: string;
-  readonly accent?: "destructive" | "success" | "default";
+  readonly variant: Variant;
+  readonly icon: React.ReactNode;
+  readonly testId: string;
+  readonly staggerClass: string;
 };
 
-function getAccentClasses(accent: SummaryCardProps["accent"]): string {
-  switch (accent) {
-    case "destructive":
-      return "text-[oklch(0.55_0.2_25)]";
+function getBorderClass(variant: Variant): string {
+  switch (variant) {
     case "success":
-      return "text-[oklch(0.45_0.15_155)]";
-    default:
-      return "text-foreground";
+      return "border-l-success";
+    case "warning":
+      return "border-l-warning";
+    case "danger":
+      return "border-l-destructive";
+    case "info":
+      return "border-l-primary";
   }
 }
 
-function SummaryCard({ title, value, unit, accent = "default" }: SummaryCardProps) {
+function getValueClass(variant: Variant): string {
+  switch (variant) {
+    case "success":
+      return "text-success";
+    case "warning":
+      return "text-warning";
+    case "danger":
+      return "text-destructive";
+    case "info":
+      return "text-primary";
+  }
+}
+
+function KPICard({ title, value, unit, variant, icon, testId, staggerClass }: KPICardProps) {
   return (
-    <div className="rounded-xl border bg-card p-5">
-      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-        {title}
-      </p>
-      <p className={`text-2xl font-semibold tracking-tight ${getAccentClasses(accent)}`}>
+    <div
+      data-testid={testId}
+      className={`animate-fade-in-up ${staggerClass} rounded-xl border border-l-4 ${getBorderClass(variant)} bg-card p-5`}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {title}
+        </p>
+        <span className={`${getValueClass(variant)} opacity-70`}>{icon}</span>
+      </div>
+      <p className={`text-4xl font-bold tracking-tight ${getValueClass(variant)}`}>
         {value}
-        <span className="ml-0.5 text-sm font-normal text-muted-foreground">{unit}</span>
+        <span className="ml-1 text-sm font-normal text-muted-foreground">{unit}</span>
       </p>
     </div>
   );
 }
 
-function getFollowUpAccent(count: number): SummaryCardProps["accent"] {
-  return count > 0 ? "destructive" : "success";
+function getFollowUpVariant(count: number): Variant {
+  if (count === 0) return "success";
+  if (count <= 2) return "warning";
+  return "danger";
 }
 
-function getCompletionAccent(rate: number): SummaryCardProps["accent"] {
+function getCompletionVariant(rate: number): Variant {
   if (rate >= 80) return "success";
-  if (rate >= 50) return "default";
-  return "destructive";
+  if (rate >= 50) return "warning";
+  return "danger";
 }
 
-function getOverdueAccent(count: number): SummaryCardProps["accent"] {
-  return count > 0 ? "destructive" : "success";
+function getOverdueVariant(count: number): Variant {
+  return count === 0 ? "success" : "danger";
 }
 
 export function DashboardSummary({ summary }: Props) {
   return (
-    <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
-      <SummaryCard
+    <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <KPICard
+        testId="kpi-card-follow-up"
         title="要フォロー"
         value={summary.needsFollowUp}
         unit="人"
-        accent={getFollowUpAccent(summary.needsFollowUp)}
+        variant={getFollowUpVariant(summary.needsFollowUp)}
+        icon={<CircleAlert className="w-5 h-5" />}
+        staggerClass="stagger-1"
       />
-      <SummaryCard
+      <KPICard
+        testId="kpi-card-completion"
         title="アクション完了率"
         value={summary.actionCompletionRate}
         unit="%"
-        accent={getCompletionAccent(summary.actionCompletionRate)}
+        variant={getCompletionVariant(summary.actionCompletionRate)}
+        icon={<TrendingUp className="w-5 h-5" />}
+        staggerClass="stagger-2"
       />
-      <SummaryCard
+      <KPICard
+        testId="kpi-card-meetings"
+        title="今月の1on1"
+        value={summary.meetingsThisMonth}
+        unit="回"
+        variant="info"
+        icon={<Calendar className="w-5 h-5" />}
+        staggerClass="stagger-3"
+      />
+      <KPICard
+        testId="kpi-card-overdue"
         title="期限超過"
         value={summary.overdueActions}
         unit="件"
-        accent={getOverdueAccent(summary.overdueActions)}
+        variant={getOverdueVariant(summary.overdueActions)}
+        icon={<CircleCheck className="w-5 h-5" />}
+        staggerClass="stagger-4"
       />
     </div>
   );

--- a/src/components/member/__tests__/member-list.test.tsx
+++ b/src/components/member/__tests__/member-list.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemberList } from "../member-list";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseMember = {
+  id: "member-1",
+  name: "田中太郎",
+  department: "エンジニアリング",
+  position: "シニアエンジニア",
+  _count: { actionItems: 3 },
+  meetings: [{ date: new Date("2026-02-10") }],
+  overdueActionCount: 1,
+};
+
+describe("MemberList", () => {
+  it("renders empty state when no members", () => {
+    render(<MemberList members={[]} />);
+    expect(screen.getByText("メンバーがまだ登録されていません")).toBeDefined();
+    expect(screen.getByText("メンバーを追加")).toBeDefined();
+  });
+
+  it("renders member name and department", () => {
+    render(<MemberList members={[baseMember]} />);
+    expect(screen.getByText("田中太郎")).toBeDefined();
+    expect(screen.getByText("エンジニアリング")).toBeDefined();
+  });
+
+  it("renders position as subtext under name", () => {
+    render(<MemberList members={[baseMember]} />);
+    expect(screen.getByText("シニアエンジニア")).toBeDefined();
+  });
+
+  it("renders status badges", () => {
+    const recentMember = {
+      ...baseMember,
+      meetings: [{ date: new Date() }],
+    };
+    render(<MemberList members={[recentMember]} />);
+    expect(screen.getByText("良好")).toBeDefined();
+  });
+
+  it("renders 要フォロー badge for members with old meetings", () => {
+    const oldMember = {
+      ...baseMember,
+      meetings: [{ date: new Date("2026-01-01") }],
+    };
+    render(<MemberList members={[oldMember]} />);
+    expect(screen.getByText("要フォロー")).toBeDefined();
+  });
+
+  it("renders overdue action count", () => {
+    render(<MemberList members={[baseMember]} />);
+    expect(screen.getByText(/1件超過/)).toBeDefined();
+  });
+
+  it("applies pulse-attention class to 要フォロー badge", () => {
+    const oldMember = {
+      ...baseMember,
+      meetings: [{ date: new Date("2026-01-01") }],
+    };
+    render(<MemberList members={[oldMember]} />);
+    const badge = screen.getByText("要フォロー");
+    expect(badge.className).toContain("animate-pulse-attention");
+  });
+
+  it("uses shadcn Table components", () => {
+    const { container } = render(<MemberList members={[baseMember]} />);
+    expect(container.querySelector('[data-slot="table"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="table-header"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="table-body"]')).not.toBeNull();
+  });
+
+  it("renders rows with role=link", () => {
+    render(<MemberList members={[baseMember]} />);
+    const rows = screen.getAllByRole("link");
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -5,6 +5,14 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { formatRelativeDate } from "@/lib/format";
 import { ArrowUpDown } from "lucide-react";
@@ -30,7 +38,9 @@ function getLastMeetingDays(date: Date | null): number {
 function getStatusBadge(days: number): React.ReactNode {
   if (days >= 14)
     return (
-      <Badge className="bg-[oklch(0.95_0.05_25)] text-[oklch(0.45_0.15_25)]">要フォロー</Badge>
+      <Badge className="animate-pulse-attention bg-[oklch(0.95_0.05_25)] text-[oklch(0.45_0.15_25)]">
+        要フォロー
+      </Badge>
     );
   if (days >= 7)
     return <Badge className="bg-[oklch(0.95_0.05_80)] text-[oklch(0.4_0.1_80)]">注意</Badge>;
@@ -78,16 +88,16 @@ export function MemberList({ members }: Props) {
 
   return (
     <div className="animate-fade-in-up rounded-xl border bg-card overflow-hidden">
-      <table className="w-full">
-        <thead>
-          <tr className="border-b">
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
               メンバー
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3 hidden sm:table-cell">
+            </TableHead>
+            <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3 hidden sm:table-cell">
               部署
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
+            </TableHead>
+            <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
               <button
                 onClick={() => toggleSort("lastMeeting")}
                 className="flex items-center gap-1 hover:text-foreground transition-colors duration-150"
@@ -95,8 +105,8 @@ export function MemberList({ members }: Props) {
                 最終1on1
                 <ArrowUpDown className="w-3 h-3" />
               </button>
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
+            </TableHead>
+            <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
               <button
                 onClick={() => toggleSort("actions")}
                 className="flex items-center gap-1 hover:text-foreground transition-colors duration-150"
@@ -104,21 +114,21 @@ export function MemberList({ members }: Props) {
                 未完了
                 <ArrowUpDown className="w-3 h-3" />
               </button>
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3 hidden md:table-cell">
+            </TableHead>
+            <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3 hidden md:table-cell">
               ステータス
-            </th>
-            <th className="px-4 py-3">
+            </TableHead>
+            <TableHead className="px-4 py-3">
               <span className="sr-only">アクション</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {sortedMembers.map((member) => {
             const lastDate = member.meetings[0]?.date ?? null;
             const days = getLastMeetingDays(lastDate);
             return (
-              <tr
+              <TableRow
                 key={member.id}
                 onClick={() => router.push(`/members/${member.id}`)}
                 onKeyDown={(e) => {
@@ -126,34 +136,43 @@ export function MemberList({ members }: Props) {
                 }}
                 tabIndex={0}
                 role="link"
-                className="border-b last:border-b-0 hover:bg-muted/50 cursor-pointer transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="hover:bg-muted/50 hover:shadow-sm cursor-pointer transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                <td className="px-4 py-3">
+                <TableCell className="px-4 py-3">
                   <div className="flex items-center gap-3">
                     <AvatarInitial name={member.name} size="sm" />
-                    <span className="font-medium text-sm">{member.name}</span>
+                    <div>
+                      <span className="font-medium text-sm">{member.name}</span>
+                      {member.position && (
+                        <p className="text-xs text-muted-foreground">{member.position}</p>
+                      )}
+                    </div>
                   </div>
-                </td>
-                <td className="px-4 py-3 text-sm text-muted-foreground hidden sm:table-cell">
+                </TableCell>
+                <TableCell className="px-4 py-3 text-sm text-muted-foreground hidden sm:table-cell">
                   {member.department ?? "—"}
-                </td>
-                <td className="px-4 py-3 text-sm text-muted-foreground">
+                </TableCell>
+                <TableCell className="px-4 py-3 text-sm text-muted-foreground">
                   {formatRelativeDate(lastDate)}
-                </td>
-                <td className="px-4 py-3 text-sm">
-                  {member._count.actionItems > 0 ? (
-                    <span className="text-foreground">{member._count.actionItems}件</span>
-                  ) : (
-                    <span className="text-muted-foreground">—</span>
-                  )}
-                  {member.overdueActionCount > 0 && (
-                    <span className="ml-1 text-[oklch(0.55_0.2_25)] text-xs">
-                      ({member.overdueActionCount}件超過)
-                    </span>
-                  )}
-                </td>
-                <td className="px-4 py-3 hidden md:table-cell">{getStatusBadge(days)}</td>
-                <td className="px-4 py-3 text-right">
+                </TableCell>
+                <TableCell className="px-4 py-3 text-sm">
+                  <div>
+                    {member._count.actionItems > 0 ? (
+                      <span className="text-foreground">{member._count.actionItems}件</span>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                    {member.overdueActionCount > 0 && (
+                      <p className="text-destructive text-xs">
+                        {member.overdueActionCount}件超過
+                      </p>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell className="px-4 py-3 hidden md:table-cell">
+                  {getStatusBadge(days)}
+                </TableCell>
+                <TableCell className="px-4 py-3 text-right">
                   <Link
                     href={`/members/${member.id}/meetings/new`}
                     onClick={(e) => e.stopPropagation()}
@@ -162,12 +181,12 @@ export function MemberList({ members }: Props) {
                       1on1
                     </Button>
                   </Link>
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             );
           })}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Summary
- KPI カードを3枚→4枚に拡張（今月の1on1 追加）、variant ベースの左ボーダー・lucide アイコン・text-4xl 数値表示でエグゼクティブダッシュボード化
- メンバーテーブルを shadcn/ui Table に置換、position サブテキスト追加、要フォローバッジに pulse アニメーション
- CSS にセマンティックカラー変数（success/warning）、pulse-attention アニメーション、prefers-reduced-motion 対応を追加

## Test Plan
- [x] dashboard-summary テスト 10件パス（4枚カード、variant ボーダー、アイコン、レイアウト）
- [x] member-list テスト 9件パス（空状態、名前・部署表示、position サブテキスト、ステータスバッジ、pulse、shadcn Table）
- [ ] 開発サーバーで目視確認（KPI カード4枚、テーブルホバー、pulse バッジ）
- [ ] モバイルレスポンシブ確認（375px, 768px）
- [ ] prefers-reduced-motion 確認