### PR TITLE
feat: ミーティング・メンバーの削除確認ダイアログを追加

### DIFF
--- a/src/app/members/[id]/meetings/[meetingId]/page.tsx
+++ b/src/app/members/[id]/meetings/[meetingId]/page.tsx
@@ -4,6 +4,7 @@ import { getMeeting } from "@/lib/actions/meeting-actions";
 import { formatDate } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { MeetingDetail } from "@/components/meeting/meeting-detail";
+import { MeetingDeleteDialog } from "@/components/meeting/meeting-delete-dialog";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 
 type Props = { params: Promise<{ id: string; meetingId: string }> };
@@ -33,9 +34,16 @@ export default async function MeetingDetailPage({ params }: Props) {
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
           {meeting.member.name}との1on1
         </h1>
-        <Link href={`/members/${id}`}>
-          <Button variant="outline">戻る</Button>
-        </Link>
+        <div className="flex gap-2">
+          <MeetingDeleteDialog
+            meetingId={meetingId}
+            memberId={id}
+            meetingDate={formatDate(meeting.date)}
+          />
+          <Link href={`/members/${id}`}>
+            <Button variant="outline">戻る</Button>
+          </Link>
+        </div>
       </div>
       <MeetingDetail
         date={meeting.date}

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -8,6 +8,7 @@ import { MeetingHistory } from "@/components/meeting/meeting-history";
 import { ActionListCompact } from "@/components/action/action-list-compact";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { MemberEditDialog } from "@/components/member/member-edit-dialog";
+import { MemberDeleteDialog } from "@/components/member/member-delete-dialog";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -31,6 +32,7 @@ export default async function MemberDetailPage({ params }: Props) {
           </div>
         </div>
         <div className="flex gap-2">
+          <MemberDeleteDialog memberId={member.id} memberName={member.name} />
           <MemberEditDialog
             member={{
               id: member.id,

--- a/src/components/meeting/__tests__/meeting-delete-dialog.test.tsx
+++ b/src/components/meeting/__tests__/meeting-delete-dialog.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MeetingDeleteDialog } from "../meeting-delete-dialog";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: vi.fn(),
+  }),
+}));
+
+const mockDeleteMeeting = vi.fn();
+
+vi.mock("@/lib/actions/meeting-actions", () => ({
+  deleteMeeting: (...args: unknown[]) => mockDeleteMeeting(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const props = {
+  meetingId: "meeting-1",
+  memberId: "member-1",
+  meetingDate: "2025年1月15日",
+};
+
+describe("MeetingDeleteDialog", () => {
+  it("「削除」ボタンが表示される", () => {
+    render(<MeetingDeleteDialog {...props} />);
+    expect(screen.getByRole("button", { name: /削除/ })).toBeDefined();
+  });
+
+  it("ボタンクリックで確認ダイアログが開く", async () => {
+    const user = userEvent.setup();
+    render(<MeetingDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+
+    expect(screen.getByText("ミーティングを削除しますか？")).toBeDefined();
+    expect(
+      screen.getByText(
+        "2025年1月15日のミーティング記録を削除します。関連する話題とアクションアイテムもすべて削除されます。この操作は取り消せません。",
+      ),
+    ).toBeDefined();
+  });
+
+  it("キャンセルボタンでダイアログが閉じる", async () => {
+    const user = userEvent.setup();
+    render(<MeetingDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(mockDeleteMeeting).not.toHaveBeenCalled();
+  });
+
+  it("削除成功後にメンバー詳細ページへ遷移する", async () => {
+    const user = userEvent.setup();
+    mockDeleteMeeting.mockResolvedValue({});
+    render(<MeetingDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+
+    expect(mockDeleteMeeting).toHaveBeenCalledWith("meeting-1");
+    expect(mockPush).toHaveBeenCalledWith("/members/member-1");
+  });
+
+  it("削除失敗時にエラーメッセージが表示される", async () => {
+    const user = userEvent.setup();
+    mockDeleteMeeting.mockRejectedValue(new Error("Server error"));
+    render(<MeetingDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("削除に失敗しました。もう一度お試しください。")).toBeDefined();
+    });
+  });
+});

--- a/src/components/meeting/meeting-delete-dialog.tsx
+++ b/src/components/meeting/meeting-delete-dialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { deleteMeeting } from "@/lib/actions/meeting-actions";
+
+type Props = {
+  readonly meetingId: string;
+  readonly memberId: string;
+  readonly meetingDate: string;
+};
+
+export function MeetingDeleteDialog({ meetingId, memberId, meetingDate }: Props) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleDelete() {
+    setLoading(true);
+    setError(null);
+    try {
+      await deleteMeeting(meetingId);
+      setOpen(false);
+      router.push(`/members/${memberId}`);
+    } catch {
+      setError("削除に失敗しました。もう一度お試しください。");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          <Trash2 className="w-4 h-4 mr-1.5" />
+          削除
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>ミーティングを削除しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            {meetingDate}
+            のミーティング記録を削除します。関連する話題とアクションアイテムもすべて削除されます。この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>キャンセル</AlertDialogCancel>
+          <Button variant="destructive" onClick={handleDelete} disabled={loading}>
+            {loading ? "削除中..." : "削除する"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/member/__tests__/member-delete-dialog.test.tsx
+++ b/src/components/member/__tests__/member-delete-dialog.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemberDeleteDialog } from "../member-delete-dialog";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: vi.fn(),
+  }),
+}));
+
+const mockDeleteMember = vi.fn();
+
+vi.mock("@/lib/actions/member-actions", () => ({
+  deleteMember: (...args: unknown[]) => mockDeleteMember(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const props = {
+  memberId: "member-1",
+  memberName: "田中太郎",
+};
+
+describe("MemberDeleteDialog", () => {
+  it("「削除」ボタンが表示される", () => {
+    render(<MemberDeleteDialog {...props} />);
+    expect(screen.getByRole("button", { name: /削除/ })).toBeDefined();
+  });
+
+  it("ボタンクリックで確認ダイアログが開く", async () => {
+    const user = userEvent.setup();
+    render(<MemberDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+
+    expect(screen.getByText("メンバーを削除しますか？")).toBeDefined();
+    expect(
+      screen.getByText(
+        "田中太郎のデータを削除します。関連するミーティング記録やアクションアイテムもすべて削除されます。この操作は取り消せません。",
+      ),
+    ).toBeDefined();
+  });
+
+  it("キャンセルボタンでダイアログが閉じる", async () => {
+    const user = userEvent.setup();
+    render(<MemberDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(mockDeleteMember).not.toHaveBeenCalled();
+  });
+
+  it("削除成功後にダッシュボードへ遷移する", async () => {
+    const user = userEvent.setup();
+    mockDeleteMember.mockResolvedValue({});
+    render(<MemberDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+
+    expect(mockDeleteMember).toHaveBeenCalledWith("member-1");
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+
+  it("削除失敗時にエラーメッセージが表示される", async () => {
+    const user = userEvent.setup();
+    mockDeleteMember.mockRejectedValue(new Error("Server error"));
+    render(<MemberDeleteDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("削除に失敗しました。もう一度お試しください。")).toBeDefined();
+    });
+  });
+});

--- a/src/components/member/member-delete-dialog.tsx
+++ b/src/components/member/member-delete-dialog.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { deleteMember } from "@/lib/actions/member-actions";
+
+type Props = {
+  readonly memberId: string;
+  readonly memberName: string;
+};
+
+export function MemberDeleteDialog({ memberId, memberName }: Props) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleDelete() {
+    setLoading(true);
+    setError(null);
+    try {
+      await deleteMember(memberId);
+      setOpen(false);
+      router.push("/");
+    } catch {
+      setError("削除に失敗しました。もう一度お試しください。");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          <Trash2 className="w-4 h-4 mr-1.5" />
+          削除
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>メンバーを削除しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            {memberName}
+            のデータを削除します。関連するミーティング記録やアクションアイテムもすべて削除されます。この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>キャンセル</AlertDialogCancel>
+          <Button variant="destructive" onClick={handleDelete} disabled={loading}>
+            {loading ? "削除中..." : "削除する"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};


### PR DESCRIPTION
削除操作にAlertDialogベースの確認ダイアログを導入し、誤削除を防止する。
既存のdeleteMeeting/deleteMember Server Actionsに対応するUIを追加。

- shadcn/ui AlertDialogコンポーネントを追加
- ミーティング詳細画面に削除ボタン・確認ダイアログを追加
- メンバー詳細画面に削除ボタン・確認ダイアログを追加
- 削除中のローディング状態とエラーハンドリングを実装
- 各コンポーネントのユニットテストを追加（10テスト）

https://claude.ai/code/session_01VyXbc59Y3QMZXyAkebKxyW