### PR TITLE
feat: メンバー別ミーティング頻度ヒートマップ（issue #35）

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -2,15 +2,18 @@ import { Breadcrumb } from "@/components/layout/breadcrumb";
 import {
   getMeetingFrequencyByMonth,
   getAllMembersWithInterval,
+  getMemberMeetingHeatmap,
 } from "@/lib/actions/analytics-actions";
 import { MeetingFrequencyChart } from "@/components/analytics/meeting-frequency-chart";
 import { MeetingIntervalTable } from "@/components/analytics/meeting-interval-table";
+import { MeetingHeatmap } from "@/components/analytics/meeting-heatmap";
 
 export const dynamic = "force-dynamic";
 
 export default async function AnalyticsPage() {
-  const [frequencyData, allMembers] = await Promise.all([
+  const [frequencyData, heatmapData, allMembers] = await Promise.all([
     getMeetingFrequencyByMonth(),
+    getMemberMeetingHeatmap(),
     getAllMembersWithInterval(),
   ]);
 
@@ -26,6 +29,10 @@ export default async function AnalyticsPage() {
           月次実施回数（直近12ヶ月）
         </h2>
         <MeetingFrequencyChart data={frequencyData} />
+      </div>
+
+      <div className="mb-8">
+        <MeetingHeatmap data={heatmapData} />
       </div>
 
       <div>

--- a/src/components/analytics/__tests__/meeting-heatmap.test.tsx
+++ b/src/components/analytics/__tests__/meeting-heatmap.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MeetingHeatmap } from "../meeting-heatmap";
+import type { HeatmapData } from "@/lib/actions/analytics-actions";
+
+const emptyData: HeatmapData = {
+  members: [],
+  months: [
+    "2025-03",
+    "2025-04",
+    "2025-05",
+    "2025-06",
+    "2025-07",
+    "2025-08",
+    "2025-09",
+    "2025-10",
+    "2025-11",
+    "2025-12",
+    "2026-01",
+    "2026-02",
+  ],
+};
+
+const sampleData: HeatmapData = {
+  members: [
+    {
+      memberId: "member-1",
+      memberName: "田中 太郎",
+      months: [
+        { month: "2025-03", count: 0 },
+        { month: "2025-04", count: 1 },
+        { month: "2025-05", count: 0 },
+        { month: "2025-06", count: 2 },
+        { month: "2025-07", count: 0 },
+        { month: "2025-08", count: 3 },
+        { month: "2025-09", count: 0 },
+        { month: "2025-10", count: 4 },
+        { month: "2025-11", count: 0 },
+        { month: "2025-12", count: 1 },
+        { month: "2026-01", count: 0 },
+        { month: "2026-02", count: 2 },
+      ],
+    },
+    {
+      memberId: "member-2",
+      memberName: "鈴木 花子",
+      months: [
+        { month: "2025-03", count: 1 },
+        { month: "2025-04", count: 0 },
+        { month: "2025-05", count: 2 },
+        { month: "2025-06", count: 0 },
+        { month: "2025-07", count: 1 },
+        { month: "2025-08", count: 0 },
+        { month: "2025-09", count: 3 },
+        { month: "2025-10", count: 0 },
+        { month: "2025-11", count: 1 },
+        { month: "2025-12", count: 0 },
+        { month: "2026-01", count: 2 },
+        { month: "2026-02", count: 0 },
+      ],
+    },
+  ],
+  months: [
+    "2025-03",
+    "2025-04",
+    "2025-05",
+    "2025-06",
+    "2025-07",
+    "2025-08",
+    "2025-09",
+    "2025-10",
+    "2025-11",
+    "2025-12",
+    "2026-01",
+    "2026-02",
+  ],
+};
+
+describe("MeetingHeatmap", () => {
+  it("メンバーがいない場合は空状態メッセージを表示する", () => {
+    render(<MeetingHeatmap data={emptyData} />);
+    expect(screen.getByText("データがありません")).toBeDefined();
+  });
+
+  it("メンバー名を表示する", () => {
+    render(<MeetingHeatmap data={sampleData} />);
+    expect(screen.getByText("田中 太郎")).toBeDefined();
+    expect(screen.getByText("鈴木 花子")).toBeDefined();
+  });
+
+  it("月ヘッダーを表示する（M月形式）", () => {
+    render(<MeetingHeatmap data={sampleData} />);
+    // 月ヘッダーは "3月", "4月", ... と表示
+    expect(screen.getAllByText("3月")).toBeDefined();
+    expect(screen.getAllByText("2月")).toBeDefined();
+  });
+
+  it("ミーティング回数に応じたセルを表示する", () => {
+    render(<MeetingHeatmap data={sampleData} />);
+    // 各セルに title 属性でツールチップ情報を持つ
+    const cells = screen.getAllByRole("cell");
+    // メンバー2人 × 12ヶ月 = 24セル（ヘッダー行は含まない）
+    expect(cells.length).toBeGreaterThanOrEqual(24);
+  });
+
+  it("凡例を表示する", () => {
+    render(<MeetingHeatmap data={sampleData} />);
+    expect(screen.getAllByText("0回").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("4回以上").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/analytics/meeting-heatmap.tsx
+++ b/src/components/analytics/meeting-heatmap.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { HeatmapData } from "@/lib/actions/analytics-actions";
+
+type Props = {
+  readonly data: HeatmapData;
+};
+
+const HEATMAP_LEVELS = [
+  { min: 0, max: 0, label: "0回", className: "bg-muted" },
+  { min: 1, max: 1, label: "1回", className: "bg-primary/20" },
+  { min: 2, max: 2, label: "2回", className: "bg-primary/40" },
+  { min: 3, max: 3, label: "3回", className: "bg-primary/60" },
+  { min: 4, max: Infinity, label: "4回以上", className: "bg-primary/80" },
+] as const;
+
+function getHeatmapCellClass(count: number): string {
+  const level = HEATMAP_LEVELS.find((l) => count >= l.min && count <= l.max);
+  return level?.className ?? "bg-muted";
+}
+
+function formatMonthLabel(monthKey: string): string {
+  const parts = monthKey.split("-");
+  return parts.length === 2 ? `${parseInt(parts[1], 10)}月` : monthKey;
+}
+
+function formatCellLabel(memberName: string, month: string, count: number): string {
+  return `${memberName} - ${month}: ${count}回`;
+}
+
+export function MeetingHeatmap({ data }: Props) {
+  const { members, months } = data;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          メンバー別 ミーティング頻度（直近12ヶ月）
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {members.length === 0 ? (
+          <div className="flex items-center justify-center py-8 text-muted-foreground text-sm">
+            データがありません
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table
+              className="w-full text-xs border-separate border-spacing-1"
+              aria-label="メンバー別ミーティング頻度ヒートマップ"
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                    className="text-left font-medium text-muted-foreground pr-3 min-w-[120px]"
+                  >
+                    メンバー
+                  </th>
+                  {months.map((month) => (
+                    <th
+                      key={month}
+                      scope="col"
+                      className="text-center font-medium text-muted-foreground min-w-[36px]"
+                    >
+                      {formatMonthLabel(month)}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {members.map((member) => (
+                  <tr key={member.memberId}>
+                    <th
+                      scope="row"
+                      className="pr-3 py-1 text-sm font-medium text-left truncate max-w-[160px]"
+                    >
+                      {member.memberName}
+                    </th>
+                    {member.months.map(({ month, count }) => (
+                      <td
+                        key={month}
+                        className={`rounded-sm h-7 w-9 text-center align-middle transition-colors ${getHeatmapCellClass(count)}`}
+                        aria-label={formatCellLabel(member.memberName, month, count)}
+                        title={formatCellLabel(member.memberName, month, count)}
+                      >
+                        {count > 0 && (
+                          <span className="text-[10px] font-medium text-foreground/70">
+                            {count}
+                          </span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {/* 凡例 */}
+            <div className="mt-4 flex items-center gap-3 text-xs text-muted-foreground">
+              <span>少</span>
+              {HEATMAP_LEVELS.map(({ label, className }) => (
+                <div key={label} className="flex items-center gap-1">
+                  <div className={`h-4 w-4 rounded-sm ${className}`} aria-hidden="true" />
+                  <span>{label}</span>
+                </div>
+              ))}
+              <span>多</span>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

- `getMemberMeetingHeatmap()` Server Action を新規追加し、直近12ヶ月のミーティングをメンバー別 × 月別にクロス集計
- `MeetingHeatmap` コンポーネントを新規作成（CSS Grid + Tailwind によるヒートマップ UI）
- `/analytics` ページに既存の月次バーチャートと経過日数テーブルの間にヒートマップセクションを追加

## Changes

### 新規ファイル
- `src/components/analytics/meeting-heatmap.tsx` — ヒートマップ UI コンポーネント
- `src/components/analytics/__tests__/meeting-heatmap.test.tsx` — コンポーネントテスト（5件）

### 変更ファイル
- `src/lib/actions/analytics-actions.ts` — `getMemberMeetingHeatmap()` 関数・型定義を追加
- `src/lib/actions/__tests__/analytics-actions.test.ts` — Server Action テストを追加（4件）
- `src/app/analytics/page.tsx` — ヒートマップセクションを統合

## Implementation Details

- Recharts ではなく CSS Grid + Tailwind でヒートマップを実装（追加ライブラリ不要）
- `HEATMAP_LEVELS` 定数で色定義を一元管理（0回〜4回以上の5段階）
- `Array.from` による宣言的な月配列生成（イミュータブルパターン準拠）
- try-catch によるデータベースエラーハンドリング
- `aria-label`・`scope` 属性によるアクセシビリティ対応
- Prisma の `include` で N+1 クエリを回避

## Closes

Closes #35

## Test plan

- [ ] `/analytics` ページにアクセスして「メンバー別 ミーティング頻度（直近12ヶ月）」ヒートマップが表示されることを確認
- [ ] メンバー行・月列・色セルが正しく表示されることを確認
- [ ] セルにホバーすると「メンバー名 - YYYY-MM: N回」ツールチップが表示されることを確認
- [ ] 凡例（0回〜4回以上）が表示されることを確認
- [ ] メンバーが0件の場合に「データがありません」が表示されることを確認
- [ ] `npm test` — 全 456 テストがパスすることを確認
- [ ] `npm run build` — ビルドエラーがないことを確認