### PR TITLE
fix: アクション一覧のステータス変更後にフィルターを即時再適用する (#75)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -45,7 +45,7 @@ export default async function ActionsPage({ searchParams }: Props) {
       <Suspense>
         <ActionFilters members={memberList} tags={tagList} />
       </Suspense>
-      <ActionListFull actionItems={actionItemsWithTags} />
+      <ActionListFull actionItems={actionItemsWithTags} statusFilter={filters.status} />
     </div>
   );
 }

--- a/src/components/action/__tests__/action-list-full.test.tsx
+++ b/src/components/action/__tests__/action-list-full.test.tsx
@@ -160,7 +160,37 @@ describe("ActionListFull", () => {
     expect(toast.error).toHaveBeenCalledWith(TOAST_MESSAGES.actionItem.updateError);
   });
 
+  describe("statusFilter プロパティ", () => {
+    it("statusFilter を指定しない場合、すべてのアイテムが表示される", () => {
+      render(<ActionListFull actionItems={baseItems} />);
+      expect(screen.getByText("レビュー依頼")).toBeDefined();
+      expect(screen.getByText("ドキュメント更新")).toBeDefined();
+    });
+
+    it("statusFilter を指定しても、渡されたアイテムはそのまま表示される", () => {
+      const inProgressItems = [
+        {
+          id: "action-2",
+          title: "ドキュメント更新",
+          description: "",
+          status: "IN_PROGRESS",
+          dueDate: null,
+          member: { id: "member-2", name: "佐藤花子" },
+          meeting: { id: "meeting-2", date: new Date("2026-02-10") },
+        },
+      ];
+      render(<ActionListFull actionItems={inProgressItems} statusFilter="IN_PROGRESS" />);
+      expect(screen.getByText("ドキュメント更新")).toBeDefined();
+    });
+
+    it("statusFilter を指定して空リストの場合、空状態メッセージを表示する", () => {
+      render(<ActionListFull actionItems={[]} statusFilter="DONE" />);
+      expect(screen.getByText("アクションアイテムはありません")).toBeDefined();
+    });
+  });
+
   // Note: Radix UI Select の onValueChange テストは jsdom 環境では
   // hasPointerCapture 非対応のため実行不可。
+  // statusFilter によるステータス変更後のフィルタリング動作（楽観的更新）は E2E テストで検証する。
   // トースト通知のロジックは action-list-compact テストで検証している。
 });

--- a/src/components/action/action-list-full.tsx
+++ b/src/components/action/action-list-full.tsx
@@ -45,9 +45,9 @@ type EditFormState = {
   dueDate: string;
 };
 
-type Props = { actionItems: ActionItemRow[] };
+type Props = { actionItems: ActionItemRow[]; statusFilter?: string };
 
-export function ActionListFull({ actionItems }: Props) {
+export function ActionListFull({ actionItems, statusFilter }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -58,8 +58,14 @@ export function ActionListFull({ actionItems }: Props) {
   });
   const [optimisticItems, setOptimisticItems] = useOptimistic(
     actionItems,
-    (currentItems, { id, status }: { id: string; status: string }) =>
-      currentItems.map((item) => (item.id === id ? { ...item, status } : item)),
+    (currentItems, { id, status }: { id: string; status: string }) => {
+      const updated = currentItems.map((item) => (item.id === id ? { ...item, status } : item));
+      // statusFilter が有効な場合、条件に合わないアイテムを楽観的に除外する
+      if (statusFilter) {
+        return updated.filter((item) => item.status === statusFilter);
+      }
+      return updated;
+    },
   );
 
   if (actionItems.length === 0) {


### PR DESCRIPTION
## 概要

Issue #75 の修正。

アクション一覧ページでステータスフィルターを適用中にアイテムのステータスを変更すると、フィルター条件を満たさなくなったアイテムが即座にリストから除外されなかった問題を修正した。

## 根本原因

`ActionListFull` の `useOptimistic` リデューサーがステータスを更新するのみで、アクティブなフィルター条件に合わないアイテムを除外していなかった。`router.refresh()` はすでに実装済みだったが、サーバーとの同期完了タイミングの問題でフィルタリングに遅延が生じていた。

## 変更内容

- `ActionListFull` コンポーネントに `statusFilter?: string` prop を追加
- `useOptimistic` リデューサーに楽観的フィルタリングを追加。`statusFilter` が有効な場合、ステータス変更後に条件に合わないアイテムを即座に除外する
- `ActionsPage` から `statusFilter={filters.status}` を渡すように更新

## Test plan

- [ ] ステータスフィルターなしの状態でステータス変更 → アイテムはリストに残る（全件表示）
- [ ] ステータスフィルター「進行中」を適用中に「完了」へ変更 → アイテムが即座に除外される
- [ ] ステータスフィルター「未着手」を適用中に「進行中」へ変更 → アイテムが即座に除外される
- [ ] フィルター変更後のリロード → サーバーデータと一致する（`router.refresh()` による同期）
- [ ] 単体テスト: `npm test` → 846 tests pass

Closes #75