### PR TITLE
feat: 定期ミーティングスケジュール（issue #39）

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -65,6 +65,7 @@ export default async function MemberDetailPage({ params }: Props) {
         lastMeetingDate={lastMeetingDate}
         totalMeetingCount={totalMeetingCount}
         pendingActionCount={pendingActionItems.length}
+        meetingIntervalDays={member.meetingIntervalDays}
       />
 
       <TopicAnalyticsSection memberId={id} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,17 @@ import {
   getRecentActivity,
   getUpcomingActions,
 } from "@/lib/actions/dashboard-actions";
-import { getRecommendedMeetings } from "@/lib/actions/analytics-actions";
+import {
+  getRecommendedMeetings,
+  getScheduledMeetingsThisWeek,
+} from "@/lib/actions/analytics-actions";
 import { getOverdueReminders } from "@/lib/actions/reminder-actions";
 import { MemberList } from "@/components/member/member-list";
 import { DashboardSummary } from "@/components/dashboard/dashboard-summary";
 import { RecentActivityFeed } from "@/components/dashboard/recent-activity-feed";
 import { UpcomingActionsSection } from "@/components/dashboard/upcoming-actions-section";
 import { RecommendedMeetingsSection } from "@/components/dashboard/recommended-meetings-section";
+import { ScheduledMeetingsSection } from "@/components/dashboard/scheduled-meetings-section";
 import { ReminderAlertBanner } from "@/components/dashboard/reminder-alert-banner";
 import { BrowserNotification } from "@/components/dashboard/browser-notification";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
@@ -18,15 +22,23 @@ import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
-  const [members, summary, recentActivity, upcomingActions, recommendedMeetings, overdueReminders] =
-    await Promise.all([
-      getMembers(),
-      getDashboardSummary(),
-      getRecentActivity(),
-      getUpcomingActions(),
-      getRecommendedMeetings(),
-      getOverdueReminders(),
-    ]);
+  const [
+    members,
+    summary,
+    recentActivity,
+    upcomingActions,
+    recommendedMeetings,
+    scheduledMeetings,
+    overdueReminders,
+  ] = await Promise.all([
+    getMembers(),
+    getDashboardSummary(),
+    getRecentActivity(),
+    getUpcomingActions(),
+    getRecommendedMeetings(),
+    getScheduledMeetingsThisWeek(),
+    getOverdueReminders(),
+  ]);
 
   const isFirstTime = members.length === 0;
 
@@ -57,6 +69,15 @@ export default async function DashboardPage() {
           />
         </div>
       </div>
+
+      {!isFirstTime && (
+        <div className="rounded-xl border bg-card p-5 mb-8">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-4">
+            今週の1on1予定
+          </h2>
+          <ScheduledMeetingsSection meetings={scheduledMeetings} />
+        </div>
+      )}
 
       {recommendedMeetings.length > 0 && (
         <div className="rounded-xl border bg-card p-5 mb-8">

--- a/src/components/analytics/__tests__/meeting-interval-table.test.tsx
+++ b/src/components/analytics/__tests__/meeting-interval-table.test.tsx
@@ -18,6 +18,8 @@ const mockData = [
     position: null,
     daysSinceLast: 30,
     lastMeetingDate: new Date("2026-01-23T00:00:00Z"),
+    meetingIntervalDays: 14,
+    nextRecommendedDate: new Date("2026-02-06T00:00:00Z"),
   },
   {
     id: "m2",
@@ -26,6 +28,8 @@ const mockData = [
     position: null,
     daysSinceLast: 9999,
     lastMeetingDate: null,
+    meetingIntervalDays: 14,
+    nextRecommendedDate: null,
   },
 ];
 

--- a/src/components/dashboard/__tests__/recommended-meetings-section.test.tsx
+++ b/src/components/dashboard/__tests__/recommended-meetings-section.test.tsx
@@ -14,6 +14,8 @@ const mockMembers = [
     position: null,
     daysSinceLast: 20,
     lastMeetingDate: new Date("2026-02-02T00:00:00Z"),
+    meetingIntervalDays: 14,
+    nextRecommendedDate: new Date("2026-02-16T00:00:00Z"),
   },
 ];
 
@@ -25,11 +27,38 @@ describe("RecommendedMeetingsSection", () => {
 
   it("shows days since last meeting", () => {
     render(<RecommendedMeetingsSection members={mockMembers} />);
-    expect(screen.getByText("20日経過")).toBeDefined();
+    expect(screen.getByText(/20日経過/)).toBeDefined();
+  });
+
+  it("shows interval badge", () => {
+    render(<RecommendedMeetingsSection members={mockMembers} />);
+    expect(screen.getByText("隔週")).toBeDefined();
+  });
+
+  it("shows next recommended date info", () => {
+    render(<RecommendedMeetingsSection members={mockMembers} />);
+    expect(screen.getByText(/次回:/)).toBeDefined();
   });
 
   it("shows empty message when no members need meetings", () => {
     render(<RecommendedMeetingsSection members={[]} />);
     expect(screen.getByText("全員と最近1on1を実施済みです")).toBeDefined();
+  });
+
+  it("shows 未実施 when member has never had a meeting", () => {
+    const noMeetingMember = [
+      {
+        id: "m2",
+        name: "佐藤 花子",
+        department: null,
+        position: null,
+        daysSinceLast: 9999,
+        lastMeetingDate: null,
+        meetingIntervalDays: 14,
+        nextRecommendedDate: null,
+      },
+    ];
+    render(<RecommendedMeetingsSection members={noMeetingMember} />);
+    expect(screen.getByText("未実施")).toBeDefined();
   });
 });

--- a/src/components/dashboard/__tests__/scheduled-meetings-section.test.tsx
+++ b/src/components/dashboard/__tests__/scheduled-meetings-section.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { ScheduledMeetingsSection } from "../scheduled-meetings-section";
+import type { ScheduledMeeting } from "@/lib/actions/analytics-actions";
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseDate = new Date("2026-02-22T00:00:00Z");
+const todayMeeting: ScheduledMeeting = {
+  id: "m1",
+  name: "山田 太郎",
+  department: "開発部",
+  position: null,
+  meetingIntervalDays: 14,
+  nextRecommendedDate: baseDate,
+  lastMeetingDate: new Date("2026-02-08T00:00:00Z"),
+};
+
+const futureMeeting: ScheduledMeeting = {
+  id: "m2",
+  name: "佐藤 花子",
+  department: null,
+  position: null,
+  meetingIntervalDays: 7,
+  nextRecommendedDate: new Date("2026-02-25T00:00:00Z"),
+  lastMeetingDate: new Date("2026-02-18T00:00:00Z"),
+};
+
+describe("ScheduledMeetingsSection", () => {
+  it("shows empty state when no meetings scheduled", () => {
+    render(<ScheduledMeetingsSection meetings={[]} />);
+    expect(screen.getByText("今週予定の1on1はありません")).toBeDefined();
+  });
+
+  it("renders member names", () => {
+    render(<ScheduledMeetingsSection meetings={[todayMeeting]} />);
+    expect(screen.getByText("山田 太郎")).toBeDefined();
+  });
+
+  it("shows interval badge", () => {
+    render(<ScheduledMeetingsSection meetings={[todayMeeting]} />);
+    expect(screen.getByText("隔週")).toBeDefined();
+  });
+
+  it("shows 1on1準備 button with correct link", () => {
+    render(<ScheduledMeetingsSection meetings={[todayMeeting]} />);
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("/members/m1/meetings/prepare");
+  });
+
+  it("renders multiple members", () => {
+    render(<ScheduledMeetingsSection meetings={[todayMeeting, futureMeeting]} />);
+    expect(screen.getByText("山田 太郎")).toBeDefined();
+    expect(screen.getByText("佐藤 花子")).toBeDefined();
+  });
+
+  it("shows 毎週 badge for weekly interval", () => {
+    render(<ScheduledMeetingsSection meetings={[futureMeeting]} />);
+    expect(screen.getByText("毎週")).toBeDefined();
+  });
+});

--- a/src/components/dashboard/recommended-meetings-section.tsx
+++ b/src/components/dashboard/recommended-meetings-section.tsx
@@ -3,6 +3,8 @@ import { Heart } from "lucide-react";
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { getMeetingIntervalLabel } from "@/lib/constants";
+import { formatNextRecommendedDate } from "@/lib/schedule";
 import type { RecommendedMeeting } from "@/lib/actions/analytics-actions";
 
 export function RecommendedMeetingsSection({ members }: { members: RecommendedMeeting[] }) {
@@ -26,9 +28,16 @@ export function RecommendedMeetingsSection({ members }: { members: RecommendedMe
         >
           <AvatarInitial name={member.name} size="sm" />
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{member.name}</p>
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium truncate">{member.name}</p>
+              <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
+                {getMeetingIntervalLabel(member.meetingIntervalDays)}
+              </span>
+            </div>
             <p className="text-xs text-muted-foreground">
-              {member.daysSinceLast >= 9999 ? "未実施" : `${member.daysSinceLast}日経過`}
+              {member.daysSinceLast >= 9999
+                ? "未実施"
+                : `${member.daysSinceLast}日経過 · 次回: ${formatNextRecommendedDate(member.nextRecommendedDate)}`}
             </p>
           </div>
           <Link href={`/members/${member.id}/meetings/prepare`}>

--- a/src/components/dashboard/scheduled-meetings-section.tsx
+++ b/src/components/dashboard/scheduled-meetings-section.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { CalendarDays } from "lucide-react";
+import { AvatarInitial } from "@/components/ui/avatar-initial";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { getMeetingIntervalLabel } from "@/lib/constants";
+import type { ScheduledMeeting } from "@/lib/actions/analytics-actions";
+
+type Props = {
+  meetings: ScheduledMeeting[];
+};
+
+function formatScheduledDate(date: Date): string {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const diffDays = Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+  const dayLabels = ["日", "月", "火", "水", "木", "金", "土"];
+  const dayOfWeek = dayLabels[date.getDay()];
+  const dateStr = `${date.getMonth() + 1}/${date.getDate()}（${dayOfWeek}）`;
+
+  if (diffDays === 0) return `今日 · ${dateStr}`;
+  if (diffDays === 1) return `明日 · ${dateStr}`;
+  return dateStr;
+}
+
+export function ScheduledMeetingsSection({ meetings }: Props) {
+  if (meetings.length === 0) {
+    return (
+      <EmptyState
+        icon={CalendarDays}
+        title="今週予定の1on1はありません"
+        description="メンバーのミーティング間隔を設定すると、今週の予定が表示されます"
+        size="compact"
+      />
+    );
+  }
+
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  return (
+    <div className="space-y-2">
+      {meetings.map((meeting) => {
+        const target = new Date(
+          meeting.nextRecommendedDate.getFullYear(),
+          meeting.nextRecommendedDate.getMonth(),
+          meeting.nextRecommendedDate.getDate(),
+        );
+        const isToday = target.getTime() === today.getTime();
+        const isPast = target < today;
+
+        return (
+          <div
+            key={meeting.id}
+            className="flex items-center gap-3 py-2 px-1 rounded-lg hover:bg-muted/50 transition-colors"
+          >
+            <AvatarInitial name={meeting.name} size="sm" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium truncate">{meeting.name}</p>
+                <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
+                  {getMeetingIntervalLabel(meeting.meetingIntervalDays)}
+                </span>
+                {isToday && (
+                  <span className="text-xs text-primary bg-primary/10 px-1.5 py-0.5 rounded font-medium shrink-0">
+                    今日
+                  </span>
+                )}
+                {isPast && !isToday && (
+                  <span className="text-xs text-destructive bg-destructive/10 px-1.5 py-0.5 rounded font-medium shrink-0">
+                    要対応
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {formatScheduledDate(meeting.nextRecommendedDate)}
+              </p>
+            </div>
+            <Link href={`/members/${meeting.id}/meetings/prepare`}>
+              <Button size="sm" variant="outline" className="text-xs h-7">
+                1on1準備
+              </Button>
+            </Link>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/member/__tests__/member-stats-bar.test.tsx
+++ b/src/components/member/__tests__/member-stats-bar.test.tsx
@@ -8,20 +8,41 @@ afterEach(() => {
 
 describe("MemberStatsBar", () => {
   it("最終1on1が未実施の場合を表示する", () => {
-    render(<MemberStatsBar lastMeetingDate={null} totalMeetingCount={0} pendingActionCount={0} />);
+    render(
+      <MemberStatsBar
+        lastMeetingDate={null}
+        totalMeetingCount={0}
+        pendingActionCount={0}
+        meetingIntervalDays={14}
+      />,
+    );
     expect(screen.getByText("最終1on1")).toBeDefined();
-    expect(screen.getByText("未実施")).toBeDefined();
+    expect(screen.getAllByText("未実施").length).toBeGreaterThan(0);
   });
 
   it("通算1on1回数を表示する", () => {
-    render(<MemberStatsBar lastMeetingDate={null} totalMeetingCount={12} pendingActionCount={0} />);
+    render(
+      <MemberStatsBar
+        lastMeetingDate={null}
+        totalMeetingCount={12}
+        pendingActionCount={0}
+        meetingIntervalDays={14}
+      />,
+    );
     expect(screen.getByText("通算1on1")).toBeDefined();
     expect(screen.getByText("12")).toBeDefined();
     expect(screen.getByText("回")).toBeDefined();
   });
 
   it("未完了アクション数を表示する", () => {
-    render(<MemberStatsBar lastMeetingDate={null} totalMeetingCount={0} pendingActionCount={5} />);
+    render(
+      <MemberStatsBar
+        lastMeetingDate={null}
+        totalMeetingCount={0}
+        pendingActionCount={5}
+        meetingIntervalDays={14}
+      />,
+    );
     expect(screen.getByText("未完了アクション")).toBeDefined();
     expect(screen.getByText("5")).toBeDefined();
     expect(screen.getByText("件")).toBeDefined();
@@ -29,21 +50,70 @@ describe("MemberStatsBar", () => {
 
   it("今日の日付は '今日' を表示する", () => {
     const today = new Date();
-    render(<MemberStatsBar lastMeetingDate={today} totalMeetingCount={1} pendingActionCount={0} />);
+    render(
+      <MemberStatsBar
+        lastMeetingDate={today}
+        totalMeetingCount={1}
+        pendingActionCount={0}
+        meetingIntervalDays={14}
+      />,
+    );
     expect(screen.getByText("今日")).toBeDefined();
   });
 
   it("7日前の日付は '7日経過' を表示する", () => {
     const date = new Date();
     date.setDate(date.getDate() - 7);
-    render(<MemberStatsBar lastMeetingDate={date} totalMeetingCount={5} pendingActionCount={2} />);
+    render(
+      <MemberStatsBar
+        lastMeetingDate={date}
+        totalMeetingCount={5}
+        pendingActionCount={2}
+        meetingIntervalDays={14}
+      />,
+    );
     expect(screen.getByText("7日経過")).toBeDefined();
   });
 
   it("14日前の日付は '2週間経過' を表示する", () => {
     const date = new Date();
     date.setDate(date.getDate() - 14);
-    render(<MemberStatsBar lastMeetingDate={date} totalMeetingCount={10} pendingActionCount={0} />);
+    render(
+      <MemberStatsBar
+        lastMeetingDate={date}
+        totalMeetingCount={10}
+        pendingActionCount={0}
+        meetingIntervalDays={14}
+      />,
+    );
     expect(screen.getByText("2週間経過")).toBeDefined();
+  });
+
+  it("次回推奨日カードを表示する", () => {
+    const date = new Date();
+    date.setDate(date.getDate() - 7);
+    render(
+      <MemberStatsBar
+        lastMeetingDate={date}
+        totalMeetingCount={5}
+        pendingActionCount={0}
+        meetingIntervalDays={14}
+      />,
+    );
+    expect(screen.getByText("次回推奨日")).toBeDefined();
+    // 7日前のミーティング、interval=14 → next=7日後 → 「あと7日」
+    expect(screen.getByText("あと7日")).toBeDefined();
+  });
+
+  it("lastMeetingDate が null の場合、次回推奨日は未設定を表示する", () => {
+    render(
+      <MemberStatsBar
+        lastMeetingDate={null}
+        totalMeetingCount={0}
+        pendingActionCount={0}
+        meetingIntervalDays={14}
+      />,
+    );
+    expect(screen.getByText("未設定")).toBeDefined();
   });
 });

--- a/src/lib/__tests__/schedule.test.ts
+++ b/src/lib/__tests__/schedule.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  calcNextRecommendedDate,
+  isOverdue,
+  isScheduledThisWeek,
+  formatNextRecommendedDate,
+} from "@/lib/schedule";
+
+describe("calcNextRecommendedDate", () => {
+  it("lastMeetingDate が null の場合は null を返す", () => {
+    expect(calcNextRecommendedDate(null, 14)).toBeNull();
+  });
+
+  it("lastMeetingDate + intervalDays の日付を返す", () => {
+    const last = new Date("2026-02-01");
+    const result = calcNextRecommendedDate(last, 14);
+    expect(result).not.toBeNull();
+    expect(result!.toISOString().slice(0, 10)).toBe("2026-02-15");
+  });
+
+  it("intervalDays=7 の場合は1週間後を返す", () => {
+    const last = new Date("2026-02-08");
+    const result = calcNextRecommendedDate(last, 7);
+    expect(result!.toISOString().slice(0, 10)).toBe("2026-02-15");
+  });
+
+  it("intervalDays=30 の場合は30日後を返す", () => {
+    const last = new Date("2026-01-01");
+    const result = calcNextRecommendedDate(last, 30);
+    expect(result!.toISOString().slice(0, 10)).toBe("2026-01-31");
+  });
+});
+
+describe("isOverdue", () => {
+  it("lastMeetingDate が null の場合は true を返す（未実施）", () => {
+    expect(isOverdue(null, 14)).toBe(true);
+  });
+
+  it("次回推奨日が now より前の場合は true を返す（超過）", () => {
+    const last = new Date("2026-01-01");
+    const now = new Date("2026-02-01"); // 31日経過、interval=14
+    expect(isOverdue(last, 14, now)).toBe(true);
+  });
+
+  it("次回推奨日が now より後の場合は false を返す（期限内）", () => {
+    const last = new Date("2026-02-20");
+    const now = new Date("2026-02-22"); // 2日経過、interval=14
+    expect(isOverdue(last, 14, now)).toBe(false);
+  });
+
+  it("次回推奨日が now と同日の場合は true を返す（当日 = 超過）", () => {
+    const last = new Date("2026-02-08");
+    const now = new Date("2026-02-22"); // 14日経過、interval=14
+    // next = 2026-02-22, now = 2026-02-22 → overdue
+    expect(isOverdue(last, 14, now)).toBe(true);
+  });
+
+  it("intervalDays=7 で8日経過の場合は true を返す", () => {
+    const last = new Date("2026-02-14");
+    const now = new Date("2026-02-22"); // 8日経過、interval=7
+    expect(isOverdue(last, 7, now)).toBe(true);
+  });
+
+  it("intervalDays=30 で20日経過の場合は false を返す", () => {
+    const last = new Date("2026-02-02");
+    const now = new Date("2026-02-22"); // 20日経過、interval=30
+    expect(isOverdue(last, 30, now)).toBe(false);
+  });
+});
+
+describe("isScheduledThisWeek", () => {
+  // now = 2026-02-22（日曜）として、今日から7日間（2/22〜2/28）を「今週」と定義
+  const now = new Date("2026-02-22");
+
+  it("lastMeetingDate が null の場合は false を返す", () => {
+    expect(isScheduledThisWeek(null, 14, now)).toBe(false);
+  });
+
+  it("次回推奨日が今週内（今日）の場合は true を返す", () => {
+    const last = new Date("2026-02-08"); // next = 2026-02-22 = 今日
+    expect(isScheduledThisWeek(last, 14, now)).toBe(true);
+  });
+
+  it("次回推奨日が今週内（未来）の場合は true を返す", () => {
+    const last = new Date("2026-02-14"); // next = 2026-02-28 = 今週末
+    expect(isScheduledThisWeek(last, 14, now)).toBe(true);
+  });
+
+  it("次回推奨日が来週以降の場合は false を返す", () => {
+    const last = new Date("2026-02-16"); // next = 2026-03-02 = 来週
+    expect(isScheduledThisWeek(last, 14, now)).toBe(false);
+  });
+
+  it("次回推奨日が過去（超過）の場合は false を返す", () => {
+    const last = new Date("2026-01-01"); // next = 2026-01-15 = 過去
+    expect(isScheduledThisWeek(last, 14, now)).toBe(false);
+  });
+});
+
+describe("formatNextRecommendedDate", () => {
+  const now = new Date("2026-02-22");
+
+  it("null の場合は「未設定」を返す", () => {
+    expect(formatNextRecommendedDate(null, now)).toBe("未設定");
+  });
+
+  it("今日の場合は「今日」を返す", () => {
+    const today = new Date("2026-02-22");
+    expect(formatNextRecommendedDate(today, now)).toBe("今日");
+  });
+
+  it("過去の場合は「X日超過」を返す", () => {
+    const past = new Date("2026-02-15"); // 7日前
+    expect(formatNextRecommendedDate(past, now)).toBe("7日超過");
+  });
+
+  it("未来の場合は「あとX日」を返す", () => {
+    const future = new Date("2026-02-25"); // 3日後
+    expect(formatNextRecommendedDate(future, now)).toBe("あと3日");
+  });
+
+  it("明日の場合は「あと1日」を返す", () => {
+    const tomorrow = new Date("2026-02-23");
+    expect(formatNextRecommendedDate(tomorrow, now)).toBe("あと1日");
+  });
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,3 +5,13 @@ export const CATEGORY_LABELS: Record<string, string> = {
   FEEDBACK: "フィードバック",
   OTHER: "その他",
 };
+
+export const MEETING_INTERVAL_LABELS: Record<number, string> = {
+  7: "毎週",
+  14: "隔週",
+  30: "月1回",
+};
+
+export function getMeetingIntervalLabel(days: number): string {
+  return MEETING_INTERVAL_LABELS[days] ?? `${days}日間隔`;
+}

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -1,0 +1,78 @@
+/**
+ * 定期ミーティングスケジュール計算ユーティリティ
+ */
+
+/**
+ * 次回推奨ミーティング日を計算する
+ * @param lastMeetingDate 最終ミーティング日（null の場合は null を返す）
+ * @param intervalDays ミーティング間隔（日数）
+ */
+export function calcNextRecommendedDate(
+  lastMeetingDate: Date | null,
+  intervalDays: number,
+): Date | null {
+  if (!lastMeetingDate) return null;
+  const next = new Date(lastMeetingDate);
+  next.setDate(next.getDate() + intervalDays);
+  return next;
+}
+
+/**
+ * ミーティングが期限超過かどうかを判定する
+ * @param lastMeetingDate 最終ミーティング日（null の場合は未実施 → true）
+ * @param intervalDays ミーティング間隔（日数）
+ * @param now 現在日時（省略時は new Date()）
+ */
+export function isOverdue(
+  lastMeetingDate: Date | null,
+  intervalDays: number,
+  now: Date = new Date(),
+): boolean {
+  if (!lastMeetingDate) return true;
+  const next = calcNextRecommendedDate(lastMeetingDate, intervalDays);
+  if (!next) return true;
+  return now >= next;
+}
+
+/**
+ * 今日から7日以内に次回推奨日が含まれるかどうかを判定する（「今週予定」判定）
+ * @param lastMeetingDate 最終ミーティング日（null の場合は false）
+ * @param intervalDays ミーティング間隔（日数）
+ * @param now 現在日時（省略時は new Date()）
+ */
+export function isScheduledThisWeek(
+  lastMeetingDate: Date | null,
+  intervalDays: number,
+  now: Date = new Date(),
+): boolean {
+  if (!lastMeetingDate) return false;
+  const next = calcNextRecommendedDate(lastMeetingDate, intervalDays);
+  if (!next) return false;
+
+  const weekEnd = new Date(now);
+  weekEnd.setDate(weekEnd.getDate() + 7);
+
+  return next >= now && next < weekEnd;
+}
+
+/**
+ * 次回推奨日を人間が読みやすい文字列にフォーマットする
+ * @param nextDate 次回推奨日（null の場合は「未設定」）
+ * @param now 現在日時（省略時は new Date()）
+ */
+export function formatNextRecommendedDate(nextDate: Date | null, now: Date = new Date()): string {
+  if (!nextDate) return "未設定";
+
+  const nowDate = new Date(now);
+  nowDate.setHours(0, 0, 0, 0);
+
+  const targetDate = new Date(nextDate);
+  targetDate.setHours(0, 0, 0, 0);
+
+  const diffMs = targetDate.getTime() - nowDate.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "今日";
+  if (diffDays < 0) return `${Math.abs(diffDays)}日超過`;
+  return `あと${diffDays}日`;
+}


### PR DESCRIPTION
## Summary

- `getRecommendedMeetings` / `getDashboardSummary` がハードコード 14 日を使用していた問題を修正し、各メンバー固有の `meetingIntervalDays` を使った超過判定に変更
- 次回推奨ミーティング日の自動計算ユーティリティ（`src/lib/schedule.ts`）を新規追加
- ダッシュボードに「今週の1on1予定」セクションを新設（今日から7日以内に推奨日があるメンバーを表示）
- 推奨メンバーセクションに次回推奨日とミーティング頻度バッジ（毎週/隔週/月1回）を追加
- メンバー詳細ページの統計バーに「次回推奨日」カードを追加（3列→4列レイアウト）

Closes #39

## Changes

### 新規ファイル
- `src/lib/schedule.ts` — `calcNextRecommendedDate`, `isOverdue`, `isScheduledThisWeek`, `formatNextRecommendedDate` の純粋関数
- `src/components/dashboard/scheduled-meetings-section.tsx` — 「今週の1on1予定」セクション

### 修正ファイル
- `src/lib/actions/analytics-actions.ts` — `RecommendedMeeting` 型拡張・`getRecommendedMeetings` 修正・`getScheduledMeetingsThisWeek` 新規追加
- `src/lib/actions/dashboard-actions.ts` — `getDashboardSummary.needsFollowUp` を `meetingIntervalDays` ベースに修正
- `src/lib/constants.ts` — `MEETING_INTERVAL_LABELS`, `getMeetingIntervalLabel` を追加
- `src/components/dashboard/recommended-meetings-section.tsx` — 次回推奨日・インターバルバッジ表示を追加
- `src/components/member/member-stats-bar.tsx` — 「次回推奨日」カードを追加
- `src/app/page.tsx` — 「今週の1on1予定」セクションをダッシュボードに統合
- `src/app/members/[id]/page.tsx` — `meetingIntervalDays` を `MemberStatsBar` に渡すよう修正

## Test plan

- [ ] テスト 519件すべてパス（`npm test`）
- [ ] TypeScript 型チェックパス（`npx tsc --noEmit`）
- [ ] プロダクションビルド成功（`npm run build`）
- [ ] meetingIntervalDays=7 のメンバーが7日超で推奨リストに表示されること
- [ ] meetingIntervalDays=30 のメンバーが20日経過で推奨リストに表示されないこと
- [ ] ダッシュボードに「今週の1on1予定」セクションが表示されること
- [ ] メンバー詳細ページの統計バーに「次回推奨日」が表示されること