### PR TITLE
test: action-filters テスト追加（buildFilterUrl ロジック抽出）

### DIFF
--- a/docs/feature-analysis.md
+++ b/docs/feature-analysis.md
@@ -218,7 +218,7 @@ Member (1) ──< (N) Meeting (1) ──< (N) Topic
 - [x] `member-delete-dialog` のテスト追加
 - [x] `meeting-delete-dialog` のテスト追加
 - [x] `member-form` のテスト追加
-- [ ] `action-filters` のテスト追加
+- [x] `action-filters` のテスト追加
 - [ ] `sidebar` のテスト追加
 - [ ] `breadcrumb` のテスト追加
 - [ ] Playwright による E2E テストの導入

--- a/src/components/action/__tests__/action-filters.test.tsx
+++ b/src/components/action/__tests__/action-filters.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ActionFilters, buildFilterUrl } from "../action-filters";
+
+const mockPush = vi.fn();
+const mockSearchParamsGet = vi.fn().mockReturnValue(null);
+const mockSearchParamsToString = vi.fn().mockReturnValue("");
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({
+    get: mockSearchParamsGet,
+    toString: mockSearchParamsToString,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const mockMembers = [
+  { id: "member-1", name: "田中太郎" },
+  { id: "member-2", name: "佐藤花子" },
+];
+
+describe("buildFilterUrl", () => {
+  it("value が 'all' のとき該当キーを削除する", () => {
+    expect(buildFilterUrl("status=TODO", "status", "all")).toBe("/actions?");
+  });
+
+  it("value が 'all' でないとき該当キーをセットする", () => {
+    expect(buildFilterUrl("", "status", "TODO")).toBe("/actions?status=TODO");
+  });
+
+  it("既存パラメータを保持しつつ新しいパラメータを追加する", () => {
+    const result = buildFilterUrl("status=TODO", "memberId", "member-1");
+    expect(result).toBe("/actions?status=TODO&memberId=member-1");
+  });
+
+  it("status を 'all' にすると memberId のみ残る", () => {
+    const result = buildFilterUrl("status=TODO&memberId=member-1", "status", "all");
+    expect(result).toBe("/actions?memberId=member-1");
+  });
+
+  it("空のパラメータに値を追加する", () => {
+    expect(buildFilterUrl("", "memberId", "member-1")).toBe("/actions?memberId=member-1");
+  });
+});
+
+describe("ActionFilters", () => {
+  it("2つのフィルターセレクトが表示される", () => {
+    render(<ActionFilters members={mockMembers} />);
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers.length).toBe(2);
+  });
+
+  it("空のメンバーリストでもレンダリングされる", () => {
+    render(<ActionFilters members={[]} />);
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers.length).toBe(2);
+  });
+
+  it("searchParams にステータスがないとき 'すべて' がデフォルト表示される", () => {
+    mockSearchParamsGet.mockReturnValue(null);
+    render(<ActionFilters members={mockMembers} />);
+    expect(screen.getByText("すべて")).toBeDefined();
+  });
+
+  it("searchParams にメンバーがないとき '全メンバー' がデフォルト表示される", () => {
+    mockSearchParamsGet.mockReturnValue(null);
+    render(<ActionFilters members={mockMembers} />);
+    expect(screen.getByText("全メンバー")).toBeDefined();
+  });
+
+  // Note: Radix UI Select の onValueChange テストは jsdom 環境では
+  // hasPointerCapture 非対応のため実行不可。
+  // フィルターロジックは buildFilterUrl のユニットテストで検証している。
+});

--- a/src/components/action/action-filters.tsx
+++ b/src/components/action/action-filters.tsx
@@ -12,18 +12,22 @@ import {
 type Member = { id: string; name: string };
 type Props = { members: Member[] };
 
+export function buildFilterUrl(currentParams: string, key: string, value: string): string {
+  const params = new URLSearchParams(currentParams);
+  if (value === "all") {
+    params.delete(key);
+  } else {
+    params.set(key, value);
+  }
+  return `/actions?${params.toString()}`;
+}
+
 export function ActionFilters({ members }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   function updateFilter(key: string, value: string) {
-    const params = new URLSearchParams(searchParams.toString());
-    if (value === "all") {
-      params.delete(key);
-    } else {
-      params.set(key, value);
-    }
-    router.push(`/actions?${params.toString()}`);
+    router.push(buildFilterUrl(searchParams.toString(), key, value));
   }
 
   return (


### PR DESCRIPTION
## Summary

- `action-filters.tsx` から URL パラメータ構築ロジックを `buildFilterUrl` として抽出・named export 化
- `action-filters.test.tsx` を新規作成（9 テスト）
- `docs/feature-analysis.md` の `action-filters` テスト項目を完了マークに更新

## 変更内容

### `src/components/action/action-filters.tsx`
- `buildFilterUrl(currentParams, key, value)` をピュア関数として抽出・named export
- `updateFilter` 内で `buildFilterUrl` を呼び出すようにリファクタリング（外部動作は変化なし）

### `src/components/action/__tests__/action-filters.test.tsx`（新規）
**buildFilterUrl ユニットテスト（5件）**
- `value="all"` のとき該当キーを削除する
- `value="all"` でないとき該当キーをセットする
- 既存パラメータを保持しつつ新しいパラメータを追加する
- status を `all` にすると memberId のみ残る
- 空のパラメータに値を追加する

**ActionFilters レンダリングテスト（4件）**
- 2つのフィルターセレクトが表示される
- 空のメンバーリストでもレンダリングされる
- searchParams なしで「すべて」がデフォルト表示される
- searchParams なしで「全メンバー」がデフォルト表示される

> **Note:** jsdom 環境では Radix UI Select の `onValueChange` が `hasPointerCapture` 非対応のため実行不可。フィルターロジックは `buildFilterUrl` のユニットテストで完全に検証。

## Test plan

- [ ] `npm test` で全テスト（9件追加 → 計 187件）が通ることを確認
- [ ] `buildFilterUrl` のロジックが URL パラメータの追加・削除・保持を正しく行うことを確認
- [ ] `ActionFilters` コンポーネントがメンバーリスト有無にかかわらず正しくレンダリングされることを確認
- [ ] 既存テスト（`action-list-full`, `action-list-compact` 等）への影響がないことを確認