### PR TITLE
feat: キーボードショートカット機能の実装（issue #36）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { GeistSans } from "geist/font/sans";
 import { Noto_Sans_JP } from "next/font/google";
 import { prisma } from "@/lib/prisma";
 import { Sidebar } from "@/components/layout/sidebar";
+import { KeyboardShortcutProvider } from "@/components/layout/keyboard-shortcut-provider";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
@@ -47,6 +48,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <div className="max-w-5xl mx-auto">{children}</div>
         </main>
         <Toaster />
+        <KeyboardShortcutProvider members={members} />
       </body>
     </html>
   );

--- a/src/components/layout/__tests__/keyboard-shortcut-provider.test.tsx
+++ b/src/components/layout/__tests__/keyboard-shortcut-provider.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { fireEvent } from "@testing-library/dom";
+import { KeyboardShortcutProvider } from "../keyboard-shortcut-provider";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const members = [
+  { id: "m1", name: "田中太郎" },
+  { id: "m2", name: "鈴木花子" },
+];
+
+describe("KeyboardShortcutProvider", () => {
+  describe("'n' キー — 新規メンバー追加", () => {
+    it("'n' キーで /members/new にナビゲートされる", () => {
+      render(<KeyboardShortcutProvider members={members} />);
+
+      fireEvent.keyDown(document, { key: "n" });
+
+      expect(mockPush).toHaveBeenCalledWith("/members/new");
+    });
+  });
+
+  describe("'m' キー — 新規ミーティング作成", () => {
+    it("'m' キーで NewMeetingDialog が開く", () => {
+      render(<KeyboardShortcutProvider members={members} />);
+
+      fireEvent.keyDown(document, { key: "m" });
+
+      expect(screen.getByText("新規ミーティングを作成")).toBeDefined();
+    });
+  });
+
+  describe("'?' キー — ショートカット一覧", () => {
+    it("'?' キーで ShortcutHelpDialog が開く", () => {
+      render(<KeyboardShortcutProvider members={members} />);
+
+      fireEvent.keyDown(document, { key: "?" });
+
+      expect(screen.getByText("キーボードショートカット")).toBeDefined();
+    });
+  });
+});

