### PR TITLE
ux: 平均完了日数の表示を意味が伝わる形式に改善する

### DIFF
--- a/src/components/analytics/__tests__/action-kpi-cards.test.tsx
+++ b/src/components/analytics/__tests__/action-kpi-cards.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ActionKpiCards } from "../action-kpi-cards";
+
+afterEach(cleanup);
+
+describe("ActionKpiCards", () => {
+  describe("期限遵守率の表示", () => {
+    it("onTimeRate を丸めてパーセント表示する", () => {
+      render(<ActionKpiCards onTimeRate={85.7} averageDays={0} />);
+      expect(screen.getByText("86%")).toBeDefined();
+    });
+  });
+
+  describe("平均完了日数の表示", () => {
+    it("正の値（遅延）の場合は「X.X 日遅延」と赤系テキストで表示する", () => {
+      render(<ActionKpiCards onTimeRate={80} averageDays={3.2} />);
+      expect(screen.getByTestId("avg-days-value").textContent).toBe("3.2 日遅延");
+    });
+
+    it("負の値（前倒し）の場合は絶対値で「X.X 日前倒し」と緑系テキストで表示する", () => {
+      render(<ActionKpiCards onTimeRate={80} averageDays={-5.9} />);
+      expect(screen.getByTestId("avg-days-value").textContent).toBe("5.9 日前倒し");
+    });
+
+    it("ゼロの場合は「期限通り」と表示する", () => {
+      render(<ActionKpiCards onTimeRate={80} averageDays={0} />);
+      expect(screen.getByTestId("avg-days-value").textContent).toBe("期限通り");
+    });
+
+    it("負の整数値も正しく絶対値表示する", () => {
+      render(<ActionKpiCards onTimeRate={80} averageDays={-2.0} />);
+      expect(screen.getByTestId("avg-days-value").textContent).toBe("2.0 日前倒し");
+    });
+
+    it("大きな遅延値も正しく表示する", () => {
+      render(<ActionKpiCards onTimeRate={80} averageDays={14.5} />);
+      expect(screen.getByTestId("avg-days-value").textContent).toBe("14.5 日遅延");
+    });
+  });
+});

--- a/src/components/analytics/action-kpi-cards.tsx
+++ b/src/components/analytics/action-kpi-cards.tsx
@@ -1,6 +1,36 @@
-import { CheckCircle2, Clock } from "lucide-react";
+import { AlertCircle, CheckCircle2, Clock, TrendingDown } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+function formatAverageDays(averageDays: number): {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  valueClassName: string;
+} {
+  if (averageDays === 0) {
+    return {
+      label: "平均完了日数",
+      value: "期限通り",
+      icon: <CheckCircle2 className="h-4 w-4 text-muted-foreground" />,
+      valueClassName: "text-2xl font-bold",
+    };
+  }
+  if (averageDays < 0) {
+    return {
+      label: "平均完了日数",
+      value: `${Math.abs(averageDays).toFixed(1)} 日前倒し`,
+      icon: <TrendingDown className="h-4 w-4 text-emerald-500" />,
+      valueClassName: "text-2xl font-bold text-emerald-600",
+    };
+  }
+  return {
+    label: "平均完了日数",
+    value: `${averageDays.toFixed(1)} 日遅延`,
+    icon: <AlertCircle className="h-4 w-4 text-destructive" />,
+    valueClassName: "text-2xl font-bold text-destructive",
+  };
+}
 
 export function ActionKpiCards({
   onTimeRate,
@@ -9,6 +39,8 @@ export function ActionKpiCards({
   onTimeRate: number;
   averageDays: number;
 }) {
+  const avgDaysDisplay = formatAverageDays(averageDays);
+
   return (
     <div className="flex flex-col gap-4">
       <Card>
@@ -22,11 +54,13 @@ export function ActionKpiCards({
       </Card>
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">平均完了日数</CardTitle>
-          <Clock className="h-4 w-4 text-muted-foreground" />
+          <CardTitle className="text-sm font-medium">{avgDaysDisplay.label}</CardTitle>
+          {avgDaysDisplay.icon}
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{averageDays.toFixed(1)} 日</div>
+          <div className={avgDaysDisplay.valueClassName} data-testid="avg-days-value">
+            {avgDaysDisplay.value}
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## 概要

Issue #77 の対応。メンバー詳細の「アクションアイテムの傾向」セクションで、「平均完了日数」が負の値の場合に意味が伝わらなかった問題を改善する。

## 変更内容

| 値 | 変更前 | 変更後 |
|---|---|---|
| 負の値（例: -5.9） | \`-5.9 日\` | \`5.9 日前倒し\`（緑テキスト + TrendingDown アイコン） |
| 正の値（例: 3.0） | \`3.0 日\` | \`3.0 日遅延\`（赤テキスト + AlertCircle アイコン） |
| ゼロ | \`0.0 日\` | \`期限通り\`（デフォルトテキスト） |

## 実装詳細

- \`ActionKpiCards\` コンポーネントに \`formatAverageDays\` ヘルパー関数を追加
- 値の符号・ゼロに応じて表示テキスト・テキスト色・アイコンを動的に切り替え
- \`action-kpi-cards.test.tsx\` を新規作成（6テストケース）

## テスト計画

- [x] 正の値（遅延）の表示テスト
- [x] 負の値（前倒し）の表示テスト
- [x] ゼロの表示テスト
- [x] 既存 analytics テスト全通過確認
- [x] TypeScript 型チェック通過
- [x] Prettier フォーマットチェック通過

Closes #77