### PR TITLE
feat: テンプレート選択時のアクティブ状態スタイルを実装する (#69)

### DIFF
--- a/src/components/meeting/__tests__/template-selector.test.tsx
+++ b/src/components/meeting/__tests__/template-selector.test.tsx
@@ -37,6 +37,37 @@ describe("TemplateSelector", () => {
   it("highlights the selected template", () => {
     render(<TemplateSelector onSelect={vi.fn()} selectedId="career" />);
     const careerButton = screen.getByRole("button", { name: /キャリア面談/ });
-    expect(careerButton.className).toMatch(/border-primary|ring/);
+    expect(careerButton.className).toMatch(/ring-2/);
+    expect(careerButton.className).toMatch(/border-primary/);
+  });
+
+  it("applies background color to selected template", () => {
+    render(<TemplateSelector onSelect={vi.fn()} selectedId="career" />);
+    const careerButton = screen.getByRole("button", { name: /キャリア面談/ });
+    expect(careerButton.className).toMatch(/bg-primary/);
+  });
+
+  it("shows check icon only for selected template", () => {
+    render(<TemplateSelector onSelect={vi.fn()} selectedId="career" />);
+    const checkIcons = document.querySelectorAll("[data-testid='template-check-icon']");
+    expect(checkIcons).toHaveLength(1);
+  });
+
+  it("does not show check icon when no template is selected", () => {
+    render(<TemplateSelector onSelect={vi.fn()} />);
+    const checkIcons = document.querySelectorAll("[data-testid='template-check-icon']");
+    expect(checkIcons).toHaveLength(0);
+  });
+
+  it("moves check icon when selection changes", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<TemplateSelector onSelect={onSelect} selectedId="career" />);
+
+    const checkIcons = document.querySelectorAll("[data-testid='template-check-icon']");
+    expect(checkIcons).toHaveLength(1);
+
+    await user.click(screen.getByRole("button", { name: /定期チェックイン/ }));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "regular-checkin" }));
   });
 });

--- a/src/components/meeting/template-selector.tsx
+++ b/src/components/meeting/template-selector.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Check } from "lucide-react";
+
 import { Card, CardContent } from "@/components/ui/card";
 import { MEETING_TEMPLATES, type MeetingTemplate } from "@/lib/meeting-templates";
 import { cn } from "@/lib/utils";
@@ -12,25 +14,40 @@ type Props = {
 export function TemplateSelector({ onSelect, selectedId }: Props) {
   return (
     <div className="grid grid-cols-2 gap-3">
-      {MEETING_TEMPLATES.map((template) => (
-        <button
-          key={template.id}
-          type="button"
-          aria-label={template.name}
-          onClick={() => onSelect(template)}
-          className={cn(
-            "text-left rounded-lg border border-transparent transition-colors",
-            selectedId === template.id && "border-primary ring-1 ring-primary",
-          )}
-        >
-          <Card className="h-full hover:border-primary/50 border-transparent">
-            <CardContent className="p-3">
-              <p className="font-medium text-sm">{template.name}</p>
-              <p className="text-xs text-muted-foreground mt-1">{template.description}</p>
-            </CardContent>
-          </Card>
-        </button>
-      ))}
+      {MEETING_TEMPLATES.map((template) => {
+        const isSelected = selectedId === template.id;
+        return (
+          <button
+            key={template.id}
+            type="button"
+            aria-label={template.name}
+            onClick={() => onSelect(template)}
+            className={cn(
+              "text-left rounded-lg border border-transparent transition-colors",
+              isSelected && "border-primary ring-2 ring-primary bg-primary/10",
+            )}
+          >
+            <Card
+              className={cn(
+                "h-full border-transparent",
+                isSelected ? "" : "hover:border-primary/50",
+              )}
+            >
+              <CardContent className="p-3 relative">
+                {isSelected && (
+                  <Check
+                    size={16}
+                    className="absolute top-2 right-2 text-primary"
+                    data-testid="template-check-icon"
+                  />
+                )}
+                <p className="font-medium text-sm">{template.name}</p>
+                <p className="text-xs text-muted-foreground mt-1">{template.description}</p>
+              </CardContent>
+            </Card>
+          </button>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

Issue #69 を対応。1on1 準備ページのテンプレートセレクターに、選択中テンプレートの視覚的フィードバックを追加した。

## 変更内容

- 選択中テンプレートに `ring-2 ring-primary bg-primary/10` を適用
- `lucide-react` の `Check` アイコンを選択時のみ右上に表示
- 選択時は `Card` の hover スタイルを無効化して二重枠を防止（外側 button の ring のみで選択状態を表現）

## テスト計画

- [x] 選択中テンプレートに `ring-2` / `border-primary` が適用される
- [x] 選択中テンプレートに `bg-primary/10` 背景色が適用される
- [x] 選択中テンプレートにのみチェックアイコンが表示される
- [x] 未選択状態ではチェックアイコンが表示されない
- [x] テンプレート切り替え時に `onSelect` が呼ばれる
- [x] 全 843 テスト通過
- [x] lint / format チェック通過

Closes #69