### PR TITLE
feat: メンバー編集UIを追加

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -7,6 +7,7 @@ import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { MeetingHistory } from "@/components/meeting/meeting-history";
 import { ActionListCompact } from "@/components/action/action-list-compact";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { MemberEditDialog } from "@/components/member/member-edit-dialog";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -30,6 +31,14 @@ export default async function MemberDetailPage({ params }: Props) {
           </div>
         </div>
         <div className="flex gap-2">
+          <MemberEditDialog
+            member={{
+              id: member.id,
+              name: member.name,
+              department: member.department,
+              position: member.position,
+            }}
+          />
           <Link href={`/members/${id}/meetings/prepare`}>
             <Button variant="outline">1on1 を準備</Button>
           </Link>

--- a/src/components/member/__tests__/member-edit-dialog.test.tsx
+++ b/src/components/member/__tests__/member-edit-dialog.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemberEditDialog } from "../member-edit-dialog";
+
+const mockRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: mockRefresh,
+  }),
+}));
+
+const mockUpdateMember = vi.fn();
+
+vi.mock("@/lib/actions/member-actions", () => ({
+  createMember: vi.fn(),
+  updateMember: (...args: unknown[]) => mockUpdateMember(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const member = {
+  id: "member-1",
+  name: "田中太郎",
+  department: "エンジニアリング",
+  position: "シニアエンジニア",
+};
+
+describe("MemberEditDialog", () => {
+  it("「編集」ボタンが表示される", () => {
+    render(<MemberEditDialog member={member} />);
+    expect(screen.getByRole("button", { name: /編集/ })).toBeDefined();
+  });
+
+  it("ボタンクリックでダイアログが開く", async () => {
+    const user = userEvent.setup();
+    render(<MemberEditDialog member={member} />);
+
+    await user.click(screen.getByRole("button", { name: /編集/ }));
+
+    expect(screen.getByText("メンバー情報の編集")).toBeDefined();
+    expect(screen.getByText("名前、部署、役職を変更できます。")).toBeDefined();
+  });
+
+  it("ダイアログ内にメンバーの初期値が表示される", async () => {
+    const user = userEvent.setup();
+    render(<MemberEditDialog member={member} />);
+
+    await user.click(screen.getByRole("button", { name: /編集/ }));
+
+    const nameInput = screen.getByLabelText("名前 *") as HTMLInputElement;
+    expect(nameInput.value).toBe("田中太郎");
+  });
+
+  it("更新成功後にダイアログが閉じ、router.refresh が呼ばれる", async () => {
+    const user = userEvent.setup();
+    mockUpdateMember.mockResolvedValue({});
+    render(<MemberEditDialog member={member} />);
+
+    await user.click(screen.getByRole("button", { name: /編集/ }));
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    expect(mockUpdateMember).toHaveBeenCalledWith("member-1", {
+      name: "田中太郎",
+      department: "エンジニアリング",
+      position: "シニアエンジニア",
+    });
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/src/components/member/__tests__/member-form.test.tsx
+++ b/src/components/member/__tests__/member-form.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemberForm } from "../member-form";
+
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}));
+
+const mockCreateMember = vi.fn();
+const mockUpdateMember = vi.fn();
+
+vi.mock("@/lib/actions/member-actions", () => ({
+  createMember: (...args: unknown[]) => mockCreateMember(...args),
+  updateMember: (...args: unknown[]) => mockUpdateMember(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("MemberForm - 新規作成モード", () => {
+  it("「メンバー登録」タイトルが表示される", () => {
+    render(<MemberForm />);
+    expect(screen.getByText("メンバー登録")).toBeDefined();
+  });
+
+  it("「登録する」ボタンが表示される", () => {
+    render(<MemberForm />);
+    expect(screen.getByRole("button", { name: "登録する" })).toBeDefined();
+  });
+
+  it("空の入力フィールドが表示される", () => {
+    render(<MemberForm />);
+    const nameInput = screen.getByLabelText("名前 *") as HTMLInputElement;
+    const deptInput = screen.getByLabelText("部署") as HTMLInputElement;
+    const posInput = screen.getByLabelText("役職") as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+    expect(deptInput.value).toBe("");
+    expect(posInput.value).toBe("");
+  });
+
+  it("送信時に createMember が呼ばれる", async () => {
+    const user = userEvent.setup();
+    mockCreateMember.mockResolvedValue({});
+    render(<MemberForm />);
+
+    await user.type(screen.getByLabelText("名前 *"), "山田花子");
+    await user.type(screen.getByLabelText("部署"), "デザイン");
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    expect(mockCreateMember).toHaveBeenCalledWith({
+      name: "山田花子",
+      department: "デザイン",
+      position: undefined,
+    });
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+
+  it("エラー時にエラーメッセージが表示される", async () => {
+    const user = userEvent.setup();
+    mockCreateMember.mockRejectedValue(new Error("登録に失敗しました"));
+    render(<MemberForm />);
+
+    await user.type(screen.getByLabelText("名前 *"), "テスト");
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    expect(screen.getByText("登録に失敗しました")).toBeDefined();
+  });
+});
+
+describe("MemberForm - 編集モード", () => {
+  const initialData = {
+    id: "member-1",
+    name: "田中太郎",
+    department: "エンジニアリング",
+    position: "シニアエンジニア",
+  };
+
+  it("「メンバー登録」タイトルが表示されない（Card なし）", () => {
+    render(<MemberForm initialData={initialData} />);
+    expect(screen.queryByText("メンバー登録")).toBeNull();
+  });
+
+  it("「更新する」ボタンが表示される", () => {
+    render(<MemberForm initialData={initialData} />);
+    expect(screen.getByRole("button", { name: "更新する" })).toBeDefined();
+  });
+
+  it("初期値がフォームに入力されている", () => {
+    render(<MemberForm initialData={initialData} />);
+    const nameInput = screen.getByLabelText("名前 *") as HTMLInputElement;
+    const deptInput = screen.getByLabelText("部署") as HTMLInputElement;
+    const posInput = screen.getByLabelText("役職") as HTMLInputElement;
+    expect(nameInput.value).toBe("田中太郎");
+    expect(deptInput.value).toBe("エンジニアリング");
+    expect(posInput.value).toBe("シニアエンジニア");
+  });
+
+  it("送信時に updateMember が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    mockUpdateMember.mockResolvedValue({});
+    render(<MemberForm initialData={initialData} onSuccess={onSuccess} />);
+
+    const nameInput = screen.getByLabelText("名前 *");
+    await user.clear(nameInput);
+    await user.type(nameInput, "田中次郎");
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    expect(mockUpdateMember).toHaveBeenCalledWith("member-1", {
+      name: "田中次郎",
+      department: "エンジニアリング",
+      position: "シニアエンジニア",
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("エラー時にエラーメッセージが表示される", async () => {
+    const user = userEvent.setup();
+    mockUpdateMember.mockRejectedValue(new Error("更新に失敗しました"));
+    render(<MemberForm initialData={initialData} />);
+
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    expect(screen.getByText("更新に失敗しました")).toBeDefined();
+  });
+
+  it("初期値の department が null の場合、空文字で表示される", () => {
+    render(<MemberForm initialData={{ ...initialData, department: null }} />);
+    const deptInput = screen.getByLabelText("部署") as HTMLInputElement;
+    expect(deptInput.value).toBe("");
+  });
+});

--- a/src/components/member/member-edit-dialog.tsx
+++ b/src/components/member/member-edit-dialog.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { MemberForm } from "@/components/member/member-form";
+
+type MemberData = {
+  readonly id: string;
+  readonly name: string;
+  readonly department: string | null;
+  readonly position: string | null;
+};
+
+type Props = {
+  readonly member: MemberData;
+};
+
+export function MemberEditDialog({ member }: Props) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  function handleSuccess() {
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Pencil className="w-4 h-4 mr-1.5" />
+          編集
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold tracking-tight">
+            メンバー情報の編集
+          </DialogTitle>
+          <DialogDescription>名前、部署、役職を変更できます。</DialogDescription>
+        </DialogHeader>
+        <MemberForm initialData={member} onSuccess={handleSuccess} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/member/member-form.tsx
+++ b/src/components/member/member-form.tsx
@@ -6,12 +6,25 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { createMember } from "@/lib/actions/member-actions";
+import { createMember, updateMember } from "@/lib/actions/member-actions";
 
-export function MemberForm() {
+type MemberData = {
+  readonly id: string;
+  readonly name: string;
+  readonly department: string | null;
+  readonly position: string | null;
+};
+
+type Props = {
+  readonly initialData?: MemberData;
+  readonly onSuccess?: () => void;
+};
+
+export function MemberForm({ initialData, onSuccess }: Props) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isEditing = !!initialData;
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -24,8 +37,13 @@ export function MemberForm() {
     const position = (formData.get("position") as string) || undefined;
 
     try {
-      await createMember({ name, department, position });
-      router.push("/");
+      if (isEditing) {
+        await updateMember(initialData.id, { name, department, position });
+        onSuccess?.();
+      } else {
+        await createMember({ name, department, position });
+        router.push("/");
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "エラーが発生しました");
     } finally {
@@ -33,31 +51,59 @@ export function MemberForm() {
     }
   }
 
+  const content = (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="name">名前 *</Label>
+        <Input
+          id="name"
+          name="name"
+          required
+          defaultValue={initialData?.name ?? ""}
+          placeholder="例: 田中太郎"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="department">部署</Label>
+        <Input
+          id="department"
+          name="department"
+          defaultValue={initialData?.department ?? ""}
+          placeholder="例: エンジニアリング"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="position">役職</Label>
+        <Input
+          id="position"
+          name="position"
+          defaultValue={initialData?.position ?? ""}
+          placeholder="例: シニアエンジニア"
+        />
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting
+          ? isEditing
+            ? "更新中..."
+            : "登録中..."
+          : isEditing
+            ? "更新する"
+            : "登録する"}
+      </Button>
+    </form>
+  );
+
+  if (isEditing) {
+    return content;
+  }
+
   return (
     <Card className="max-w-lg">
       <CardHeader>
         <CardTitle className="text-lg font-semibold tracking-tight">メンバー登録</CardTitle>
       </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="name">名前 *</Label>
-            <Input id="name" name="name" required placeholder="例: 田中太郎" />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="department">部署</Label>
-            <Input id="department" name="department" placeholder="例: エンジニアリング" />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="position">役職</Label>
-            <Input id="position" name="position" placeholder="例: シニアエンジニア" />
-          </div>
-          {error && <p className="text-sm text-destructive">{error}</p>}
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? "登録中..." : "登録する"}
-          </Button>
-        </form>
-      </CardContent>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
既存のupdateMember Server Actionに対応するUIを実装。
MemberFormを新規作成・編集の両方に対応させ、メンバー詳細画面にダイアログ形式の編集ボタンを追加。

https://claude.ai/code/session_0159r48kJA9hFoCnPMiQpwvC