--- a/src/components/layout/__tests__/shortcut-help-dialog.test.tsx
+++ b/src/components/layout/__tests__/shortcut-help-dialog.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ShortcutHelpDialog } from "../shortcut-help-dialog";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ShortcutHelpDialog", () => {
+  describe("表示", () => {
+    it("open=true のとき全ショートカットが表示される", () => {
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      expect(screen.getByText("新規メンバーを追加")).toBeDefined();
+      expect(screen.getByText("新規ミーティングを作成")).toBeDefined();
+      expect(screen.getByText("検索")).toBeDefined();
+      expect(screen.getByText("ショートカット一覧を表示")).toBeDefined();
+    });
+
+    it("open=false のとき内容が表示されない", () => {
+      render(<ShortcutHelpDialog open={false} onClose={() => {}} />);
+
+      expect(screen.queryByText("新規メンバーを追加")).toBeNull();
+    });
+
+    it("キーボードショートカットキーが kbd 要素として表示される", () => {
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      const kbdElements = screen.getAllByRole("term");
+      expect(kbdElements.length).toBeGreaterThan(0);
+    });
+
+    it("ダイアログタイトルが表示される", () => {
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      expect(screen.getByText("キーボードショートカット")).toBeDefined();
+    });
+  });
+
+  describe("クローズ動作", () => {
+    it("閉じるボタンで onClose が呼ばれる", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<ShortcutHelpDialog open={true} onClose={onClose} />);
+
+      // Radix Dialog の close button
+      const closeButton = screen.getByRole("button");
+      await user.click(closeButton);
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/layout/keyboard-shortcut-provider.tsx
+++ b/src/components/layout/keyboard-shortcut-provider.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { ShortcutHelpDialog } from "@/components/layout/shortcut-help-dialog";
+import { NewMeetingDialog } from "@/components/meeting/new-meeting-dialog";
+
+type MemberItem = {
+  readonly id: string;
+  readonly name: string;
+};
+
+type Props = {
+  readonly members: ReadonlyArray<MemberItem>;
+};
+
+export function KeyboardShortcutProvider({ members }: Props) {
+  const router = useRouter();
+  const [isMeetingDialogOpen, setIsMeetingDialogOpen] = useState(false);
+  const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
+
+  const handleNewMember = useCallback(() => {
+    router.push("/members/new");
+  }, [router]);
+
+  const handleNewMeeting = useCallback(() => {
+    setIsMeetingDialogOpen(true);
+  }, []);
+
+  const handleShowHelp = useCallback(() => {
+    setIsHelpDialogOpen(true);
+  }, []);
+
+  useKeyboardShortcuts({
+    onNewMember: handleNewMember,
+    onNewMeeting: handleNewMeeting,
+    onShowHelp: handleShowHelp,
+  });
+
+  return (
+    <>
+      <NewMeetingDialog
+        open={isMeetingDialogOpen}
+        onClose={() => setIsMeetingDialogOpen(false)}
+        members={members}
+      />
+      <ShortcutHelpDialog open={isHelpDialogOpen} onClose={() => setIsHelpDialogOpen(false)} />
+    </>
+  );
+}

--- a/src/components/layout/shortcut-help-dialog.tsx
+++ b/src/components/layout/shortcut-help-dialog.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+type ShortcutEntry = {
+  readonly key: string;
+  readonly description: string;
+};
+
+const SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
+  { key: "n", description: "新規メンバーを追加" },
+  { key: "m", description: "新規ミーティングを作成" },
+  { key: "⌘ K", description: "検索" },
+  { key: "?", description: "ショートカット一覧を表示" },
+];
+
+type Props = {
+  readonly open: boolean;
+  readonly onClose: () => void;
+};
+
+export function ShortcutHelpDialog({ open, onClose }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="font-semibold tracking-tight">
+            キーボードショートカット
+          </DialogTitle>
+          <DialogDescription>利用可能なキーボードショートカット一覧</DialogDescription>
+        </DialogHeader>
+        <dl className="space-y-3">
+          {SHORTCUTS.map(({ key, description }) => (
+            <div key={key} className="flex items-center justify-between">
+              <dt>
+                <kbd
+                  role="term"
+                  className="inline-flex items-center rounded border border-border bg-muted px-2 py-0.5 font-mono text-sm font-medium text-muted-foreground"
+                >
+                  {key}
+                </kbd>
+              </dt>
+              <dd className="text-sm text-foreground">{description}</dd>
+            </div>
+          ))}
+        </dl>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/meeting/__tests__/new-meeting-dialog.test.tsx
+++ b/src/components/meeting/__tests__/new-meeting-dialog.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NewMeetingDialog } from "../new-meeting-dialog";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const members = [
+  { id: "m1", name: "田中太郎" },
+  { id: "m2", name: "鈴木花子" },
+];
+
+describe("NewMeetingDialog", () => {
+  describe("表示", () => {
+    it("open=true のときメンバー選択ダイアログが表示される", () => {
+      render(<NewMeetingDialog open={true} onClose={() => {}} members={members} />);
+
+      expect(screen.getByText("新規ミーティングを作成")).toBeDefined();
+    });
+
+    it("open=false のとき内容が表示されない", () => {
+      render(<NewMeetingDialog open={false} onClose={() => {}} members={members} />);
+
+      expect(screen.queryByText("新規ミーティングを作成")).toBeNull();
+    });
+
+    it("メンバーが選択肢に表示される", () => {
+      render(<NewMeetingDialog open={true} onClose={() => {}} members={members} />);
+
+      // select の option を直接確認
+      const options = screen.getAllByRole("option");
+      const names = options.map((o) => o.textContent);
+      expect(names).toContain("田中太郎");
+      expect(names).toContain("鈴木花子");
+    });
+
+    it("メンバーが 0 人の場合は空状態メッセージを表示する", () => {
+      render(<NewMeetingDialog open={true} onClose={() => {}} members={[]} />);
+
+      expect(screen.getByText("メンバーがいません")).toBeDefined();
+    });
+  });
+
+  describe("ナビゲーション", () => {
+    it("メンバーを選択して作成ボタンを押すと正しいURLに遷移する", async () => {
+      const user = userEvent.setup();
+      render(<NewMeetingDialog open={true} onClose={() => {}} members={members} />);
+
+      const select = screen.getByRole("combobox");
+      await user.selectOptions(select, "m1");
+
+      const createButton = screen.getByRole("button", { name: "作成" });
+      await user.click(createButton);
+
+      expect(mockPush).toHaveBeenCalledWith("/members/m1/meetings/new");
+    });
+  });
+
+  describe("クローズ動作", () => {
+    it("キャンセルボタンで onClose が呼ばれる", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<NewMeetingDialog open={true} onClose={onClose} members={members} />);
+
+      const cancelButton = screen.getByRole("button", { name: "キャンセル" });
+      await user.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/meeting/new-meeting-dialog.tsx
+++ b/src/components/meeting/new-meeting-dialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+type MemberItem = {
+  readonly id: string;
+  readonly name: string;
+};
+
+type Props = {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly members: ReadonlyArray<MemberItem>;
+};
+
+export function NewMeetingDialog({ open, onClose, members }: Props) {
+  const router = useRouter();
+  const [selectedMemberId, setSelectedMemberId] = useState<string>(members[0]?.id ?? "");
+
+  const handleCreate = () => {
+    if (!selectedMemberId) return;
+    onClose();
+    router.push(`/members/${selectedMemberId}/meetings/new`);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="font-semibold tracking-tight">新規ミーティングを作成</DialogTitle>
+          <DialogDescription>ミーティングを作成するメンバーを選択してください。</DialogDescription>
+        </DialogHeader>
+
+        {members.length === 0 ? (
+          <div className="py-4 text-center text-sm text-muted-foreground">
+            <p>メンバーがいません</p>
+            <Link
+              href="/members/new"
+              className="mt-2 block text-primary underline-offset-4 hover:underline"
+            >
+              メンバーを追加する
+            </Link>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <label htmlFor="member-select" className="text-sm font-medium">
+              メンバー
+            </label>
+            <select
+              id="member-select"
+              value={selectedMemberId}
+              onChange={(e) => setSelectedMemberId(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {members.map((member) => (
+                <option key={member.id} value={member.id}>
+                  {member.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          {members.length > 0 && (
+            <Button onClick={handleCreate} disabled={!selectedMemberId}>
+              作成
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
+++ b/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { fireEvent } from "@testing-library/dom";
+import { useKeyboardShortcuts } from "../use-keyboard-shortcuts";
+
+const defaultCallbacks = () => ({
+  onNewMember: vi.fn(),
+  onNewMeeting: vi.fn(),
+  onShowHelp: vi.fn(),
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useKeyboardShortcuts", () => {
+  describe("ショートカット発火", () => {
+    it("'n' キーで onNewMember が呼ばれる", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "n" });
+
+      expect(callbacks.onNewMember).toHaveBeenCalledOnce();
+    });
+
+    it("'m' キーで onNewMeeting が呼ばれる", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "m" });
+
+      expect(callbacks.onNewMeeting).toHaveBeenCalledOnce();
+    });
+
+    it("'?' キーで onShowHelp が呼ばれる", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "?" });
+
+      expect(callbacks.onShowHelp).toHaveBeenCalledOnce();
+    });
+
+    it("関係ないキーでは何も呼ばれない", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "x" });
+
+      expect(callbacks.onNewMember).not.toHaveBeenCalled();
+      expect(callbacks.onNewMeeting).not.toHaveBeenCalled();
+      expect(callbacks.onShowHelp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("入力フォーカス中はショートカットを無効化", () => {
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+      input = document.createElement("input");
+      document.body.appendChild(input);
+      input.focus();
+    });
+
+    afterEach(() => {
+      document.body.removeChild(input);
+    });
+
+    it("input フォーカス中は 'n' が無効", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "n" });
+
+      expect(callbacks.onNewMember).not.toHaveBeenCalled();
+    });
+
+    it("input フォーカス中は 'm' が無効", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "m" });
+
+      expect(callbacks.onNewMeeting).not.toHaveBeenCalled();
+    });
+
+    it("input フォーカス中は '?' が無効", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "?" });
+
+      expect(callbacks.onShowHelp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("textarea フォーカス中はショートカットを無効化", () => {
+    let textarea: HTMLTextAreaElement;
+
+    beforeEach(() => {
+      textarea = document.createElement("textarea");
+      document.body.appendChild(textarea);
+      textarea.focus();
+    });
+
+    afterEach(() => {
+      document.body.removeChild(textarea);
+    });
+
+    it("textarea フォーカス中は 'n' が無効", () => {
+      const callbacks = defaultCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      fireEvent.keyDown(document, { key: "n" });
+
+      expect(callbacks.onNewMember).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("アンマウント時のクリーンアップ", () => {
+    it("アンマウント後はキーイベントに反応しない", () => {
+      const callbacks = defaultCallbacks();
+      const { unmount } = renderHook(() => useKeyboardShortcuts(callbacks));
+
+      unmount();
+      fireEvent.keyDown(document, { key: "n" });
+
+      expect(callbacks.onNewMember).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type ShortcutCallbacks = {
+  readonly onNewMember: () => void;
+  readonly onNewMeeting: () => void;
+  readonly onShowHelp: () => void;
+};
+
+function isTypingTarget(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  const tag = element.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select" || element.isContentEditable;
+}
+
+export function useKeyboardShortcuts(callbacks: ShortcutCallbacks): void {
+  // useRef でコールバックを最新に保つ（依存配列の問題を回避）
+  const callbacksRef = useRef(callbacks);
+
+  useEffect(() => {
+    callbacksRef.current = callbacks;
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTypingTarget(document.activeElement)) return;
+
+      const { onNewMember, onNewMeeting, onShowHelp } = callbacksRef.current;
+
+      switch (e.key) {
+        case "n":
+          e.preventDefault();
+          onNewMember();
+          break;
+        case "m":
+          e.preventDefault();
+          onNewMeeting();
+          break;
+        case "?":
+          e.preventDefault();
+          onShowHelp();
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+}


### PR DESCRIPTION
## Summary

- `n` キー: 新規メンバー追加（`/members/new` へナビゲート）
- `m` キー: 新規ミーティング作成（メンバー選択ダイアログ → `/members/[id]/meetings/new` へナビゲート）
- `?` キー: ショートカット一覧ダイアログ表示（`<kbd>` 要素でキー表示）
- `Cmd+K`: 既存の検索フォーカス実装を維持しつつヘルプに説明を追加

## 実装詳細

### 新規ファイル

| ファイル | 説明 |
|---|---|
| `src/hooks/use-keyboard-shortcuts.ts` | グローバルキーイベント管理フック（input/textarea フォーカス中は無効化） |
| `src/components/layout/shortcut-help-dialog.tsx` | `?` キーで表示するショートカット一覧ダイアログ |
| `src/components/meeting/new-meeting-dialog.tsx` | `m` キーで表示するメンバー選択ダイアログ（メンバー0人時の空状態対応） |
| `src/components/layout/keyboard-shortcut-provider.tsx` | 全ショートカットを統合するクライアントコンポーネント |

### 変更ファイル

| ファイル | 説明 |
|---|---|
| `src/app/layout.tsx` | `KeyboardShortcutProvider` を追加（Server Component 維持） |

## Test plan

- [x] `n` キーで `/members/new` にナビゲートされること
- [x] `m` キーで `NewMeetingDialog` が表示されること
- [x] `?` キーで `ShortcutHelpDialog` が表示されること
- [x] input/textarea フォーカス中はショートカットが無効化されること
- [x] アンマウント後はキーイベントに反応しないこと
- [x] メンバーが0人の場合に空状態メッセージが表示されること
- [x] 全 409 テスト通過（23 テスト追加）

Closes #36