### PR TITLE
docs: プロジェクトドキュメントの追加と CLAUDE.md 更新

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Database
+# Prisma ORM で使用する SQLite データベースファイルのパス
+# 開発環境: file:./dev.db
+# テスト環境: file:./test.db（vitest.config.ts で自動設定）
+DATABASE_URL="file:./dev.db"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Nudge は 1on1 ミーティングの記録・管理を行うシングルユー�
 - **テスト:** Vitest + Testing Library + jsdom
 - **デザインシステム:** Slate & Indigo テーマ（OKLch カラーパレット、Geist Sans）
 - **アイコン:** lucide-react
+- **DnD:** @dnd-kit/core + @dnd-kit/sortable
 - **コード品質:** ESLint, Prettier, husky + lint-staged
 - **言語:** TypeScript 5 (strict mode)
 
@@ -24,13 +25,17 @@ src/
 ├── app/                    # Next.js App Router ページ
 │   ├── actions/            # アクションアイテム一覧
 │   ├── members/            # メンバー CRUD・ミーティングページ
+│   │   ├── [id]/           # メンバー詳細・ミーティング管理
+│   │   │   └── meetings/   # ミーティング作成・詳細・準備
+│   │   └── new/            # メンバー新規作成
 │   ├── globals.css         # テーマ変数・アニメーション定義
 │   ├── layout.tsx          # ルートレイアウト（フォント・サイドバー統合）
 │   └── page.tsx            # ダッシュボード
 ├── components/
 │   ├── action/             # アクションアイテム コンポーネント
-│   ├── layout/             # レイアウト コンポーネント（サイドバー）
-│   ├── meeting/            # ミーティング コンポーネント
+│   ├── dashboard/          # ダッシュボード コンポーネント
+│   ├── layout/             # レイアウト コンポーネント（サイドバー・パンくず）
+│   ├── meeting/            # ミーティング コンポーネント（DnD ソート含む）
 │   ├── member/             # メンバー コンポーネント
 │   └── ui/                 # shadcn/ui ベースコンポーネント（avatar-initial 含む）
 ├── generated/prisma/       # Prisma 生成クライアント（gitignore対象）
@@ -38,6 +43,7 @@ src/
     ├── actions/            # Server Actions（データ変更処理）
     ├── validations/        # Zod スキーマ
     ├── avatar.ts           # アバターイニシャル・グラデーション生成
