### PR TITLE
fix: UI/UX アクセシビリティ・タッチターゲット改善

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -215,4 +215,10 @@
   .animate-pulse-attention {
     animation: none;
   }
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,9 +46,15 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="ja" suppressHydrationWarning>
       <body className={`${GeistSans.variable} ${notoSansJP.variable} flex h-screen`}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-lg focus:font-medium focus:shadow-lg"
+        >
+          メインコンテンツへスキップ
+        </a>
         <Providers>
           <Sidebar members={members} actionCount={actionCount} />
-          <main className="flex-1 overflow-auto p-6 pt-18 lg:p-10 lg:pt-10">
+          <main id="main-content" className="flex-1 overflow-auto p-6 pt-18 lg:p-10 lg:pt-10">
             <div className="max-w-5xl mx-auto">{children}</div>
           </main>
           <Toaster />

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import { BarChart2, LayoutDashboard, ListChecks, Menu, UserPlus, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { Separator } from "@/components/ui/separator";
@@ -99,9 +99,50 @@ function MemberQuickList({
   );
 }
 
+const FOCUSABLE_SELECTORS =
+  'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 export function Sidebar({ members = [], actionCount }: SidebarProps) {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
+  const sidebarRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const sidebar = sidebarRef.current;
+    if (!sidebar) return;
+
+    const focusable = sidebar.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    if (focusable.length > 0) focusable[0].focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const elements = Array.from(sidebar!.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
+      const firstEl = elements[0];
+      const lastEl = elements[elements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        }
+      } else {
+        if (document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
 
   return (
     <>
@@ -124,6 +165,10 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
           onClick={() => setIsOpen(false)}
         >
           <aside
+            ref={sidebarRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="ナビゲーションメニュー"
             className="w-56 h-full bg-[var(--sidebar)] p-4 flex flex-col gap-6 shadow-lg transition-transform duration-150"
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -33,7 +33,7 @@ export function ThemeToggle() {
           aria-label={label}
           aria-pressed={theme === value}
           title={label}
-          className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors duration-150 ${
+          className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors duration-150 ${
             theme === value
               ? "bg-background text-primary shadow-sm"
               : "text-muted-foreground hover:text-foreground"

--- a/src/components/meeting/sortable-action-item.tsx
+++ b/src/components/meeting/sortable-action-item.tsx
@@ -66,7 +66,7 @@ export function SortableActionItem({
         <button
           type="button"
           data-testid={`drag-handle-${id}`}
-          className="cursor-grab touch-none text-muted-foreground hover:text-foreground self-center"
+          className="cursor-grab touch-none text-muted-foreground hover:text-foreground self-center p-1"
           {...attributes}
           {...listeners}
           aria-label={`${title || "アクションアイテム"}を並び替え`}

--- a/src/components/meeting/sortable-topic-item.tsx
+++ b/src/components/meeting/sortable-topic-item.tsx
@@ -80,7 +80,7 @@ export function SortableTopicItem({
         <button
           type="button"
           data-testid={`drag-handle-${id}`}
-          className="cursor-grab touch-none text-muted-foreground hover:text-foreground self-center"
+          className="cursor-grab touch-none text-muted-foreground hover:text-foreground self-center p-1"
           {...attributes}
           {...listeners}
           aria-label={`${title || "話題"}を並び替え`}

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -103,7 +103,7 @@ export function MemberList({ members }: Props) {
             <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
               <button
                 onClick={() => toggleSort("lastMeeting")}
-                className="flex items-center gap-1 hover:text-foreground transition-colors duration-150"
+                className="flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors duration-150"
               >
                 最終1on1
                 <ArrowUpDown className="w-3 h-3" />
@@ -112,7 +112,7 @@ export function MemberList({ members }: Props) {
             <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
               <button
                 onClick={() => toggleSort("actions")}
-                className="flex items-center gap-1 hover:text-foreground transition-colors duration-150"
+                className="flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors duration-150"
               >
                 未完了
                 <ArrowUpDown className="w-3 h-3" />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-xs": "size-8 rounded-md [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",
         "icon-lg": "size-10",
       },

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -65,7 +65,7 @@ function DialogContent({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">閉じる</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
@@ -100,7 +100,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="outline">閉じる</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -71,7 +71,7 @@ function SheetContent({
         {showCloseButton && (
           <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
             <XIcon className="size-4" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">閉じる</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Content>


### PR DESCRIPTION
## 概要

UI/UX レビューで指摘された全8件の改善を実施。

## 変更内容

### CRITICAL（タッチターゲット）
- **`button.tsx`**: `icon-xs` サイズを 24px → 32px に拡大（推奨最小 44px 方向へ改善）
- **`sortable-topic-item.tsx` / `sortable-action-item.tsx`**: DnD ドラッグハンドルに `p-1` を追加してタッチエリアを拡大

### HIGH
- **`dialog.tsx` / `sheet.tsx`**: 閉じるボタンラベルを英語 "Close" → 日本語 "閉じる" に修正（スクリーンリーダー対応）
- **`theme-toggle.tsx`**: ボタンサイズを 28px → 32px に拡大
- **`member-list.tsx`**: ソートボタンに `cursor-pointer` を追加

### MEDIUM（アクセシビリティ）
- **`layout.tsx`**: スキップナビゲーションリンクを追加（`<a href="#main-content">`）、`<main>` に `id="main-content"` を付与
- **`sidebar.tsx`**: モバイルメニューにフォーカストラップ（Tab キーループ）・Escape キーサポート・`aria-modal="true"` を追加
- **`globals.css`**: `prefers-reduced-motion` で `transition-duration` も `0.01ms` に短縮（カスタムアニメーションだけでなくすべての遷移を対象に）

## テスト計画

- [ ] テスト 836件 全パス確認済み（`npm test`）
- [ ] Prettier フォーマットチェック通過済み（`npm run format:check`）
- [ ] TypeScript 型チェック通過済み
- [ ] モバイルでドラッグハンドル・編集ボタンのタップ操作確認
- [ ] キーボードのみでモバイルメニューを操作し、Tab がサイドバー内でループすることを確認
- [ ] Escape キーでモバイルメニューが閉じることを確認
- [ ] スクリーンリーダーで閉じるボタンが「閉じる」と読み上げられることを確認
- [ ] キーボード Tab でスキップリンクにフォーカスが当たり、メインコンテンツにジャンプできることを確認
- [ ] `prefers-reduced-motion: reduce` 環境でアニメーション・トランジションが停止することを確認