### PR TITLE
docs: セットアップ手順に npx prisma migrate deploy を追記 (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,13 @@ npm install
 cp .env.example .env
 # .env の DATABASE_URL を確認（デフォルト: file:./dev.db）
 
-# データベースをセットアップ
-npx prisma migrate dev
+# Prisma クライアントを生成
+npx prisma generate
+
+# データベースマイグレーションを適用
+npx prisma migrate deploy
+
+# シードデータを投入
 npx prisma db seed
 
 # 開発サーバーを起動

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -30,9 +30,14 @@ npm run start
 # 環境変数の設定
 cp .env.example .env
 
-# データベース初期化（マイグレーション + シード）
-npx prisma migrate dev
-npm run db:seed
+# Prisma クライアント生成
+npx prisma generate
+
+# データベースマイグレーションを適用
+npx prisma migrate deploy
+
+# シードデータの投入
+npx prisma db seed
 ```
 
 ## トラブルシューティング


### PR DESCRIPTION
## Summary

- `README.md` のセットアップ手順を `prisma generate` + `prisma migrate deploy` に更新
- `docs/RUNBOOK.md` の初回セットアップセクションも同様に更新
- `prisma migrate dev` を削除し、明示的な2ステップ（generate → deploy）に変更

## 背景

既存のマイグレーションが未適用のまま起動すると `/members/{id}/meetings/prepare` で以下のエラーが発生する：

```
PrismaClientKnownRequestError: The column `main.Meeting.mood` does not exist in the current database.
```

`prisma migrate deploy` を明示することでこの問題を防止する。

## Test plan

- [ ] README.md のセットアップ手順が正確に記載されていることを確認
- [ ] RUNBOOK.md の初回セットアップセクションが更新されていることを確認
- [ ] 手順通りに実行した場合に正常に環境が構築できることを確認

Closes #68