### PR TITLE
test: breadcrumb のテスト追加（10件）

### DIFF
--- a/docs/feature-analysis.md
+++ b/docs/feature-analysis.md
@@ -220,7 +220,7 @@ Member (1) ──< (N) Meeting (1) ──< (N) Topic
 - [x] `member-form` のテスト追加
 - [x] `action-filters` のテスト追加
 - [x] `sidebar` のテスト追加
-- [ ] `breadcrumb` のテスト追加
+- [x] `breadcrumb` のテスト追加
 - [ ] Playwright による E2E テストの導入
 - [ ] カバレッジの CI 自動測定
 

--- a/src/components/layout/__tests__/breadcrumb.test.tsx
+++ b/src/components/layout/__tests__/breadcrumb.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { Breadcrumb } from "../breadcrumb";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Breadcrumb - アクセシビリティ", () => {
+  it("nav に aria-label='パンくずリスト' が設定されている", () => {
+    render(<Breadcrumb items={[{ label: "ホーム" }]} />);
+    expect(screen.getByRole("navigation", { name: "パンくずリスト" })).toBeDefined();
+  });
+});
+
+describe("Breadcrumb - 基本表示", () => {
+  it("空配列でもクラッシュせずレンダーされる", () => {
+    render(<Breadcrumb items={[]} />);
+    expect(screen.getByRole("navigation")).toBeDefined();
+  });
+
+  it("アイテムのラベルが表示される", () => {
+    render(<Breadcrumb items={[{ label: "ホーム" }]} />);
+    expect(screen.getByText("ホーム")).toBeDefined();
+  });
+
+  it("複数アイテム全てのラベルが表示される", () => {
+    render(
+      <Breadcrumb
+        items={[
+          { label: "ホーム", href: "/" },
+          { label: "メンバー", href: "/members" },
+          { label: "田中太郎" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("ホーム")).toBeDefined();
+    expect(screen.getByText("メンバー")).toBeDefined();
+    expect(screen.getByText("田中太郎")).toBeDefined();
+  });
+});
+
+describe("Breadcrumb - リンク表示", () => {
+  it("href があるアイテムはリンク（<a>）としてレンダーされる", () => {
+    render(<Breadcrumb items={[{ label: "ホーム", href: "/" }]} />);
+    const link = screen.getByRole("link", { name: "ホーム" });
+    expect(link).toBeDefined();
+  });
+
+  it("リンクの href 属性が正しい値を持つ", () => {
+    render(<Breadcrumb items={[{ label: "メンバー", href: "/members" }]} />);
+    const link = screen.getByRole("link", { name: "メンバー" });
+    expect(link.getAttribute("href")).toBe("/members");
+  });
+
+  it("href がないアイテムはリンクではなくテキストとしてレンダーされる", () => {
+    render(<Breadcrumb items={[{ label: "田中太郎" }]} />);
+    expect(screen.queryByRole("link", { name: "田中太郎" })).toBeNull();
+    expect(screen.getByText("田中太郎")).toBeDefined();
+  });
+});
+
+describe("Breadcrumb - セパレーター", () => {
+  it("アイテムが1つのときセパレーターが表示されない", () => {
+    const { container } = render(<Breadcrumb items={[{ label: "ホーム" }]} />);
+    expect(container.querySelectorAll("svg").length).toBe(0);
+  });
+
+  it("アイテムが2つのとき SVG セパレーターが1つ表示される", () => {
+    const { container } = render(
+      <Breadcrumb items={[{ label: "ホーム", href: "/" }, { label: "メンバー" }]} />,
+    );
+    expect(container.querySelectorAll("svg").length).toBe(1);
+  });
+
+  it("アイテムが3つのとき SVG セパレーターが2つ表示される", () => {
+    const { container } = render(
+      <Breadcrumb
+        items={[
+          { label: "ホーム", href: "/" },
+          { label: "メンバー", href: "/members" },
+          { label: "田中太郎" },
+        ]}
+      />,
+    );
+    expect(container.querySelectorAll("svg").length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- `src/components/layout/__tests__/breadcrumb.test.tsx` を新規作成
- `Breadcrumb` コンポーネントのテストを 10 件追加
- `docs/feature-analysis.md` § 2.5.4 の `breadcrumb のテスト追加` タスクを `[x]` に更新

## テストケース内訳

| describe | 件数 | 観点 |
|---------|------|------|
| アクセシビリティ | 1 | `aria-label="パンくずリスト"` |
| 基本表示 | 3 | 空配列・単一ラベル・複数アイテム |
| リンク表示 | 3 | `href` あり/なし・`href` 属性値 |
| セパレーター | 3 | SVG セパレーターの表示件数 |

## Test plan

- [ ] `npm test` で全 263 件パスすることを確認
- [ ] `breadcrumb.test.tsx` の 10 件が全てパスすること
- [ ] 既存 33 ファイルのテストにリグレッションがないこと