### PR TITLE
fix: recharts ResponsiveContainer の SSR/ハイドレーション警告を修正する (#74)

### DIFF
--- a/src/components/analytics/meeting-frequency-chart.tsx
+++ b/src/components/analytics/meeting-frequency-chart.tsx
@@ -1,11 +1,28 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { MeetingFrequencyMonth } from "@/lib/actions/analytics-actions";
 
+function subscribe() {
+  return () => {};
+}
+
+function getSnapshot() {
+  return true;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
 export function MeetingFrequencyChart({ data }: { data: MeetingFrequencyMonth[] }) {
+  const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  if (!mounted) return null;
+
   return (
     <Card className="h-full">
       <CardHeader>

--- a/src/components/analytics/topic-distribution-chart.tsx
+++ b/src/components/analytics/topic-distribution-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -27,7 +27,20 @@ type Props = {
   data: CategoryTrend[];
 };
 
+function subscribe() {
+  return () => {};
+}
+
+function getSnapshot() {
+  return true;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
 export function TopicDistributionChart({ data }: Props) {
+  const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const chartData = useMemo(() => {
     return data.map((item) => ({
       name: CATEGORY_LABELS[item.category],
@@ -35,6 +48,8 @@ export function TopicDistributionChart({ data }: Props) {
       color: CATEGORY_COLORS[item.category],
     }));
   }, [data]);
+
+  if (!mounted) return null;
 
   if (data.length === 0) {
     return (

--- a/src/components/analytics/topic-trend-chart.tsx
+++ b/src/components/analytics/topic-trend-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import {
   Bar,
   BarChart,
@@ -22,7 +22,20 @@ type Props = {
   data: MonthlyTrend[];
 };
 
+function subscribe() {
+  return () => {};
+}
+
+function getSnapshot() {
+  return true;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
 export function TopicTrendChart({ data }: Props) {
+  const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const chartData = useMemo(() => {
     return data.map((item) => {
       // month を整形 (YYYY-MM -> YYYY/MM)
@@ -35,6 +48,8 @@ export function TopicTrendChart({ data }: Props) {
   }, [data]);
 
   const categories = Object.keys(CATEGORY_LABELS) as TopicCategory[];
+
+  if (!mounted) return null;
 
   if (data.length === 0) {
     return (


### PR DESCRIPTION
## 概要

recharts の `ResponsiveContainer` が SSR/ハイドレーション時にコンテナサイズを取得できず `width=-1, height=-1` となる警告を修正する。

## 変更内容

`useSyncExternalStore` を使用してクライアントサイドでのみチャートをレンダリングするパターンを適用。`action-completion-trend-chart.tsx` ですでに同手法が採用されており、残り3つのチャートコンポーネントにも展開した。

- `meeting-frequency-chart.tsx` — `useSyncExternalStore` でマウント後のみレンダリング
- `topic-distribution-chart.tsx` — 同上
- `topic-trend-chart.tsx` — 同上

## テスト計画

- [x] 既存の analytics コンポーネントテストがすべてパス
- [x] TypeScript 型チェックがエラーなし
- [x] Prettier フォーマットチェックがパス
- [ ] 開発サーバーで `/analytics` ページを開き「1 issue」バッジが表示されないことを確認

Closes #74