### PR TITLE
feat: ミーティングノートのエクスポート機能（issue #42）

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -13,6 +13,7 @@ import { TopicAnalyticsSection } from "@/components/analytics/topic-analytics-se
 import { ActionAnalyticsSection } from "@/components/analytics/action-analytics-section";
 import { MemberStatsBar } from "@/components/member/member-stats-bar";
 import { MemberQuickActions } from "@/components/member/member-quick-actions";
+import { ExportDialog } from "@/components/meeting/export-dialog";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -41,6 +42,7 @@ export default async function MemberDetailPage({ params }: Props) {
           </div>
         </div>
         <div className="flex gap-2">
+          <ExportDialog memberId={member.id} memberName={member.name} />
           <MemberDeleteDialog memberId={member.id} memberName={member.name} />
           <MemberEditDialog
             member={{

--- a/src/components/meeting/__tests__/export-dialog.test.tsx
+++ b/src/components/meeting/__tests__/export-dialog.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ExportDialog } from "../export-dialog";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockGetMeetingsForExport = vi.fn();
+vi.mock("@/lib/actions/export-actions", () => ({
+  getMeetingsForExport: (...args: unknown[]) => mockGetMeetingsForExport(...args),
+}));
+
+vi.mock("@/lib/export", () => ({
+  formatMeetingMarkdown: vi.fn(() => "# 1on1 サマリー - テスト太郎\n\n内容"),
+}));
+
+// Clipboard API mock
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const props = {
+  memberId: "member-1",
+  memberName: "テスト太郎",
+};
+
+const mockExportResult = {
+  success: true as const,
+  data: {
+    member: { id: "member-1", name: "テスト太郎", department: "開発部", position: null },
+    meetings: [],
+  },
+};
+
+describe("ExportDialog", () => {
+  it("「エクスポート」ボタンが表示される", () => {
+    render(<ExportDialog {...props} />);
+    expect(screen.getByRole("button", { name: /エクスポート/ })).toBeDefined();
+  });
+
+  it("ボタンクリックでダイアログが開く", async () => {
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+
+    expect(screen.getByText("ミーティングノートをエクスポート")).toBeDefined();
+  });
+
+  it("ダイアログ内にメンバー名が表示される", async () => {
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+
+    expect(screen.getByText(/テスト太郎/)).toBeDefined();
+  });
+
+  it("期間入力フィールドが表示される", async () => {
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+
+    expect(screen.getByLabelText("開始日")).toBeDefined();
+    expect(screen.getByLabelText("終了日")).toBeDefined();
+  });
+
+  it("クリップボードにコピーボタンが表示される", async () => {
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+
+    expect(screen.getByRole("button", { name: /クリップボードにコピー/ })).toBeDefined();
+  });
+
+  it("Markdownをダウンロードするボタンが表示される", async () => {
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+
+    expect(screen.getByRole("button", { name: /Markdownでダウンロード/ })).toBeDefined();
+  });
+
+  it("コピーボタンクリックで getMeetingsForExport が呼ばれる", async () => {
+    mockGetMeetingsForExport.mockResolvedValue(mockExportResult);
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+    await user.click(screen.getByRole("button", { name: /クリップボードにコピー/ }));
+
+    await waitFor(() => {
+      expect(mockGetMeetingsForExport).toHaveBeenCalledWith(
+        expect.objectContaining({ memberId: "member-1" }),
+      );
+    });
+  });
+
+  it("コピー成功後に成功トーストが表示される", async () => {
+    mockGetMeetingsForExport.mockResolvedValue(mockExportResult);
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+    await user.click(screen.getByRole("button", { name: /クリップボードにコピー/ }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("クリップボードにコピーしました");
+    });
+  });
+
+  it("取得失敗時にエラートーストが表示される", async () => {
+    mockGetMeetingsForExport.mockResolvedValue({ success: false, error: "取得エラー" });
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+    await user.click(screen.getByRole("button", { name: /クリップボードにコピー/ }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("エクスポートに失敗しました");
+    });
+  });
+
+  it("キャンセルボタンでダイアログが閉じる", async () => {
+    const user = userEvent.setup();
+    render(<ExportDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /エクスポート/ }));
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("ミーティングノートをエクスポート")).toBeNull();
+    });
+  });
+});

