### PR TITLE
feat: アクセシビリティ改善（WCAG 2.1 AA 対応）

### DIFF
--- a/src/components/action/__tests__/action-list-compact.test.tsx
+++ b/src/components/action/__tests__/action-list-compact.test.tsx
@@ -131,6 +131,18 @@ describe("ActionListCompact", () => {
     expect(mockRefresh).toHaveBeenCalled();
   });
 
+  it("ステータスボタンに aria-label が設定されている", () => {
+    render(<ActionListCompact actionItems={baseItems} />);
+    // TODO → 次は IN_PROGRESS
+    expect(
+      screen.getByRole("button", { name: "テストタスク1のステータスを進行中に変更" }),
+    ).toBeDefined();
+    // IN_PROGRESS → 次は DONE
+    expect(
+      screen.getByRole("button", { name: "テストタスク2のステータスを完了に変更" }),
+    ).toBeDefined();
+  });
+
   it("編集ボタンが各行に表示される", () => {
     render(<ActionListCompact actionItems={baseItems} />);
     const editButtons = screen.getAllByRole("button", { name: /編集/ });

--- a/src/components/action/action-list-compact.tsx
+++ b/src/components/action/action-list-compact.tsx
@@ -139,7 +139,10 @@ export function ActionListCompact({ actionItems }: Props) {
         ) : (
           <div key={item.id} className="flex items-center justify-between p-2 border rounded">
             <div className="flex items-center gap-2">
-              <button onClick={() => cycleStatus(item.id, item.status)}>
+              <button
+                onClick={() => cycleStatus(item.id, item.status)}
+                aria-label={`${item.title}のステータスを${statusLabels[nextStatus(item.status)]}に変更`}
+              >
                 <Badge variant={statusColors[item.status]}>{statusLabels[item.status]}</Badge>
               </button>
               <span className="text-sm">{item.title}</span>

--- a/src/components/meeting/__tests__/sortable-action-item.test.tsx
+++ b/src/components/meeting/__tests__/sortable-action-item.test.tsx
@@ -41,6 +41,16 @@ describe("SortableActionItem", () => {
     expect(screen.getByRole("button", { name: "削除" })).toBeTruthy();
   });
 
+  it("ドラッグハンドルに aria-label が設定されている", () => {
+    render(<SortableActionItem {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "レビュー依頼を並び替え" })).toBeTruthy();
+  });
+
+  it("タイトルが空のときドラッグハンドルに fallback aria-label が設定される", () => {
+    render(<SortableActionItem {...defaultProps} title="" />);
+    expect(screen.getByRole("button", { name: "アクションアイテムを並び替え" })).toBeTruthy();
+  });
+
   it("calls onUpdate when title changes", async () => {
     const user = userEvent.setup();
     render(<SortableActionItem {...defaultProps} />);

--- a/src/components/meeting/__tests__/sortable-topic-item.test.tsx
+++ b/src/components/meeting/__tests__/sortable-topic-item.test.tsx
@@ -41,6 +41,16 @@ describe("SortableTopicItem", () => {
     expect(screen.getByRole("button", { name: "削除" })).toBeTruthy();
   });
 
+  it("ドラッグハンドルに aria-label が設定されている", () => {
+    render(<SortableTopicItem {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "進捗報告を並び替え" })).toBeTruthy();
+  });
+
+  it("タイトルが空のときドラッグハンドルに fallback aria-label が設定される", () => {
+    render(<SortableTopicItem {...defaultProps} title="" />);
+    expect(screen.getByRole("button", { name: "話題を並び替え" })).toBeTruthy();
+  });
+
   it("hides delete button when showDelete is false", () => {
     render(<SortableTopicItem {...defaultProps} showDelete={false} />);
     expect(screen.queryByRole("button", { name: "削除" })).toBeNull();

--- a/src/components/meeting/meeting-form.tsx
+++ b/src/components/meeting/meeting-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import {
   DndContext,
   closestCenter,
@@ -21,6 +21,7 @@ import { createMeeting, updateMeeting } from "@/lib/actions/meeting-actions";
 import { TOAST_MESSAGES } from "@/lib/toast-messages";
 import { SortableTopicItem } from "./sortable-topic-item";
 import { SortableActionItem } from "./sortable-action-item";
+import { screenReaderInstructions, createAnnouncements } from "@/lib/dnd-accessibility";
 
 type TopicFormData = {
   id?: string;
@@ -112,6 +113,8 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  const topicAnnouncements = useMemo(() => createAnnouncements("話題"), []);
+  const actionAnnouncements = useMemo(() => createAnnouncements("アクション"), []);
 
   function addTopic() {
     setTopics((prev) => [...prev, createEmptyTopic(prev.length)]);
@@ -270,6 +273,10 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
             sensors={sensors}
             collisionDetection={closestCenter}
             onDragEnd={handleTopicDragEnd}
+            accessibility={{
+              announcements: topicAnnouncements,
+              screenReaderInstructions,
+            }}
           >
             <SortableContext items={topicIds} strategy={verticalListSortingStrategy}>
               {topics.map((topic, index) => (
@@ -307,6 +314,10 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
             sensors={sensors}
             collisionDetection={closestCenter}
             onDragEnd={handleActionDragEnd}
+            accessibility={{
+              announcements: actionAnnouncements,
+              screenReaderInstructions,
+            }}
           >
             <SortableContext items={actionIds} strategy={verticalListSortingStrategy}>
               {actionItems.map((action, index) => (

--- a/src/components/meeting/sortable-action-item.tsx
+++ b/src/components/meeting/sortable-action-item.tsx
@@ -52,6 +52,8 @@ export function SortableActionItem({
           className="cursor-grab touch-none text-muted-foreground hover:text-foreground self-center"
           {...attributes}
           {...listeners}
+          aria-label={`${title || "アクションアイテム"}を並び替え`}
+          aria-roledescription="並び替え可能"
         >
           <GripVertical className="w-4 h-4" />
         </button>

--- a/src/components/meeting/sortable-topic-item.tsx
+++ b/src/components/meeting/sortable-topic-item.tsx
@@ -66,6 +66,8 @@ export function SortableTopicItem({
           className="cursor-grab touch-none text-muted-foreground hover:text-foreground self-center"
           {...attributes}
           {...listeners}
+          aria-label={`${title || "話題"}を並び替え`}
+          aria-roledescription="並び替え可能"
         >
           <GripVertical className="w-4 h-4" />
         </button>

--- a/src/lib/__tests__/dnd-accessibility.test.ts
+++ b/src/lib/__tests__/dnd-accessibility.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { screenReaderInstructions, createAnnouncements } from "../dnd-accessibility";
+
+describe("dnd-accessibility", () => {
+  describe("screenReaderInstructions", () => {
+    it("draggable の説明にスペースキーの操作方法が含まれる", () => {
+      expect(screenReaderInstructions.draggable).toContain("スペースキー");
+    });
+
+    it("draggable の説明に矢印キーの操作方法が含まれる", () => {
+      expect(screenReaderInstructions.draggable).toContain("矢印キー");
+    });
+
+    it("draggable の説明にエスケープキーのキャンセル方法が含まれる", () => {
+      expect(screenReaderInstructions.draggable).toContain("エスケープキー");
+    });
+  });
+
+  describe("createAnnouncements", () => {
+    const announcements = createAnnouncements("話題");
+
+    it("onDragStart でアイテムを掴んだことを通知する", () => {
+      const result = announcements.onDragStart!({
+        active: { id: "topic-0" },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      expect(result).toContain("話題");
+      expect(result).toContain("掴みました");
+    });
+
+    it("onDragOver でドロップ先がある場合に移動中を通知する", () => {
+      const result = announcements.onDragOver!({
+        active: { id: "topic-0" },
+        over: { id: "topic-1" },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      expect(result).toContain("移動中");
+    });
+
+    it("onDragOver でドロップ先がない場合に通知する", () => {
+      const result = announcements.onDragOver!({
+        active: { id: "topic-0" },
+        over: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      expect(result).toContain("外");
+    });
+
+    it("onDragEnd でドロップ先がある場合に配置を通知する", () => {
+      const result = announcements.onDragEnd!({
+        active: { id: "topic-0" },
+        over: { id: "topic-1" },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      expect(result).toContain("配置しました");
+    });
+
+    it("onDragEnd でドロップ先がない場合に通知する", () => {
+      const result = announcements.onDragEnd!({
+        active: { id: "topic-0" },
+        over: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      expect(result).toBeDefined();
+    });
+
+    it("onDragCancel でキャンセルを通知する", () => {
+      const result = announcements.onDragCancel!({
+        active: { id: "topic-0" },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      expect(result).toContain("キャンセル");
+    });
+  });
+});

--- a/src/lib/dnd-accessibility.ts
+++ b/src/lib/dnd-accessibility.ts
@@ -1,0 +1,29 @@
+import type { Announcements, ScreenReaderInstructions } from "@dnd-kit/core";
+
+export const screenReaderInstructions: ScreenReaderInstructions = {
+  draggable:
+    "並び替え可能な項目です。スペースキーまたはエンターキーで掴み、矢印キーで移動し、再度スペースキーで配置します。エスケープキーでキャンセルできます。",
+};
+
+export function createAnnouncements(itemLabel: string): Announcements {
+  return {
+    onDragStart({ active }) {
+      return `${itemLabel} ${active.id} を掴みました。`;
+    },
+    onDragOver({ active, over }) {
+      if (over) {
+        return `${itemLabel} ${active.id} を ${over.id} の位置に移動中です。`;
+      }
+      return `${itemLabel} ${active.id} はドロップ先の外にあります。`;
+    },
+    onDragEnd({ active, over }) {
+      if (over) {
+        return `${itemLabel} ${active.id} を ${over.id} の位置に配置しました。`;
+      }
+      return `${itemLabel} ${active.id} をドロップしましたが、有効なドロップ先がありませんでした。`;
+    },
+    onDragCancel({ active }) {
+      return `並び替えをキャンセルしました。${itemLabel} ${active.id} は元の位置に戻りました。`;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **ステータスボタンの aria-label 追加**: `action-list-compact.tsx` のステータスサイクルボタンに「{アイテム名}のステータスを{次のステータス}に変更」形式の `aria-label` を追加。スクリーンリーダーがボタンの機能を正確に伝えられるように
- **ドラッグハンドルの aria-label 追加**: `sortable-topic-item.tsx` / `sortable-action-item.tsx` のドラッグハンドルに `aria-label`（"{タイトル}を並び替え"）と `aria-roledescription="並び替え可能"` を追加
- **DnD 日本語アナウンスメント実装**: `src/lib/dnd-accessibility.ts` を新規作成し、ドラッグ操作の各フェーズ（開始/移動/終了/キャンセル）に対応した日本語スクリーンリーダーアナウンスを定義。`meeting-form.tsx` の `DndContext` 2箇所に適用
- **カラーコントラスト検証**: 全色ペアが WCAG 2.1 AA（4.5:1以上）を満たすことを確認（修正不要）

## Test plan

- [x] テスト14件追加（263→277件）
- [x] `dnd-accessibility.ts` のユニットテスト（9件）
- [x] ステータスボタンの `aria-label` 検証テスト（1件）
- [x] ドラッグハンドルの `aria-label` 検証テスト（各コンポーネント2件×2 = 4件）
- [x] 全テスト 277件パス確認
- [x] TypeScript 型チェック通過
- [ ] VoiceOver（macOS）での読み上げ動作確認（手動）