+    ├── meeting-templates.ts # ミーティングテンプレート定義
     ├── prisma.ts           # Prisma クライアント シングルトン
     ├── constants.ts        # アプリ定数
     ├── format.ts           # 日付フォーマット ユーティリティ

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -1,0 +1,141 @@
+# 開発ガイド (CONTRIB)
+
+> Source of truth: `package.json`, `.env.example`
+
+## 環境セットアップ
+
+### 前提条件
+
+- Node.js 20+
+- npm 10+
+- Git
+
+### 初期セットアップ
+
+```bash
+# リポジトリのクローン
+git clone https://github.com/dtakamiya/nudge.git
+cd nudge
+
+# 依存パッケージのインストール
+npm install
+
+# 環境変数の設定
+cp .env.example .env
+
+# データベースのセットアップ
+npx prisma migrate dev
+npx prisma db seed
+
+# Prisma クライアントの生成
+npx prisma generate
+
+# 開発サーバーの起動
+npm run dev
+```
+
+## npm スクリプト一覧
+
+| コマンド | 実行内容 | 説明 |
+|---------|---------|------|
+| `npm run dev` | `next dev` | 開発サーバー起動（ホットリロード付き） |
+| `npm run build` | `next build` | 本番用ビルド |
+| `npm run start` | `next start` | 本番サーバー起動 |
+| `npm run lint` | `eslint` | ESLint による静的解析 |
+| `npm test` | `vitest run` | テスト実行（単発） |
+| `npm run test:watch` | `vitest` | テスト実行（ウォッチモード） |
+| `npm run format` | `prettier --write .` | Prettier で全ファイルフォーマット |
+| `npm run format:check` | `prettier --check .` | Prettier フォーマットチェック（CI 用） |
+| `npm run prepare` | `husky` | Git フック設定（自動実行） |
+
+## データベースコマンド
+
+| コマンド | 説明 |
+|---------|------|
+| `npx prisma migrate dev` | マイグレーション実行（開発環境） |
+| `npx prisma db seed` | シードデータ投入 |
+| `npx prisma generate` | Prisma クライアント生成 |
+| `npx prisma studio` | Prisma Studio（DB GUI）起動 |
+
+## 環境変数
+
+| 変数名 | 必須 | 説明 | 例 |
+|--------|------|------|-----|
+| `DATABASE_URL` | Yes | SQLite データベースファイルパス | `file:./dev.db` |
+
+- テスト環境では `vitest.config.ts` で `DATABASE_URL=file:./test.db` に自動設定される
+
+## 開発ワークフロー
+
+### Git ブランチ戦略
+
+1. `main` ブランチから git worktree で作業ブランチを作成
+2. 機能実装は worktree 内で行う
+3. 完了後: プッシュ → PR 作成 → worktree クリーンアップ
+4. `main` には直接コミットしない
+
+### コミットメッセージ
+
+```
+<type>: <description>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
+
+### コミット時の自動チェック（lint-staged）
+
+コミット時に husky + lint-staged により以下が自動実行される:
+
+- `*.{ts,tsx,js,jsx,mjs,json,css,md}` → Prettier フォーマット
+- `*.{ts,tsx}` → ESLint 修正 + TypeScript 型チェック
+
+## テスト
+
+### テストの実行
+
+```bash
+# 全テスト実行
+npm test
+
+# ウォッチモードで実行
+npm run test:watch
+```
+
+### テスト構成
+
+- **フレームワーク:** Vitest + Testing Library + jsdom
+- **テストファイル:** `src/**/__tests__/*.test.{ts,tsx}`
+- **カバレッジ目標:** 80% 以上
+- **テスト DB:** `file:./test.db`（開発 DB とは分離）
+
+### TDD ワークフロー
+
+1. テストを書く（RED）
+2. テスト実行 → 失敗を確認
+3. 最小限の実装（GREEN）
+4. テスト実行 → 成功を確認
+5. リファクタリング（REFACTOR）
+6. カバレッジ確認（80%+）
+
+## コーディング規約
+
+- **イミュータブル:** 既存オブジェクトを変更せず、新しいオブジェクトを生成
+- **UI テキスト:** ユーザー向けは日本語
+- **パスエイリアス:** `@/*` → `src/*`
+- **ファイルサイズ:** 400 行以下推奨（最大 800 行）
+- **関数サイズ:** 50 行以下
+- **主キー:** UUID（`@id @default(uuid())`）
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+|---------|------|
+| フレームワーク | Next.js 16 (App Router) + React 19 |
+| データベース | Prisma ORM + SQLite |
+| スタイリング | Tailwind CSS 4 + shadcn/ui |
+| バリデーション | Zod 4 |
+| テスト | Vitest + Testing Library + jsdom |
+| アイコン | lucide-react |
+| DnD | @dnd-kit/core + @dnd-kit/sortable |
+| コード品質 | ESLint, Prettier, husky + lint-staged |
+| 言語 | TypeScript 5 (strict mode) |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,187 @@
+# 運用ガイド (RUNBOOK)
+
+> Nudge はシングルユーザー向けローカルアプリケーション。
+> 本ガイドはローカル環境での運用・トラブルシューティングを対象とする。
+
+## デプロイ手順
+
+### ローカルビルド & 起動
+
+```bash
+# 依存パッケージのインストール
+npm install
+
+# Prisma クライアント生成
+npx prisma generate
+
+# データベースマイグレーション
+npx prisma migrate deploy
+
+# 本番ビルド
+npm run build
+
+# サーバー起動
+npm run start
+```
+
+### 初回セットアップ
+
+```bash
+# 環境変数の設定
+cp .env.example .env
+
+# データベース初期化（マイグレーション + シード）
+npx prisma migrate dev
+npx prisma db seed
+```
+
+## トラブルシューティング
+
+### ビルドエラー
+
+**症状:** `npm run build` が失敗する
+
+```bash
+# 1. TypeScript エラーの確認
+npx tsc --noEmit
+
+# 2. ESLint エラーの確認
+npm run lint
+
+# 3. Prisma クライアントの再生成
+npx prisma generate
+
+# 4. node_modules の再インストール
+rm -rf node_modules && npm install
+```
+
+### データベース関連
+
+**症状:** Prisma エラー、DB 接続失敗
+
+```bash
+# 1. .env の DATABASE_URL を確認
+cat .env
+
+# 2. マイグレーション状態の確認
+npx prisma migrate status
+
+# 3. マイグレーションの再実行
+npx prisma migrate dev
+
+# 4. DB のリセット（データは消える）
+npx prisma migrate reset
+```
+
+**症状:** スキーマ変更後にエラー
+
+```bash
+# Prisma クライアントを再生成
+npx prisma generate
+
+# 開発サーバーを再起動
+npm run dev
+```
+
+### テスト関連
+
+**症状:** テストが失敗する
+
+```bash
+# 1. 全テスト実行で状況確認
+npm test
+
+# 2. 特定テストのみ実行
+npx vitest run src/lib/__tests__/format.test.ts
+
+# 3. テスト DB のリセット
+DATABASE_URL="file:./test.db" npx prisma migrate reset --force
+```
+
+### 開発サーバー
+
+**症状:** 開発サーバーが起動しない
+
+```bash
+# 1. ポート競合の確認
+lsof -i :3000
+
+# 2. Next.js キャッシュのクリア
+rm -rf .next
+
+# 3. 再起動
+npm run dev
+```
+
+### Prisma Studio
+
+**症状:** Prisma Studio が開かない
+
+```bash
+# DATABASE_URL が設定されていることを確認
+npx prisma studio
+```
+
+## データベーススキーマ
+
+### モデル一覧
+
+| モデル | 説明 |
+|--------|------|
+| `Member` | 1on1 対象メンバー |
+| `Meeting` | ミーティング記録 |
+| `Topic` | ミーティングのトピック |
+| `ActionItem` | アクションアイテム |
+
+### リレーション
+
+```
+Member 1--* Meeting
+Member 1--* ActionItem
+Meeting 1--* Topic
+Meeting 1--* ActionItem
+```
+
+### Enum
+
+- `TopicCategory`: WORK_PROGRESS, CAREER, ISSUES, FEEDBACK, OTHER
+- `ActionItemStatus`: TODO, IN_PROGRESS, DONE
+
+## バックアップ & リストア
+
+### バックアップ
+
+```bash
+# SQLite ファイルをコピー
+cp prisma/dev.db prisma/dev.db.backup
+```
+
+### リストア
+
+```bash
+# バックアップから復元
+cp prisma/dev.db.backup prisma/dev.db
+```
+
+## ログ確認
+
+- **Next.js ログ:** 開発サーバーのコンソール出力
+- **Prisma ログ:** `prisma.$on('query', ...)` で有効化可能
+- **ブラウザログ:** DevTools Console
+
+## ロールバック手順
+
+```bash
+# 直前のマイグレーションをロールバック
+# 注意: SQLite はマイグレーションのロールバックが限定的
+# 安全な方法: バックアップから復元
+
+# 1. DB バックアップ復元
+cp prisma/dev.db.backup prisma/dev.db
+
+# 2. 前のコミットに戻す
+git checkout <previous-commit> -- prisma/schema.prisma prisma/migrations/
+
+# 3. Prisma クライアント再生成
+npx prisma generate
+```


### PR DESCRIPTION
## Summary
- `.env.example` を新規追加（環境変数テンプレート）
- `docs/CONTRIB.md` を新規追加（開発ガイド: セットアップ手順、npm スクリプト一覧、テスト手順、コーディング規約）
- `docs/RUNBOOK.md` を新規追加（運用ガイド: デプロイ手順、トラブルシューティング、バックアップ/リストア）
- `CLAUDE.md` のディレクトリ構成を実態に合わせて更新（dashboard, DnD, meeting-templates 等を反映）
- `.gitignore` で `.env.example` を追跡対象に変更

## Test plan
- [ ] `.env.example` の内容が正しいことを確認
- [ ] `docs/CONTRIB.md` のスクリプト一覧が `package.json` と一致することを確認
- [ ] `docs/RUNBOOK.md` のコマンドが動作することを確認
- [ ] `CLAUDE.md` のディレクトリ構成が実際のファイル構成と一致することを確認