### PR TITLE
fix: UI/UX レビュー指摘事項の改善

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -215,6 +215,13 @@
   .animate-pulse-attention {
     animation: none;
   }
+  .stagger-1,
+  .stagger-2,
+  .stagger-3,
+  .stagger-4,
+  .stagger-5 {
+    animation-delay: 0ms;
+  }
   *,
   *::before,
   *::after {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ export default async function DashboardPage() {
   const isFirstTime = members.length === 0;
 
   return (
-    <div className="animate-fade-in-up">
+    <div>
       <h1 className="text-2xl font-semibold tracking-tight mb-6 text-foreground">ダッシュボード</h1>
 
       {!isFirstTime && <ReminderAlertBanner reminders={overdueReminders} />}
@@ -53,16 +53,12 @@ export default async function DashboardPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
         <div className="lg:col-span-2 rounded-xl border bg-card p-5">
-          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-4">
-            最近のアクティビティ
-          </h2>
+          <h2 className="text-base font-semibold text-foreground mb-4">最近のアクティビティ</h2>
           <RecentActivityFeed activities={recentActivity} />
         </div>
 
         <div className="rounded-xl border bg-card p-5">
-          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-4">
-            今週のタスク
-          </h2>
+          <h2 className="text-base font-semibold text-foreground mb-4">今週のタスク</h2>
           <UpcomingActionsSection
             today={upcomingActions.today}
             thisWeek={upcomingActions.thisWeek}
@@ -72,18 +68,14 @@ export default async function DashboardPage() {
 
       {!isFirstTime && (
         <div className="rounded-xl border bg-card p-5 mb-8">
-          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-4">
-            今週の1on1予定
-          </h2>
+          <h2 className="text-base font-semibold text-foreground mb-4">今週の1on1予定</h2>
           <ScheduledMeetingsSection meetings={scheduledMeetings} />
         </div>
       )}
 
       {recommendedMeetings.length > 0 && (
         <div className="rounded-xl border bg-card p-5 mb-8">
-          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-4">
-            推奨: 1on1すべきメンバー
-          </h2>
+          <h2 className="text-base font-semibold text-foreground mb-4">1on1すべきメンバー</h2>
           <RecommendedMeetingsSection members={recommendedMeetings} />
         </div>
       )}

--- a/src/components/dashboard/dashboard-summary.tsx
+++ b/src/components/dashboard/dashboard-summary.tsx
@@ -1,4 +1,4 @@
-import { Calendar, CircleAlert, CircleCheck, TrendingUp } from "lucide-react";
+import { Calendar, CircleAlert, Clock, TrendingUp } from "lucide-react";
 
 import type { DashboardSummary as DashboardSummaryType } from "@/lib/actions/dashboard-actions";
 
@@ -116,7 +116,7 @@ export function DashboardSummary({ summary }: Props) {
         value={summary.overdueActions}
         unit="件"
         variant={getOverdueVariant(summary.overdueActions)}
-        icon={<CircleCheck className="w-5 h-5" />}
+        icon={<Clock className="w-5 h-5" />}
         staggerClass="stagger-4"
       />
     </div>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -88,7 +88,7 @@ function MemberQuickList({
             key={member.id}
             href={`/members/${member.id}`}
             onClick={onNavigate}
-            className="flex items-center gap-2.5 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors duration-150"
+            className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors duration-150"
           >
             <AvatarInitial name={member.name} size="sm" />
             <span className="truncate">{member.name}</span>
@@ -147,10 +147,10 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
   return (
     <>
       {/* モバイルトップバー */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 z-40 h-14 bg-[var(--sidebar)] border-b flex items-center px-4">
+      <div className="lg:hidden fixed top-0 left-0 right-0 z-40 h-14 bg-sidebar border-b flex items-center px-4">
         <button
           onClick={() => setIsOpen(true)}
-          className="p-2 rounded-lg hover:bg-accent transition-colors duration-150"
+          className="p-3 rounded-lg hover:bg-accent transition-colors duration-150"
           aria-label="メニューを開く"
         >
           <Menu className="w-5 h-5" />
@@ -169,7 +169,7 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
             role="dialog"
             aria-modal="true"
             aria-label="ナビゲーションメニュー"
-            className="w-56 h-full bg-[var(--sidebar)] p-4 flex flex-col gap-6 shadow-lg transition-transform duration-150"
+            className="w-56 h-full bg-sidebar p-4 flex flex-col gap-6 shadow-lg transition-transform duration-150"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
@@ -178,7 +178,7 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
               </Link>
               <button
                 onClick={() => setIsOpen(false)}
-                className="p-1.5 rounded-lg hover:bg-accent transition-colors duration-150"
+                className="p-3 rounded-lg hover:bg-accent transition-colors duration-150"
                 aria-label="メニューを閉じる"
               >
                 <X className="w-4 h-4" />
@@ -199,7 +199,7 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
       )}
 
       {/* デスクトップサイドバー */}
-      <aside className="hidden lg:flex w-56 border-r bg-[var(--sidebar)] p-4 flex-col gap-6 shrink-0">
+      <aside className="hidden lg:flex w-56 border-r bg-sidebar p-4 flex-col gap-6 shrink-0">
         <Link href="/" className="text-lg font-semibold tracking-tight text-foreground">
           Nudge
         </Link>


### PR DESCRIPTION
## Summary

- **[CRITICAL]** モバイルタッチターゲット修正（44px 未満 → 44px 以上）
  - ハンバーガーメニューボタン: `p-2` → `p-3`
  - モバイルサイドバー閉じるボタン: `p-1.5` → `p-3`
  - メンバークイックリンク: `py-1.5` → `py-2.5`
- **[HIGH]** ダッシュボード二重アニメーション解消（親 div の `animate-fade-in-up` を削除、KPI カードのスタガーアニメーションのみに統一）
- **[HIGH]** 「期限超過」KPI カードのアイコンを `CircleCheck`（完了を示す）→ `Clock` に修正
- **[HIGH]** `bg-[var(--sidebar)]` → `bg-sidebar` Tailwind トークンに統一（3箇所）
- **[MEDIUM]** セクション見出しのスタイル改善: `text-sm text-muted-foreground uppercase tracking-wider` → `text-base font-semibold text-foreground`（視覚的階層を強化）
- **[MEDIUM]** 「推奨: 1on1すべきメンバー」の冗長なコロンプレフィックスを削除
- **[LOW]** `prefers-reduced-motion` 時に `.stagger-1`〜`.stagger-5` の `animation-delay` を `0ms` にリセット（reduced motion 時に要素が遅れて表示される問題を修正）

## Test plan

- [ ] モバイル（375px）でハンバーガーメニューを開閉できることを確認
- [ ] モバイルでメンバーリンクをタップしやすいことを確認（44px 以上のタッチターゲット）
- [ ] ダッシュボードで KPI カードが滑らかにスタガーアニメーションすることを確認
- [ ] KPI「期限超過」に Clock アイコンが表示されることを確認
- [ ] ダークモード・ライトモードでサイドバーの背景色が正しく表示されることを確認
- [ ] セクション見出し（最近のアクティビティ、今週のタスクなど）が明確に視認できることを確認
- [ ] OS の「視覚効果を減らす」設定でアニメーションが即時停止することを確認
- [ ] ビルドが通ること（`npm run build`）