### PR TITLE
feat: ミーティング実施リマインダーの実装（issue #43）

### DIFF
--- a/prisma/migrations/20260222085124_add_meeting_interval_days/migration.sql
+++ b/prisma/migrations/20260222085124_add_meeting_interval_days/migration.sql
@@ -1,0 +1,17 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Member" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "department" TEXT,
+    "position" TEXT,
+    "meetingIntervalDays" INTEGER NOT NULL DEFAULT 14,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Member" ("createdAt", "department", "id", "name", "position", "updatedAt") SELECT "createdAt", "department", "id", "name", "position", "updatedAt" FROM "Member";
+DROP TABLE "Member";
+ALTER TABLE "new_Member" RENAME TO "Member";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,12 +9,13 @@ datasource db {
 }
 
 model Member {
-  id         String   @id @default(uuid())
-  name       String
-  department String?
-  position   String?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id                  String   @id @default(uuid())
+  name                String
+  department          String?
+  position            String?
+  meetingIntervalDays Int      @default(14)
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
   meetings    Meeting[]
   actionItems ActionItem[]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,23 +5,27 @@ import {
   getUpcomingActions,
 } from "@/lib/actions/dashboard-actions";
 import { getRecommendedMeetings } from "@/lib/actions/analytics-actions";
+import { getOverdueReminders } from "@/lib/actions/reminder-actions";
 import { MemberList } from "@/components/member/member-list";
 import { DashboardSummary } from "@/components/dashboard/dashboard-summary";
 import { RecentActivityFeed } from "@/components/dashboard/recent-activity-feed";
 import { UpcomingActionsSection } from "@/components/dashboard/upcoming-actions-section";
 import { RecommendedMeetingsSection } from "@/components/dashboard/recommended-meetings-section";
+import { ReminderAlertBanner } from "@/components/dashboard/reminder-alert-banner";
+import { BrowserNotification } from "@/components/dashboard/browser-notification";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 
 export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
-  const [members, summary, recentActivity, upcomingActions, recommendedMeetings] =
+  const [members, summary, recentActivity, upcomingActions, recommendedMeetings, overdueReminders] =
     await Promise.all([
       getMembers(),
       getDashboardSummary(),
       getRecentActivity(),
       getUpcomingActions(),
       getRecommendedMeetings(),
+      getOverdueReminders(),
     ]);
 
   const isFirstTime = members.length === 0;
@@ -29,6 +33,9 @@ export default async function DashboardPage() {
   return (
     <div className="animate-fade-in-up">
       <h1 className="text-2xl font-semibold tracking-tight mb-6 text-foreground">ダッシュボード</h1>
+
+      {!isFirstTime && <ReminderAlertBanner reminders={overdueReminders} />}
+      {!isFirstTime && <BrowserNotification reminders={overdueReminders} />}
 
       {isFirstTime ? <OnboardingCard /> : <DashboardSummary summary={summary} />}
 

--- a/src/components/dashboard/__tests__/browser-notification.test.tsx
+++ b/src/components/dashboard/__tests__/browser-notification.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { BrowserNotification } from "../browser-notification";
+import type { OverdueReminder } from "@/lib/actions/reminder-actions";
+
+const makeReminder = (overrides: Partial<OverdueReminder> = {}): OverdueReminder => ({
+  memberId: "member-1",
+  memberName: "テストメンバー",
+  meetingIntervalDays: 14,
+  daysSinceLastMeeting: 20,
+  ...overrides,
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("BrowserNotification", () => {
+  describe("Notification API 非対応環境", () => {
+    beforeEach(() => {
+      vi.stubGlobal("Notification", undefined);
+    });
+
+    it("Notification API が未対応でもクラッシュしない", () => {
+      expect(() => {
+        render(<BrowserNotification reminders={[makeReminder()]} />);
+      }).not.toThrow();
+    });
+  });
+
+  describe("Notification API 対応環境 - 許可未設定", () => {
+    const mockRequestPermission = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const MockNotification: any = vi.fn();
+
+    beforeEach(() => {
+      Object.defineProperty(MockNotification, "permission", {
+        get: () => "default",
+        configurable: true,
+      });
+      MockNotification.requestPermission = mockRequestPermission.mockResolvedValue("granted");
+      vi.stubGlobal("Notification", MockNotification);
+    });
+
+    it("リマインダーがある場合に requestPermission を呼ぶ", async () => {
+      await act(async () => {
+        render(<BrowserNotification reminders={[makeReminder()]} />);
+      });
+      expect(mockRequestPermission).toHaveBeenCalled();
+    });
+
+    it("リマインダーが空の場合は requestPermission を呼ばない", async () => {
+      await act(async () => {
+        render(<BrowserNotification reminders={[]} />);
+      });
+      expect(mockRequestPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Notification API 対応環境 - 通知拒否", () => {
+    const mockNotificationConstructor = vi.fn();
+
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const MockNotification: any = vi.fn().mockImplementation(mockNotificationConstructor);
+      Object.defineProperty(MockNotification, "permission", {
+        get: () => "denied",
+        configurable: true,
+      });
+      MockNotification.requestPermission = vi.fn().mockResolvedValue("denied");
+      vi.stubGlobal("Notification", MockNotification);
+    });
+
+    it("通知が拒否されている場合は Notification を生成しない", async () => {
+      await act(async () => {
+        render(<BrowserNotification reminders={[makeReminder()]} />);
+      });
+      expect(mockNotificationConstructor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("今日通知済みの場合", () => {
+    const mockNotificationConstructor = vi.fn();
+
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const MockNotification: any = vi.fn().mockImplementation(mockNotificationConstructor);
+      Object.defineProperty(MockNotification, "permission", {
+        get: () => "granted",
+        configurable: true,
+      });
+      MockNotification.requestPermission = vi.fn().mockResolvedValue("granted");
+      vi.stubGlobal("Notification", MockNotification);
+
+      // 今日通知済みフラグをセット
+      const today = new Date().toISOString().split("T")[0];
+      localStorage.setItem("nudge_notification_date", today);
+    });
+
+    it("今日すでに通知済みの場合は Notification を生成しない", async () => {
+      await act(async () => {
+        render(<BrowserNotification reminders={[makeReminder()]} />);
+      });
+      expect(mockNotificationConstructor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("許可済み・未通知の場合", () => {
+    const mockNotificationConstructor = vi.fn();
+
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const MockNotification: any = vi.fn().mockImplementation(mockNotificationConstructor);
+      Object.defineProperty(MockNotification, "permission", {
+        get: () => "granted",
+        configurable: true,
+      });
+      MockNotification.requestPermission = vi.fn().mockResolvedValue("granted");
+      vi.stubGlobal("Notification", MockNotification);
+    });
+
+    it("許可済みでリマインダーがある場合は Notification を生成する", async () => {
+      await act(async () => {
+        render(<BrowserNotification reminders={[makeReminder({ memberName: "田中太郎" })]} />);
+      });
+      expect(mockNotificationConstructor).toHaveBeenCalled();
+    });
+
+    it("通知後に今日の日付を localStorage に保存する", async () => {
+      await act(async () => {
+        render(<BrowserNotification reminders={[makeReminder()]} />);
+      });
+      const today = new Date().toISOString().split("T")[0];
+      expect(localStorage.getItem("nudge_notification_date")).toBe(today);
+    });
+
+    it("リマインダーが空の場合は Notification を生成しない", async () => {
+      await act(async () => {
+        render(<BrowserNotification reminders={[]} />);
+      });
+      expect(mockNotificationConstructor).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/dashboard/__tests__/reminder-alert-banner.test.tsx
+++ b/src/components/dashboard/__tests__/reminder-alert-banner.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ReminderAlertBanner } from "../reminder-alert-banner";
+import type { OverdueReminder } from "@/lib/actions/reminder-actions";
+
+afterEach(() => {
+  cleanup();
+});
+
+const makeReminder = (overrides: Partial<OverdueReminder> = {}): OverdueReminder => ({
+  memberId: "member-1",
+  memberName: "テストメンバー",
+  meetingIntervalDays: 14,
+  daysSinceLastMeeting: 20,
+  ...overrides,
+});
+
+describe("ReminderAlertBanner", () => {
+  it("リマインダーが空の場合は何も表示しない", () => {
+    const { container } = render(<ReminderAlertBanner reminders={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("リマインダーがある場合はバナーを表示する", () => {
+    render(<ReminderAlertBanner reminders={[makeReminder()]} />);
+    expect(screen.getByText(/ミーティングリマインダー/)).toBeDefined();
+  });
+
+  it("期限超過メンバー名を表示する", () => {
+    render(
+      <ReminderAlertBanner
+        reminders={[makeReminder({ memberName: "田中太郎", daysSinceLastMeeting: 15 })]}
+      />,
+    );
+    expect(screen.getByText("田中太郎")).toBeDefined();
+  });
+
+  it("経過日数を表示する", () => {
+    render(
+      <ReminderAlertBanner
+        reminders={[makeReminder({ daysSinceLastMeeting: 20, meetingIntervalDays: 14 })]}
+      />,
+    );
+    expect(screen.getByText(/20日経過/)).toBeDefined();
+  });
+
+  it("未ミーティングメンバーは「未実施」と表示する", () => {
+    render(<ReminderAlertBanner reminders={[makeReminder({ daysSinceLastMeeting: null })]} />);
+    expect(screen.getByText(/未実施/)).toBeDefined();
+  });
+
+  it("複数のリマインダーを表示する", () => {
+    const reminders = [
+      makeReminder({ memberName: "田中太郎", memberId: "1" }),
+      makeReminder({ memberName: "鈴木花子", memberId: "2" }),
+    ];
+    render(<ReminderAlertBanner reminders={reminders} />);
+    expect(screen.getByText("田中太郎")).toBeDefined();
+    expect(screen.getByText("鈴木花子")).toBeDefined();
+  });
+
+  it("「1on1準備」リンクが各メンバーに表示される", () => {
+    render(<ReminderAlertBanner reminders={[makeReminder({ memberId: "member-abc" })]} />);
+    const link = screen.getByRole("link", { name: /1on1準備/ });
+    expect(link).toBeDefined();
+    expect((link as HTMLAnchorElement).href).toContain("/members/member-abc");
+  });
+
+  it("リマインダーが3件以上の場合、件数バッジを表示する", () => {
+    const reminders = Array.from({ length: 3 }, (_, i) =>
+      makeReminder({ memberId: `member-${i}`, memberName: `メンバー${i + 1}` }),
+    );
+    render(<ReminderAlertBanner reminders={reminders} />);
+    expect(screen.getByText(/3件/)).toBeDefined();
+  });
+});

--- a/src/components/dashboard/browser-notification.tsx
+++ b/src/components/dashboard/browser-notification.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import type { OverdueReminder } from "@/lib/actions/reminder-actions";
+
+const STORAGE_KEY = "nudge_notification_date";
+
+type Props = {
+  readonly reminders: OverdueReminder[];
+};
+
+function getTodayString(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+function hasNotifiedToday(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === getTodayString();
+  } catch {
+    return false;
+  }
+}
+
+function markNotifiedToday(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, getTodayString());
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+async function sendBrowserNotifications(reminders: OverdueReminder[]): Promise<void> {
+  if (typeof Notification === "undefined") return;
+  if (reminders.length === 0) return;
+  if (hasNotifiedToday()) return;
+
+  let permission = Notification.permission;
+
+  if (permission === "default") {
+    permission = await Notification.requestPermission();
+  }
+
+  if (permission !== "granted") return;
+
+  const count = reminders.length;
+  const names = reminders
+    .slice(0, 3)
+    .map((r) => r.memberName)
+    .join("、");
+  const body =
+    count <= 3
+      ? `${names} との 1on1 が未実施です`
+      : `${names} ほか ${count}人 との 1on1 が未実施です`;
+
+  new Notification("Nudge: ミーティングリマインダー", {
+    body,
+    icon: "/favicon.ico",
+  });
+
+  markNotifiedToday();
+}
+
+export function BrowserNotification({ reminders }: Props) {
+  useEffect(() => {
+    sendBrowserNotifications(reminders).catch(() => {
+      // 通知失敗は無視
+    });
+  }, [reminders]);
+
+  return null;
+}

--- a/src/components/dashboard/reminder-alert-banner.tsx
+++ b/src/components/dashboard/reminder-alert-banner.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import type { OverdueReminder } from "@/lib/actions/reminder-actions";
+
+type Props = {
+  readonly reminders: OverdueReminder[];
+};
+
+export function ReminderAlertBanner({ reminders }: Props) {
+  if (reminders.length === 0) return null;
+
+  return (
+    <div
+      role="alert"
+      className="mb-6 rounded-xl border border-destructive/30 bg-destructive/5 p-4 animate-fade-in-up"
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <AlertTriangle className="h-5 w-5 text-destructive shrink-0" aria-hidden="true" />
+        <h2 className="text-sm font-semibold text-destructive">ミーティングリマインダー</h2>
+        <span className="ml-auto rounded-full bg-destructive px-2 py-0.5 text-xs font-medium text-destructive-foreground">
+          {reminders.length}件
+        </span>
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {reminders.map((reminder) => (
+          <li
+            key={reminder.memberId}
+            className="flex items-center justify-between gap-3 rounded-lg bg-background/60 px-3 py-2 text-sm"
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="font-medium text-foreground truncate">{reminder.memberName}</span>
+              <span className="text-muted-foreground shrink-0">
+                {reminder.daysSinceLastMeeting === null
+                  ? "未実施"
+                  : `${reminder.daysSinceLastMeeting}日経過`}
+              </span>
+              <span className="text-xs text-muted-foreground shrink-0">
+                （設定: {reminder.meetingIntervalDays}日）
+              </span>
+            </div>
+            <Link
+              href={`/members/${reminder.memberId}/meetings/new?prepare=true`}
+              className="shrink-0 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              1on1準備
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/member/__tests__/member-edit-dialog.test.tsx
+++ b/src/components/member/__tests__/member-edit-dialog.test.tsx
@@ -69,6 +69,7 @@ describe("MemberEditDialog", () => {
       name: "田中太郎",
       department: "エンジニアリング",
       position: "シニアエンジニア",
+      meetingIntervalDays: 14,
     });
     expect(mockRefresh).toHaveBeenCalled();
   });

--- a/src/components/member/__tests__/member-form.test.tsx
+++ b/src/components/member/__tests__/member-form.test.tsx
@@ -69,9 +69,31 @@ describe("MemberForm - 新規作成モード", () => {
       name: "山田花子",
       department: "デザイン",
       position: undefined,
+      meetingIntervalDays: 14,
     });
     expect(toast.success).toHaveBeenCalledWith(TOAST_MESSAGES.member.createSuccess);
     expect(mockPush).toHaveBeenCalledWith("/");
+  });
+
+  it("ミーティング間隔セレクトが表示される（デフォルト14日）", () => {
+    render(<MemberForm />);
+    expect(screen.getByLabelText("ミーティング間隔")).toBeDefined();
+    const select = screen.getByLabelText("ミーティング間隔") as HTMLSelectElement;
+    expect(select.value).toBe("14");
+  });
+
+  it("ミーティング間隔を7日に変更して送信できる", async () => {
+    const user = userEvent.setup();
+    mockCreateMember.mockResolvedValue({ success: true, data: {} });
+    render(<MemberForm />);
+
+    await user.type(screen.getByLabelText("名前 *"), "テストメンバー");
+    await user.selectOptions(screen.getByLabelText("ミーティング間隔"), "7");
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    expect(mockCreateMember).toHaveBeenCalledWith(
+      expect.objectContaining({ meetingIntervalDays: 7 }),
+    );
   });
 
   it("エラー時にエラーメッセージとトーストが表示される", async () => {
@@ -93,6 +115,7 @@ describe("MemberForm - 編集モード", () => {
     name: "田中太郎",
     department: "エンジニアリング",
     position: "シニアエンジニア",
+    meetingIntervalDays: 14,
   };
 
   it("「メンバー登録」タイトルが表示されない（Card なし）", () => {
@@ -130,6 +153,7 @@ describe("MemberForm - 編集モード", () => {
       name: "田中次郎",
       department: "エンジニアリング",
       position: "シニアエンジニア",
+      meetingIntervalDays: 14,
     });
     expect(toast.success).toHaveBeenCalledWith(TOAST_MESSAGES.member.updateSuccess);
     expect(onSuccess).toHaveBeenCalled();
@@ -150,5 +174,11 @@ describe("MemberForm - 編集モード", () => {
     render(<MemberForm initialData={{ ...initialData, department: null }} />);
     const deptInput = screen.getByLabelText("部署") as HTMLInputElement;
     expect(deptInput.value).toBe("");
+  });
+
+  it("初期値の meetingIntervalDays がセレクトに反映される", () => {
+    render(<MemberForm initialData={{ ...initialData, meetingIntervalDays: 30 }} />);
+    const select = screen.getByLabelText("ミーティング間隔") as HTMLSelectElement;
+    expect(select.value).toBe("30");
   });
 });

--- a/src/components/member/member-form.tsx
+++ b/src/components/member/member-form.tsx
@@ -10,11 +10,18 @@ import { toast } from "sonner";
 import { createMember, updateMember } from "@/lib/actions/member-actions";
 import { TOAST_MESSAGES } from "@/lib/toast-messages";
 
+const MEETING_INTERVAL_OPTIONS = [
+  { value: 7, label: "1週間（7日）" },
+  { value: 14, label: "2週間（14日）" },
+  { value: 30, label: "1ヶ月（30日）" },
+] as const;
+
 type MemberData = {
   readonly id: string;
   readonly name: string;
   readonly department: string | null;
   readonly position: string | null;
+  readonly meetingIntervalDays?: number;
 };
 
 type Props = {
@@ -37,10 +44,16 @@ export function MemberForm({ initialData, onSuccess }: Props) {
     const name = formData.get("name") as string;
     const department = (formData.get("department") as string) || undefined;
     const position = (formData.get("position") as string) || undefined;
+    const meetingIntervalDays = Number(formData.get("meetingIntervalDays") ?? 14);
 
     try {
       if (isEditing) {
-        const result = await updateMember(initialData.id, { name, department, position });
+        const result = await updateMember(initialData.id, {
+          name,
+          department,
+          position,
+          meetingIntervalDays,
+        });
         if (!result.success) {
           setError(result.error);
           toast.error(TOAST_MESSAGES.member.updateError);
@@ -49,7 +62,7 @@ export function MemberForm({ initialData, onSuccess }: Props) {
         toast.success(TOAST_MESSAGES.member.updateSuccess);
         onSuccess?.();
       } else {
-        const result = await createMember({ name, department, position });
+        const result = await createMember({ name, department, position, meetingIntervalDays });
         if (!result.success) {
           setError(result.error);
           toast.error(TOAST_MESSAGES.member.createError);
@@ -96,6 +109,21 @@ export function MemberForm({ initialData, onSuccess }: Props) {
           defaultValue={initialData?.position ?? ""}
           placeholder="例: シニアエンジニア"
         />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="meetingIntervalDays">ミーティング間隔</Label>
+        <select
+          id="meetingIntervalDays"
+          name="meetingIntervalDays"
+          defaultValue={String(initialData?.meetingIntervalDays ?? 14)}
+          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {MEETING_INTERVAL_OPTIONS.map((opt) => (
+            <option key={opt.value} value={String(opt.value)}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
       </div>
       {error && <p className="text-sm text-destructive">{error}</p>}
       <Button type="submit" disabled={isSubmitting}>

--- a/src/lib/actions/__tests__/reminder-actions.test.ts
+++ b/src/lib/actions/__tests__/reminder-actions.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { getOverdueReminders } from "../reminder-actions";
+import { createMember } from "../member-actions";
+import { createMeeting } from "../meeting-actions";
+
+beforeEach(async () => {
+  await prisma.actionItem.deleteMany();
+  await prisma.topic.deleteMany();
+  await prisma.meeting.deleteMany();
+  await prisma.member.deleteMany();
+});
+
+describe("getOverdueReminders", () => {
+  it("メンバーが0人の場合は空配列を返す", async () => {
+    const result = await getOverdueReminders();
+    expect(result).toEqual([]);
+  });
+
+  it("全員が期間内にミーティングしている場合は空配列を返す", async () => {
+    const memberResult = await createMember({ name: "Recent", meetingIntervalDays: 14 });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    const result = await getOverdueReminders();
+    expect(result).toEqual([]);
+  });
+
+  it("デフォルト間隔（14日）を超えたメンバーを返す", async () => {
+    const memberResult = await createMember({ name: "Old Member" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const fifteenDaysAgo = new Date();
+    fifteenDaysAgo.setDate(fifteenDaysAgo.getDate() - 15);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: fifteenDaysAgo.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    const result = await getOverdueReminders();
+    expect(result).toHaveLength(1);
+    expect(result[0].memberName).toBe("Old Member");
+    expect(result[0].daysSinceLastMeeting).toBe(15);
+    expect(result[0].meetingIntervalDays).toBe(14);
+  });
+
+  it("カスタム間隔（7日）を超えたメンバーを返す", async () => {
+    const memberResult = await createMember({ name: "Weekly Member", meetingIntervalDays: 7 });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const tenDaysAgo = new Date();
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: tenDaysAgo.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    const result = await getOverdueReminders();
+    expect(result).toHaveLength(1);
+    expect(result[0].memberName).toBe("Weekly Member");
+    expect(result[0].daysSinceLastMeeting).toBe(10);
+    expect(result[0].meetingIntervalDays).toBe(7);
+  });
+
+  it("カスタム間隔（30日）の場合、15日後は期限内として除外する", async () => {
+    const memberResult = await createMember({ name: "Monthly Member", meetingIntervalDays: 30 });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const fifteenDaysAgo = new Date();
+    fifteenDaysAgo.setDate(fifteenDaysAgo.getDate() - 15);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: fifteenDaysAgo.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    const result = await getOverdueReminders();
+    expect(result).toEqual([]);
+  });
+
+  it("一度もミーティングをしていないメンバーを返す", async () => {
+    const memberResult = await createMember({ name: "Never Met" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const result = await getOverdueReminders();
+    expect(result).toHaveLength(1);
+    expect(result[0].memberName).toBe("Never Met");
+    expect(result[0].daysSinceLastMeeting).toBeNull();
+  });
+
+  it("複数メンバーを経過日数（降順）でソートして返す", async () => {
+    const m1Result = await createMember({ name: "Member A" }); // 20日超過
+    const m2Result = await createMember({ name: "Member B" }); // 30日超過
+    const m3Result = await createMember({ name: "Member C" }); // 未ミーティング
+    if (!m1Result.success || !m2Result.success || !m3Result.success) {
+      throw new Error("Failed to create members");
+    }
+
+    const twentyDaysAgo = new Date();
+    twentyDaysAgo.setDate(twentyDaysAgo.getDate() - 20);
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    await createMeeting({
+      memberId: m1Result.data.id,
+      date: twentyDaysAgo.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+    await createMeeting({
+      memberId: m2Result.data.id,
+      date: thirtyDaysAgo.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    const result = await getOverdueReminders();
+    expect(result).toHaveLength(3);
+    // null（未ミーティング）は最後にソート
+    expect(result[0].memberName).toBe("Member B"); // 30日
+    expect(result[1].memberName).toBe("Member A"); // 20日
+    expect(result[2].memberName).toBe("Member C"); // null
+  });
+
+  it("返り値の型が正しい", async () => {
+    const memberResult = await createMember({ name: "Test Member", meetingIntervalDays: 7 });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const tenDaysAgo = new Date();
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: tenDaysAgo.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    const result = await getOverdueReminders();
+    const item = result[0];
+    expect(item).toMatchObject({
+      memberId: expect.any(String),
+      memberName: expect.any(String),
+      meetingIntervalDays: expect.any(Number),
+      daysSinceLastMeeting: expect.any(Number),
+    });
+  });
+});

--- a/src/lib/actions/reminder-actions.ts
+++ b/src/lib/actions/reminder-actions.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+
+export type OverdueReminder = {
+  memberId: string;
+  memberName: string;
+  meetingIntervalDays: number;
+  daysSinceLastMeeting: number | null;
+};
+
+export async function getOverdueReminders(): Promise<OverdueReminder[]> {
+  const now = new Date();
+
+  const members = await prisma.member.findMany({
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      name: true,
+      meetingIntervalDays: true,
+      meetings: {
+        orderBy: { date: "desc" },
+        take: 1,
+        select: { date: true },
+      },
+    },
+  });
+
+  const reminders: OverdueReminder[] = [];
+
+  for (const member of members) {
+    const lastMeeting = member.meetings[0];
+
+    if (!lastMeeting) {
+      reminders.push({
+        memberId: member.id,
+        memberName: member.name,
+        meetingIntervalDays: member.meetingIntervalDays,
+        daysSinceLastMeeting: null,
+      });
+      continue;
+    }
+
+    const diffMs = now.getTime() - new Date(lastMeeting.date).getTime();
+    const daysSince = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (daysSince > member.meetingIntervalDays) {
+      reminders.push({
+        memberId: member.id,
+        memberName: member.name,
+        meetingIntervalDays: member.meetingIntervalDays,
+        daysSinceLastMeeting: daysSince,
+      });
+    }
+  }
+
+  // 経過日数降順（nullは最後）
+  return reminders.sort((a, b) => {
+    if (a.daysSinceLastMeeting === null && b.daysSinceLastMeeting === null) return 0;
+    if (a.daysSinceLastMeeting === null) return 1;
+    if (b.daysSinceLastMeeting === null) return -1;
+    return b.daysSinceLastMeeting - a.daysSinceLastMeeting;
+  });
+}

--- a/src/lib/validations/member.ts
+++ b/src/lib/validations/member.ts
@@ -1,15 +1,35 @@
 import { z } from "zod";
 
+const MEETING_INTERVAL_OPTIONS = [7, 14, 30] as const;
+
 export const createMemberSchema = z.object({
   name: z.string().min(1, "名前は必須です"),
   department: z.string().optional(),
   position: z.string().optional(),
+  meetingIntervalDays: z
+    .number()
+    .refine(
+      (v) => MEETING_INTERVAL_OPTIONS.includes(v as (typeof MEETING_INTERVAL_OPTIONS)[number]),
+      {
+        message: "ミーティング間隔は 7・14・30 日のいずれかを選択してください",
+      },
+    )
+    .optional(),
 });
 
 export const updateMemberSchema = z.object({
   name: z.string().min(1, "名前は必須です").optional(),
   department: z.string().optional(),
   position: z.string().optional(),
+  meetingIntervalDays: z
+    .number()
+    .refine(
+      (v) => MEETING_INTERVAL_OPTIONS.includes(v as (typeof MEETING_INTERVAL_OPTIONS)[number]),
+      {
+        message: "ミーティング間隔は 7・14・30 日のいずれかを選択してください",
+      },
+    )
+    .optional(),
 });
 
 export type CreateMemberInput = z.infer<typeof createMemberSchema>;


### PR DESCRIPTION
## 概要

issue #43「ミーティング実施リマインダー」を実装しました。

## 変更内容

### DBスキーマ
- `Member` モデルに `meetingIntervalDays` フィールドを追加（デフォルト: 14日）
- マイグレーション: `20260222085124_add_meeting_interval_days`

### Server Action
- `getOverdueReminders()` を新規追加（`src/lib/actions/reminder-actions.ts`）
  - 各メンバーの `meetingIntervalDays` と最終ミーティング日を比較して期限超過を判定
  - 経過日数降順でソート（未ミーティングは最後）

### メンバーフォーム
- ミーティング間隔選択UI（1週間/2週間/1ヶ月）を追加
- `createMember` / `updateMember` の Zod バリデーションスキーマを更新

### ダッシュボード
- `ReminderAlertBanner`: 期限超過メンバーがいる場合、ページ上部に目立つアラートバナーを表示
- `BrowserNotification`: Notification API でブラウザ通知を送信（1日1回、localStorage で重複防止）

## テスト

- 新規テスト: 27件追加
- 全テスト: 483件（62ファイル）全て通過
- カバレッジ: 新機能に対して100%

## テストプラン

- [ ] ダッシュボードを開き、14日以上ミーティングしていないメンバーのアラートバナーが表示されることを確認
- [ ] メンバー作成フォームでミーティング間隔（1週間/2週間/1ヶ月）を選択できることを確認
- [ ] 選択した間隔に基づいてアラート判定が正しく動作することを確認
- [ ] ブラウザ通知の許可ダイアログが表示されることを確認（初回のみ）
- [ ] 1日1回のみ通知が送信されることを確認

Closes #43