### PR TITLE
feat: 空状態（Empty State）の改善（issue #37）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { DashboardSummary } from "@/components/dashboard/dashboard-summary";
 import { RecentActivityFeed } from "@/components/dashboard/recent-activity-feed";
 import { UpcomingActionsSection } from "@/components/dashboard/upcoming-actions-section";
 import { RecommendedMeetingsSection } from "@/components/dashboard/recommended-meetings-section";
+import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 
 export const dynamic = "force-dynamic";
 
@@ -23,10 +24,13 @@ export default async function DashboardPage() {
       getRecommendedMeetings(),
     ]);
 
+  const isFirstTime = members.length === 0;
+
   return (
     <div className="animate-fade-in-up">
       <h1 className="text-2xl font-semibold tracking-tight mb-6 text-foreground">ダッシュボード</h1>
-      <DashboardSummary summary={summary} />
+
+      {isFirstTime ? <OnboardingCard /> : <DashboardSummary summary={summary} />}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
         <div className="lg:col-span-2 rounded-xl border bg-card p-5">

--- a/src/components/action/action-list-compact.tsx
+++ b/src/components/action/action-list-compact.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useOptimistic, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Pencil } from "lucide-react";
+import { Pencil, SquareCheck } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -59,7 +60,7 @@ export function ActionListCompact({ actionItems }: Props) {
   );
 
   if (actionItems.length === 0) {
-    return <p className="text-muted-foreground py-4">アクションアイテムはありません</p>;
+    return <EmptyState icon={SquareCheck} title="アクションアイテムはありません" size="compact" />;
   }
 
   function cycleStatus(id: string, currentStatus: string) {

--- a/src/components/action/action-list-full.tsx
+++ b/src/components/action/action-list-full.tsx
@@ -3,7 +3,8 @@
 import { useState, useOptimistic, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Pencil } from "lucide-react";
+import { Pencil, SquareCheck } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -53,7 +54,13 @@ export function ActionListFull({ actionItems }: Props) {
   );
 
   if (actionItems.length === 0) {
-    return <p className="text-muted-foreground py-8 text-center">アクションアイテムはありません</p>;
+    return (
+      <EmptyState
+        icon={SquareCheck}
+        title="アクションアイテムはありません"
+        description="1on1でアクションアイテムを作成すると、ここに表示されます"
+      />
+    );
   }
 
   function handleStatusChange(id: string, newStatus: string) {

--- a/src/components/dashboard/onboarding-card.tsx
+++ b/src/components/dashboard/onboarding-card.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { ArrowRight, MessageSquare, UserPlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function OnboardingCard() {
+  return (
+    <div className="rounded-xl border-2 border-dashed border-primary/30 bg-primary/5 p-8 mb-8 text-center animate-fade-in-up">
+      <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 mb-4">
+        <MessageSquare className="w-7 h-7 text-primary" strokeWidth={1.5} />
+      </div>
+      <h2 className="text-xl font-semibold tracking-tight text-foreground mb-2">
+        Nudge へようこそ！
+      </h2>
+      <p className="text-sm text-muted-foreground mb-6 max-w-sm mx-auto">
+        1on1 ミーティングをより効果的に。まずはメンバーを追加して、 最初の 1on1
+        を記録してみましょう。
+      </p>
+
+      <div className="flex items-center justify-center gap-3 mb-6 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary text-primary-foreground text-xs font-bold">
+            1
+          </span>
+          <span>メンバーを追加</span>
+        </div>
+        <ArrowRight className="w-4 h-4 text-muted-foreground/50" />
+        <div className="flex items-center gap-2">
+          <span className="flex items-center justify-center w-6 h-6 rounded-full bg-muted text-muted-foreground text-xs font-bold">
+            2
+          </span>
+          <span>1on1 を記録</span>
+        </div>
+        <ArrowRight className="w-4 h-4 text-muted-foreground/50" />
+        <div className="flex items-center gap-2">
+          <span className="flex items-center justify-center w-6 h-6 rounded-full bg-muted text-muted-foreground text-xs font-bold">
+            3
+          </span>
+          <span>フォローアップ</span>
+        </div>
+      </div>
+
+      <Link href="/members/new">
+        <Button size="lg" className="gap-2">
+          <UserPlus className="w-4 h-4" />
+          最初のメンバーを追加する
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/dashboard/recent-activity-feed.tsx
+++ b/src/components/dashboard/recent-activity-feed.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { Calendar, CheckCircle2 } from "lucide-react";
+import { Activity, Calendar, CheckCircle2 } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { ActivityItem } from "@/lib/actions/dashboard-actions";
 import { formatRelativeDate } from "@/lib/format";
 import { AvatarInitial } from "@/components/ui/avatar-initial";
@@ -53,11 +54,7 @@ function ActivityRow({ activity }: { readonly activity: ActivityItem }) {
 
 export function RecentActivityFeed({ activities }: Props) {
   if (activities.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground text-center py-6">
-        最近のアクティビティはありません
-      </p>
-    );
+    return <EmptyState icon={Activity} title="最近のアクティビティはありません" size="compact" />;
   }
 
   return (

--- a/src/components/dashboard/recommended-meetings-section.tsx
+++ b/src/components/dashboard/recommended-meetings-section.tsx
@@ -1,12 +1,19 @@
 import Link from "next/link";
+import { Heart } from "lucide-react";
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { RecommendedMeeting } from "@/lib/actions/analytics-actions";
 
 export function RecommendedMeetingsSection({ members }: { members: RecommendedMeeting[] }) {
   if (members.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-6">全員と最近1on1を実施済みです</p>
+      <EmptyState
+        icon={Heart}
+        title="全員と最近1on1を実施済みです"
+        description="引き続き定期的な1on1でチームをサポートしましょう"
+        size="compact"
+      />
     );
   }
 

--- a/src/components/dashboard/upcoming-actions-section.tsx
+++ b/src/components/dashboard/upcoming-actions-section.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { Clock, AlertCircle } from "lucide-react";
+import { CalendarCheck, Clock, AlertCircle } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Badge } from "@/components/ui/badge";
 import type { ActionItemWithMember } from "@/lib/actions/dashboard-actions";
 import { formatDate } from "@/lib/format";
@@ -48,9 +49,7 @@ export function UpcomingActionsSection({ today, thisWeek }: Props) {
 
   if (!hasAny) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-6">
-        今週の期限アクションはありません
-      </p>
+      <EmptyState icon={CalendarCheck} title="今週の期限アクションはありません" size="compact" />
     );
   }
 

--- a/src/components/meeting/meeting-history.tsx
+++ b/src/components/meeting/meeting-history.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
+import { MessageSquare } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import { CATEGORY_LABELS } from "@/lib/constants";
 import { formatDate } from "@/lib/format";
 
@@ -16,7 +18,14 @@ type Props = { meetings: MeetingSummary[]; memberId: string };
 
 export function MeetingHistory({ meetings, memberId }: Props) {
   if (meetings.length === 0) {
-    return <p className="text-muted-foreground py-4">まだ1on1の記録がありません</p>;
+    return (
+      <EmptyState
+        icon={MessageSquare}
+        title="まだ1on1の記録がありません"
+        description="最初の1on1を記録して、継続的なフォローアップを始めましょう"
+        action={{ label: "1on1を記録する", href: `/members/${memberId}/meetings/new` }}
+      />
+    );
   }
   return (
     <div className="flex flex-col gap-3">

--- a/src/components/meeting/past-meetings-accordion.tsx
+++ b/src/components/meeting/past-meetings-accordion.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Copy } from "lucide-react";
+import { CalendarDays, Copy } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,7 +23,9 @@ type Props = {
 
 export function PastMeetingsAccordion({ meetings, onCopyTopic }: Props) {
   if (meetings.length === 0) {
-    return <p className="text-sm text-muted-foreground">過去のミーティング記録はありません</p>;
+    return (
+      <EmptyState icon={CalendarDays} title="過去のミーティング記録はありません" size="compact" />
+    );
   }
 
   return (

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -15,7 +15,8 @@ import {
 } from "@/components/ui/table";
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { formatRelativeDate } from "@/lib/format";
-import { ArrowUpDown } from "lucide-react";
+import { ArrowUpDown, Users } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 
 type MemberWithStats = {
   readonly id: string;
@@ -58,12 +59,13 @@ export function MemberList({ members }: Props) {
 
   if (members.length === 0) {
     return (
-      <div className="text-center py-12 text-muted-foreground">
-        <p>メンバーがまだ登録されていません</p>
-        <Link href="/members/new">
-          <Button className="mt-4">メンバーを追加</Button>
-        </Link>
-      </div>
+      <EmptyState
+        icon={Users}
+        title="メンバーがまだ登録されていません"
+        description="まずメンバーを追加して、1on1を始めましょう"
+        action={{ label: "メンバーを追加", href: "/members/new" }}
+        size="large"
+      />
     );
   }
 

--- a/src/components/member/member-quick-actions.tsx
+++ b/src/components/member/member-quick-actions.tsx
@@ -1,5 +1,7 @@
+import { CheckCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ActionListCompact } from "@/components/action/action-list-compact";
+import { EmptyState } from "@/components/ui/empty-state";
 
 type ActionItemRow = {
   id: string;
@@ -24,7 +26,11 @@ export function MemberQuickActions({ pendingActionItems }: Props) {
         )}
       </div>
       {pendingActionItems.length === 0 ? (
-        <p className="text-muted-foreground py-4">未完了のアクションアイテムはありません</p>
+        <EmptyState
+          icon={CheckCircle}
+          title="未完了のアクションアイテムはありません"
+          size="compact"
+        />
       ) : (
         <ActionListCompact actionItems={pendingActionItems} />
       )}

--- a/src/components/ui/__tests__/empty-state.test.tsx
+++ b/src/components/ui/__tests__/empty-state.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { Users } from "lucide-react";
+import { afterEach, describe, expect, it } from "vitest";
+import { EmptyState } from "../empty-state";
+
+afterEach(() => cleanup());
+
+describe("EmptyState", () => {
+  it("タイトルを表示する", () => {
+    render(<EmptyState icon={Users} title="メンバーがいません" />);
+    expect(screen.getByText("メンバーがいません")).toBeDefined();
+  });
+
+  it("アイコンを表示する", () => {
+    render(<EmptyState icon={Users} title="メンバーがいません" />);
+    const icon = document.querySelector("svg");
+    expect(icon).not.toBeNull();
+  });
+
+  it("説明文を表示する", () => {
+    render(
+      <EmptyState
+        icon={Users}
+        title="メンバーがいません"
+        description="メンバーを追加してください"
+      />,
+    );
+    expect(screen.getByText("メンバーを追加してください")).toBeDefined();
+  });
+
+  it("説明文が未指定の場合は表示しない", () => {
+    render(<EmptyState icon={Users} title="メンバーがいません" />);
+    expect(screen.queryByText("メンバーを追加してください")).toBeNull();
+  });
+
+  it("action が href の場合はリンクボタンを表示する", () => {
+    render(
+      <EmptyState
+        icon={Users}
+        title="メンバーがいません"
+        action={{ label: "メンバーを追加", href: "/members/new" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "メンバーを追加" });
+    expect(link).toBeDefined();
+    expect(link.getAttribute("href")).toBe("/members/new");
+  });
+
+  it("size=compact のとき縮小クラスが適用される", () => {
+    const { container } = render(<EmptyState icon={Users} title="テスト" size="compact" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("py-6");
+  });
+
+  it("size=large のとき大きいクラスが適用される", () => {
+    const { container } = render(<EmptyState icon={Users} title="テスト" size="large" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("py-16");
+  });
+
+  it("デフォルト（size 未指定）のとき標準クラスが適用される", () => {
+    const { container } = render(<EmptyState icon={Users} title="テスト" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("py-10");
+  });
+});

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type EmptyStateAction = {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+};
+
+type Props = {
+  readonly icon: LucideIcon;
+  readonly title: string;
+  readonly description?: string;
+  readonly action?: EmptyStateAction;
+  readonly size?: "compact" | "default" | "large";
+};
+
+const sizeClasses = {
+  compact: "py-6",
+  default: "py-10",
+  large: "py-16",
+} as const;
+
+const iconSizeClasses = {
+  compact: "w-8 h-8",
+  default: "w-10 h-10",
+  large: "w-12 h-12",
+} as const;
+
+export function EmptyState({ icon: Icon, title, description, action, size = "default" }: Props) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center text-center", sizeClasses[size])}>
+      <div className="rounded-full bg-muted p-3 mb-3">
+        <Icon className={cn("text-muted-foreground", iconSizeClasses[size])} strokeWidth={1.5} />
+      </div>
+      <p className="text-sm font-medium text-foreground/80">{title}</p>
+      {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+      {action && (
+        <div className="mt-4">
+          {action.href ? (
+            <Link href={action.href}>
+              <Button size="sm">{action.label}</Button>
+            </Link>
+          ) : (
+            <Button size="sm" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `EmptyState` 共通コンポーネントを新規作成し、全画面のアイコン付き空状態を統一
- 各コンポーネントにアイコン付きの空状態メッセージを追加（10コンポーネント更新）
- MeetingHistory に「1on1を記録する」CTA ボタンを追加
- ダッシュボードにオンボーディングカードを追加（初回起動時のみ表示）

## Changes

### 新規ファイル
- `src/components/ui/empty-state.tsx` — アイコン・タイトル・説明・CTA 対応の共通コンポーネント（compact / default / large の3サイズ）
- `src/components/ui/__tests__/empty-state.test.tsx` — ユニットテスト（8テスト）
- `src/components/dashboard/onboarding-card.tsx` — 初回ユーザー向けウェルカムカード

### 更新ファイル（10コンポーネント）
| コンポーネント | アイコン | CTA |
|---|---|---|
| `MemberList` | Users | メンバーを追加（既存） |
| `MeetingHistory` | MessageSquare | 1on1を記録する（新規追加） |
| `ActionListFull` | SquareCheck | なし |
| `ActionListCompact` | SquareCheck | なし |
| `RecentActivityFeed` | Activity | なし |
| `UpcomingActionsSection` | CalendarCheck | なし |
| `RecommendedMeetingsSection` | Heart | なし |
| `MemberQuickActions` | CheckCircle | なし |
| `PastMeetingsAccordion` | CalendarDays | なし |

## Test plan

- [x] `EmptyState` コンポーネントのユニットテスト（8テスト）追加・通過
- [x] 全テスト通過（386テスト）
- [x] `npm run build` 成功
- [ ] ダッシュボード（メンバー0人）でオンボーディングカードが表示されることを確認
- [ ] 各画面の空状態でアイコンが表示されることを確認
- [ ] MeetingHistory の空状態で「1on1を記録する」ボタンをクリックして正しく遷移することを確認

Closes #37