### PR TITLE
ux: メンバー作成後に新規メンバー詳細ページへリダイレクトする

### DIFF
--- a/src/components/member/__tests__/member-form.test.tsx
+++ b/src/components/member/__tests__/member-form.test.tsx
@@ -60,7 +60,7 @@ describe("MemberForm - 新規作成モード", () => {
 
   it("送信時に createMember が呼ばれる", async () => {
     const user = userEvent.setup();
-    mockCreateMember.mockResolvedValue({ success: true, data: {} });
+    mockCreateMember.mockResolvedValue({ success: true, data: { id: "new-member-id" } });
     render(<MemberForm />);
 
     await user.type(screen.getByLabelText("名前 *"), "山田花子");
@@ -74,7 +74,7 @@ describe("MemberForm - 新規作成モード", () => {
       meetingIntervalDays: 14,
     });
     expect(toast.success).toHaveBeenCalledWith(TOAST_MESSAGES.member.createSuccess);
-    expect(mockPush).toHaveBeenCalledWith("/");
+    expect(mockPush).toHaveBeenCalledWith("/members/new-member-id");
   });
 
   it("ミーティング間隔セレクトが表示される（デフォルト14日）", () => {

--- a/src/components/member/member-form.tsx
+++ b/src/components/member/member-form.tsx
@@ -70,7 +70,7 @@ export function MemberForm({ initialData, onSuccess }: Props) {
           return;
         }
         toast.success(TOAST_MESSAGES.member.createSuccess);
-        router.push("/");
+        router.push(`/members/${result.data.id}`);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : "予期しないエラーが発生しました";


### PR DESCRIPTION
## Summary

- メンバー登録フォーム送信成功後のリダイレクト先を `/` から `/members/:id` に変更
- `MemberForm` コンポーネントの `router.push("/")` を `router.push(\`/members/${result.data.id}\`)` に修正
- テストのモックデータに `id` を追加し、期待値を新しいリダイレクト先に更新

## Test plan

- [ ] `MemberForm` のユニットテスト（14件）が全件パスすることを確認
- [ ] 開発サーバーで `/members/new` からメンバーを作成し、詳細ページへリダイレクトされることを確認

Closes #76