### PR TITLE
ux: メンバー追加フォームにキャンセルボタンを追加する

### DIFF
--- a/src/components/member/__tests__/member-form.test.tsx
+++ b/src/components/member/__tests__/member-form.test.tsx
@@ -9,11 +9,13 @@ import { MemberForm } from "../member-form";
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
+const mockBack = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
     refresh: mockRefresh,
+    back: mockBack,
   }),
 }));
 
@@ -48,6 +50,19 @@ describe("MemberForm - 新規作成モード", () => {
     expect(screen.getByRole("button", { name: "登録する" })).toBeDefined();
   });
 
+  it("「キャンセル」ボタンが表示される", () => {
+    render(<MemberForm />);
+    expect(screen.getByRole("button", { name: "キャンセル" })).toBeDefined();
+  });
+
+  it("「キャンセル」ボタンをクリックすると前のページに戻る", async () => {
+    const user = userEvent.setup();
+    render(<MemberForm />);
+
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(mockBack).toHaveBeenCalledOnce();
+  });
   it("空の入力フィールドが表示される", () => {
     render(<MemberForm />);
     const nameInput = screen.getByLabelText("名前 *") as HTMLInputElement;

--- a/src/components/member/member-form.tsx
+++ b/src/components/member/member-form.tsx
@@ -81,6 +81,10 @@ export function MemberForm({ initialData, onSuccess }: Props) {
     }
   }
 
+  function handleCancel() {
+    router.back();
+  }
+
   const content = (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
@@ -127,15 +131,20 @@ export function MemberForm({ initialData, onSuccess }: Props) {
         </select>
       </div>
       {error && <p className="text-sm text-destructive">{error}</p>}
-      <Button type="submit" disabled={isSubmitting}>
-        {isSubmitting
-          ? isEditing
-            ? "更新中..."
-            : "登録中..."
-          : isEditing
-            ? "更新する"
-            : "登録する"}
-      </Button>
+      <div className="flex gap-2">
+        <Button type="button" variant="outline" onClick={handleCancel} disabled={isSubmitting}>
+          キャンセル
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting
+            ? isEditing
+              ? "更新中..."
+              : "登録中..."
+            : isEditing
+              ? "更新する"
+              : "登録する"}
+        </Button>
+      </div>
     </form>
   );
 


### PR DESCRIPTION
## Summary
- メンバー追加フォーム (`/members/new`) にキャンセルボタンを追加
- 「キャンセル」ボタンをクリックすると前のページに戻る (`router.back()`)
- ボタン配置: [キャンセル] [登録する]

Closes #86

## Test plan
- [ ] メンバー追加フォームにキャンセルボタンが表示されること
- [ ] キャンセルボタンクリックで前のページに戻ること
- [ ] 既存の登録機能が引き続き動作すること
- [ ] ユニットテストがすべてパスすること（16/16）