--- a/src/components/meeting/export-dialog.tsx
+++ b/src/components/meeting/export-dialog.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Copy, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { getMeetingsForExport } from "@/lib/actions/export-actions";
+import { formatMeetingMarkdown } from "@/lib/export";
+
+type Props = {
+  readonly memberId: string;
+  readonly memberName: string;
+};
+
+export function ExportDialog({ memberId, memberName }: Props) {
+  const [open, setOpen] = useState(false);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function fetchMarkdown() {
+    const result = await getMeetingsForExport({
+      memberId,
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+    });
+
+    if (!result.success) {
+      toast.error("エクスポートに失敗しました");
+      return null;
+    }
+
+    return formatMeetingMarkdown(result.data.member, result.data.meetings);
+  }
+
+  async function handleCopy() {
+    setLoading(true);
+    try {
+      const markdown = await fetchMarkdown();
+      if (!markdown) return;
+      await navigator.clipboard.writeText(markdown);
+      toast.success("クリップボードにコピーしました");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDownload() {
+    setLoading(true);
+    try {
+      const markdown = await fetchMarkdown();
+      if (!markdown) return;
+
+      const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `1on1-${memberName}-${new Date().toISOString().slice(0, 10)}.md`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast.success("ダウンロードしました");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <FileText className="w-4 h-4 mr-1.5" />
+          エクスポート
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>ミーティングノートをエクスポート</DialogTitle>
+          <DialogDescription>
+            {memberName} の1on1ノートをMarkdown形式でエクスポートします。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="start-date">開始日</Label>
+              <Input
+                id="start-date"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="end-date">終了日</Label>
+              <Input
+                id="end-date"
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+              />
+            </div>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            期間を指定しない場合はすべてのミーティングをエクスポートします。
+          </p>
+        </div>
+
+        <DialogFooter className="flex-col sm:flex-row gap-2">
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={loading}>
+            キャンセル
+          </Button>
+          <Button variant="outline" onClick={handleCopy} disabled={loading}>
+            <Copy className="w-4 h-4 mr-1.5" />
+            クリップボードにコピー
+          </Button>
+          <Button onClick={handleDownload} disabled={loading}>
+            <Download className="w-4 h-4 mr-1.5" />
+            Markdownでダウンロード
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/__tests__/export.test.ts
+++ b/src/lib/__tests__/export.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatMeetingMarkdown,
+  formatSingleMeetingMarkdown,
+  type MeetingExportData,
+  type MemberExportData,
+} from "@/lib/export";
+
+const sampleMember: MemberExportData = {
+  id: "m1",
+  name: "田中 太郎",
+  department: "エンジニアリング",
+  position: "シニアエンジニア",
+};
+
+const sampleMeetings: MeetingExportData[] = [
+  {
+    id: "meeting1",
+    date: new Date("2025-01-15"),
+    topics: [
+      {
+        id: "t1",
+        category: "WORK_PROGRESS",
+        title: "Q1 の進捗確認",
+        notes: "プロジェクトAは順調に進んでいる。",
+        sortOrder: 0,
+      },
+      {
+        id: "t2",
+        category: "CAREER",
+        title: "スキルアップ計画",
+        notes: "",
+        sortOrder: 1,
+      },
+    ],
+    actionItems: [
+      {
+        id: "a1",
+        title: "APIドキュメント作成",
+        description: "OpenAPI 仕様に合わせて更新",
+        status: "TODO",
+        dueDate: new Date("2025-01-31"),
+      },
+      {
+        id: "a2",
+        title: "レビュー依頼",
+        description: "",
+        status: "DONE",
+        dueDate: null,
+      },
+    ],
+  },
+  {
+    id: "meeting2",
+    date: new Date("2025-02-05"),
+    topics: [
+      {
+        id: "t3",
+        category: "ISSUES",
+        title: "スプリント遅延の原因分析",
+        notes: "要件変更が主な原因。",
+        sortOrder: 0,
+      },
+    ],
+    actionItems: [],
+  },
+];
+
+describe("formatMeetingMarkdown", () => {
+  it("メンバー名とエクスポート情報がヘッダーに含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("# 1on1 サマリー - 田中 太郎");
+    expect(result).toContain("田中 太郎");
+    expect(result).toContain("エンジニアリング");
+    expect(result).toContain("シニアエンジニア");
+  });
+
+  it("ミーティング数が含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("2");
+  });
+
+  it("各ミーティングの日付が含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("2025");
+    expect(result).toContain("1");
+    expect(result).toContain("15");
+  });
+
+  it("トピックのカテゴリラベルが日本語で含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("業務進捗");
+    expect(result).toContain("キャリア");
+    expect(result).toContain("課題・相談");
+  });
+
+  it("トピックのタイトルが含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("Q1 の進捗確認");
+    expect(result).toContain("スキルアップ計画");
+    expect(result).toContain("スプリント遅延の原因分析");
+  });
+
+  it("トピックのノートが含まれる（空でない場合）", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("プロジェクトAは順調に進んでいる。");
+    expect(result).toContain("要件変更が主な原因。");
+  });
+
+  it("アクションアイテムのタイトルが含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("APIドキュメント作成");
+    expect(result).toContain("レビュー依頼");
+  });
+
+  it("アクションアイテムのステータスが含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("TODO");
+    expect(result).toContain("DONE");
+  });
+
+  it("期日が含まれる", () => {
+    const result = formatMeetingMarkdown(sampleMember, sampleMeetings);
+    expect(result).toContain("2025");
+    expect(result).toContain("31");
+  });
+
+  it("アクションアイテムがない場合でも正常に動作する", () => {
+    const result = formatMeetingMarkdown(sampleMember, [sampleMeetings[1]]);
+    expect(result).toContain("スプリント遅延の原因分析");
+  });
+
+  it("ミーティングが空の場合はその旨を含む", () => {
+    const result = formatMeetingMarkdown(sampleMember, []);
+    expect(result).toContain("記録なし");
+  });
+
+  it("部署・役職がない場合でも正常に動作する", () => {
+    const memberNoDetails: MemberExportData = { id: "m2", name: "鈴木 花子" };
+    const result = formatMeetingMarkdown(memberNoDetails, sampleMeetings);
+    expect(result).toContain("鈴木 花子");
+  });
+});
+
+describe("formatSingleMeetingMarkdown", () => {
+  it("単一ミーティングのMarkdownを生成する", () => {
+    const result = formatSingleMeetingMarkdown(sampleMeetings[0]);
+    expect(result).toContain("Q1 の進捗確認");
+    expect(result).toContain("APIドキュメント作成");
+  });
+
+  it("日付が含まれる", () => {
+    const result = formatSingleMeetingMarkdown(sampleMeetings[0]);
+    expect(result).toContain("2025");
+  });
+});

