### PR TITLE
fix: createMeeting 失敗時にユーザー向けエラーメッセージを表示する

### DIFF
--- a/src/components/meeting/meeting-form.tsx
+++ b/src/components/meeting/meeting-form.tsx
@@ -10,8 +10,9 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import { arrayMove, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { AlertCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -151,6 +152,7 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showClosingDialog, setShowClosingDialog] = useState(false);
+  const errorRef = useRef<HTMLDivElement>(null);
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
   const topicAnnouncements = useMemo(() => createAnnouncements("話題"), []);
@@ -267,6 +269,10 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
         if (!result.success) {
           setError(result.error);
           toast.error(TOAST_MESSAGES.meeting.updateError);
+          setTimeout(
+            () => errorRef.current?.scrollIntoView?.({ behavior: "smooth", block: "center" }),
+            0,
+          );
           return;
         }
         toast.success(TOAST_MESSAGES.meeting.updateSuccess);
@@ -298,6 +304,10 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
         if (!result.success) {
           setError(result.error);
           toast.error(TOAST_MESSAGES.meeting.createError);
+          setTimeout(
+            () => errorRef.current?.scrollIntoView?.({ behavior: "smooth", block: "center" }),
+            0,
+          );
           return;
         }
         toast.success(TOAST_MESSAGES.meeting.createSuccess);
@@ -307,6 +317,10 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
       const message = err instanceof Error ? err.message : "予期しないエラーが発生しました";
       setError(message);
       toast.error(message);
+      setTimeout(
+        () => errorRef.current?.scrollIntoView?.({ behavior: "smooth", block: "center" }),
+        0,
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -443,7 +457,16 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
           </CardContent>
         </Card>
 
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && (
+          <div
+            ref={errorRef}
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
         <Button type="submit" disabled={isSubmitting} className="self-start">
           {isSubmitting
             ? isEditing

--- a/src/lib/actions/__tests__/types.test.ts
+++ b/src/lib/actions/__tests__/types.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 import { runAction } from "../types";
 
@@ -20,5 +21,39 @@ describe("runAction", () => {
       throw "string error";
     });
     expect(result).toEqual({ success: false, error: "予期しないエラーが発生しました" });
+  });
+
+  it("ZodError がスローされた場合にユーザー向けバリデーションメッセージを返す", async () => {
+    const schema = z.object({
+      title: z.string().min(1, "タイトルは必須です"),
+      age: z.number().min(0, "年齢は0以上で入力してください"),
+    });
+    const result = await runAction(async () => {
+      schema.parse({ title: "", age: -1 });
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("タイトルは必須です、年齢は0以上で入力してください");
+    }
+  });
+
+  it("ZodError が単一の場合にそのメッセージのみを返す", async () => {
+    const schema = z.object({ name: z.string().min(1, "名前は必須です") });
+    const result = await runAction(async () => {
+      schema.parse({ name: "" });
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("名前は必須です");
+    }
+  });
+
+  it("エラー発生時に console.error でサーバーサイドログを出力する", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await runAction(async () => {
+      throw new Error("ログテスト");
+    });
+    expect(consoleSpy).toHaveBeenCalledWith("[Server Action Error]", expect.any(Error));
+    consoleSpy.mockRestore();
   });
 });

--- a/src/lib/actions/types.ts
+++ b/src/lib/actions/types.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { ZodError } from "zod";
+
 /**
  * Server Action の統一エラーハンドリング型。
  * すべての書き込み系 Server Action はこの型を返却する。
@@ -15,7 +17,15 @@ export async function runAction<T>(fn: () => Promise<T>): Promise<ActionResult<T
     const data = await fn();
     return { success: true, data };
   } catch (err) {
-    const message = err instanceof Error ? err.message : "予期しないエラーが発生しました";
+    console.error("[Server Action Error]", err);
+    let message: string;
+    if (err instanceof ZodError) {
+      message = err.issues.map((issue) => issue.message).join("、");
+    } else if (err instanceof Error) {
+      message = err.message;
+    } else {
+      message = "予期しないエラーが発生しました";
+    }
     return { success: false, error: message };
   }
 }


### PR DESCRIPTION
## Summary

Fixes #67

- `runAction` の catch ブロックで `ZodError` を特別処理し、`issues[].message` を結合したユーザー向けメッセージを返すよう変更
- `runAction` にサーバーサイドの `console.error` ログを追加（デバッグ容易化）
- `meeting-form` のエラー表示を `<p>` から `AlertCircle` アイコン付きの Alert スタイル `<div role="alert">` に変更して視認性を向上
- エラー発生時に `errorRef.scrollIntoView` で自動スクロールし、エラーを見逃しにくくする

## 変更ファイル

- `src/lib/actions/types.ts` — ZodError ハンドリング + console.error ログ
- `src/lib/actions/__tests__/types.test.ts` — ZodError テスト・console.error テストを追加
- `src/components/meeting/meeting-form.tsx` — エラー表示 UI 改善 + 自動スクロール

## Test plan

- [ ] `npm test` 全テストパスを確認（839 テスト）
- [ ] 新規作成フォームで話題タイトルを空にした状態で保存 → 日本語バリデーションエラーが表示されること
- [ ] 保存失敗時にエラー箇所へ自動スクロールされること
- [ ] サーバーログに `[Server Action Error]` が出力されること