--- a/src/lib/actions/__tests__/export-actions.test.ts
+++ b/src/lib/actions/__tests__/export-actions.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { getMeetingsForExport } from "../export-actions";
+import { createMember } from "../member-actions";
+import { createMeeting } from "../meeting-actions";
+
+beforeEach(async () => {
+  await prisma.actionItem.deleteMany();
+  await prisma.topic.deleteMany();
+  await prisma.meeting.deleteMany();
+  await prisma.member.deleteMany();
+});
+
+describe("getMeetingsForExport", () => {
+  it("メンバーのミーティングデータを取得する", async () => {
+    const memberResult = await createMember({ name: "テスト太郎", department: "開発部" });
+    if (!memberResult.success) throw new Error("member creation failed");
+    const memberId = memberResult.data.id;
+
+    await createMeeting({
+      memberId,
+      date: "2025-01-15",
+      topics: [
+        {
+          category: "WORK_PROGRESS",
+          title: "進捗確認",
+          notes: "問題なし",
+          sortOrder: 0,
+        },
+      ],
+      actionItems: [],
+    });
+
+    const result = await getMeetingsForExport({ memberId });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.member.name).toBe("テスト太郎");
+    expect(result.data.member.department).toBe("開発部");
+    expect(result.data.meetings).toHaveLength(1);
+    expect(result.data.meetings[0].topics).toHaveLength(1);
+    expect(result.data.meetings[0].topics[0].title).toBe("進捗確認");
+  });
+
+  it("期間指定でミーティングを絞り込む", async () => {
+    const memberResult = await createMember({ name: "期間テスト" });
+    if (!memberResult.success) throw new Error("member creation failed");
+    const memberId = memberResult.data.id;
+
+    await createMeeting({
+      memberId,
+      date: "2025-01-10",
+      topics: [{ category: "OTHER", title: "古いミーティング", notes: "", sortOrder: 0 }],
+      actionItems: [],
+    });
+    await createMeeting({
+      memberId,
+      date: "2025-03-20",
+      topics: [{ category: "OTHER", title: "新しいミーティング", notes: "", sortOrder: 0 }],
+      actionItems: [],
+    });
+
+    const result = await getMeetingsForExport({
+      memberId,
+      startDate: "2025-02-01",
+      endDate: "2025-04-30",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.meetings).toHaveLength(1);
+    expect(result.data.meetings[0].topics[0].title).toBe("新しいミーティング");
+  });
+
+  it("存在しないメンバーIDの場合はエラーを返す", async () => {
+    const result = await getMeetingsForExport({ memberId: "non-existent-id" });
+    expect(result.success).toBe(false);
+  });
+
+  it("アクションアイテムも含んで返す", async () => {
+    const memberResult = await createMember({ name: "アクションテスト" });
+    if (!memberResult.success) throw new Error("member creation failed");
+    const memberId = memberResult.data.id;
+
+    await createMeeting({
+      memberId,
+      date: "2025-02-01",
+      topics: [],
+      actionItems: [
+        {
+          title: "タスクA",
+          description: "詳細A",
+          dueDate: "2025-02-28",
+          sortOrder: 0,
+        },
+      ],
+    });
+
+    const result = await getMeetingsForExport({ memberId });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.meetings[0].actionItems).toHaveLength(1);
+    expect(result.data.meetings[0].actionItems[0].title).toBe("タスクA");
+  });
+
+  it("日付降順でミーティングが返る", async () => {
+    const memberResult = await createMember({ name: "順序テスト" });
+    if (!memberResult.success) throw new Error("member creation failed");
+    const memberId = memberResult.data.id;
+
+    await createMeeting({
+      memberId,
+      date: "2025-01-01",
+      topics: [{ category: "OTHER", title: "1月", notes: "", sortOrder: 0 }],
+      actionItems: [],
+    });
+    await createMeeting({
+      memberId,
+      date: "2025-03-01",
+      topics: [{ category: "OTHER", title: "3月", notes: "", sortOrder: 0 }],
+      actionItems: [],
+    });
+
+    const result = await getMeetingsForExport({ memberId });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.meetings[0].topics[0].title).toBe("3月");
+    expect(result.data.meetings[1].topics[0].title).toBe("1月");
+  });
+});

--- a/src/lib/actions/export-actions.ts
+++ b/src/lib/actions/export-actions.ts
@@ -1,0 +1,79 @@
+"use server";
+
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { runAction, type ActionResult } from "./types";
+import type { MeetingExportData, MemberExportData } from "@/lib/export";
+
+const exportQuerySchema = z.object({
+  memberId: z.string().min(1, "メンバーIDは必須です"),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+});
+
+export type ExportQueryInput = z.input<typeof exportQuerySchema>;
+
+export type ExportResult = {
+  member: MemberExportData;
+  meetings: MeetingExportData[];
+};
+
+export async function getMeetingsForExport(
+  input: ExportQueryInput,
+): Promise<ActionResult<ExportResult>> {
+  return runAction(async () => {
+    const { memberId, startDate, endDate } = exportQuerySchema.parse(input);
+
+    const member = await prisma.member.findUnique({ where: { id: memberId } });
+    if (!member) {
+      throw new Error("メンバーが見つかりません");
+    }
+
+    const dateFilter: { gte?: Date; lte?: Date } = {};
+    if (startDate) dateFilter.gte = new Date(startDate);
+    if (endDate) {
+      const end = new Date(endDate);
+      end.setHours(23, 59, 59, 999);
+      dateFilter.lte = end;
+    }
+
+    const meetings = await prisma.meeting.findMany({
+      where: {
+        memberId,
+        ...(Object.keys(dateFilter).length > 0 ? { date: dateFilter } : {}),
+      },
+      orderBy: { date: "desc" },
+      include: {
+        topics: { orderBy: { sortOrder: "asc" } },
+        actionItems: { orderBy: { sortOrder: "asc" } },
+      },
+    });
+
+    return {
+      member: {
+        id: member.id,
+        name: member.name,
+        department: member.department,
+        position: member.position,
+      },
+      meetings: meetings.map((m) => ({
+        id: m.id,
+        date: m.date,
+        topics: m.topics.map((t) => ({
+          id: t.id,
+          category: t.category,
+          title: t.title,
+          notes: t.notes,
+          sortOrder: t.sortOrder,
+        })),
+        actionItems: m.actionItems.map((a) => ({
+          id: a.id,
+          title: a.title,
+          description: a.description,
+          status: a.status,
+          dueDate: a.dueDate,
+        })),
+      })),
+    };
+  });
+}

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,104 @@
+import { CATEGORY_LABELS } from "@/lib/constants";
+import { formatDate } from "@/lib/format";
+
+export type TopicExportData = {
+  id: string;
+  category: string;
+  title: string;
+  notes: string;
+  sortOrder: number;
+};
+
+export type ActionItemExportData = {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  dueDate: Date | null;
+};
+
+export type MeetingExportData = {
+  id: string;
+  date: Date;
+  topics: TopicExportData[];
+  actionItems: ActionItemExportData[];
+};
+
+export type MemberExportData = {
+  id: string;
+  name: string;
+  department?: string | null;
+  position?: string | null;
+};
+
+function formatTopics(topics: TopicExportData[]): string {
+  if (topics.length === 0) return "";
+
+  const lines: string[] = ["### トピック", ""];
+  for (const topic of topics) {
+    const categoryLabel = CATEGORY_LABELS[topic.category] ?? topic.category;
+    lines.push(`#### ${categoryLabel}: ${topic.title}`);
+    if (topic.notes) {
+      lines.push("", topic.notes);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function formatActionItems(actionItems: ActionItemExportData[]): string {
+  if (actionItems.length === 0) return "";
+
+  const lines: string[] = ["### アクションアイテム", ""];
+  for (const item of actionItems) {
+    const due = item.dueDate ? ` (期日: ${formatDate(item.dueDate)})` : "";
+    lines.push(`- [${item.status}] ${item.title}${due}`);
+    if (item.description) {
+      lines.push(`  ${item.description}`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function formatSingleMeetingMarkdown(meeting: MeetingExportData): string {
+  const lines: string[] = [`## ${formatDate(meeting.date)} のミーティング`, ""];
+
+  const topicsSection = formatTopics(meeting.topics);
+  if (topicsSection) lines.push(topicsSection);
+
+  const actionsSection = formatActionItems(meeting.actionItems);
+  if (actionsSection) lines.push(actionsSection);
+
+  lines.push("---");
+  return lines.join("\n");
+}
+
+export function formatMeetingMarkdown(
+  member: MemberExportData,
+  meetings: MeetingExportData[],
+): string {
+  const memberInfo = [member.name, member.department, member.position].filter(Boolean).join(" / ");
+
+  const lines: string[] = [
+    `# 1on1 サマリー - ${member.name}`,
+    "",
+    `**メンバー:** ${memberInfo}`,
+    `**ミーティング数:** ${meetings.length}`,
+    "",
+    "---",
+    "",
+  ];
+
+  if (meetings.length === 0) {
+    lines.push("記録なし");
+    return lines.join("\n");
+  }
+
+  for (const meeting of meetings) {
+    lines.push(formatSingleMeetingMarkdown(meeting));
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

- `src/lib/export.ts`: ミーティングデータを Markdown 形式に変換するユーティリティを追加
- `src/lib/actions/export-actions.ts`: メンバー・期間指定でミーティングデータを取得する Server Action を追加
- `src/components/meeting/export-dialog.tsx`: エクスポートダイアログコンポーネントを追加
- メンバー詳細ページ (`/members/[id]`) にエクスポートボタンを追加

## 機能詳細

- **Markdown ダウンロード**: `.md` ファイルとしてローカルに保存
- **クリップボードコピー**: ワンクリックでMarkdownをコピー
- **期間絞り込み**: 開始日・終了日を指定してエクスポート範囲を絞れる
- **全期間エクスポート**: 期間指定なしで全ミーティングをエクスポート

## Closes

Closes #42

## Test plan

- [x] `src/lib/__tests__/export.test.ts` — Markdownフォーマット関数（14件）
- [x] `src/lib/actions/__tests__/export-actions.test.ts` — Server Action（5件）
- [x] `src/components/meeting/__tests__/export-dialog.test.tsx` — コンポーネント（10件）
- [x] 全テスト通過: 438件（+29件）
- [x] 本番ビルド成功