### PR TITLE
fix: CoachingTipCard の Hydration ミスマッチエラーを修正する

### DIFF
--- a/src/components/meeting/coaching-tip-card.tsx
+++ b/src/components/meeting/coaching-tip-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -8,6 +8,7 @@ import {
   type CoachingCategory,
   type CoachingTip,
   getRandomTipByCategory,
+  getTipsByCategory,
 } from "@/lib/coaching-tips";
 
 interface CoachingTipCardProps {
@@ -16,7 +17,11 @@ interface CoachingTipCardProps {
 }
 
 export function CoachingTipCard({ category, className }: CoachingTipCardProps) {
-  const [current, setCurrent] = useState<CoachingTip>(() => getRandomTipByCategory(category));
+  const [current, setCurrent] = useState<CoachingTip>(() => getTipsByCategory(category)[0]);
+
+  useEffect(() => {
+    setCurrent(getRandomTipByCategory(category));
+  }, [category]);
 
   const handleRefresh = () => {
     setCurrent((prev) => getRandomTipByCategory(category, prev.id));


### PR DESCRIPTION
## 問題

ミーティング詳細ページ（`/members/[id]/meetings/[meetingId]`）を開くと、コンソールに Hydration エラーが発生していた。

```
Hydration failed because the server rendered text didn't match the client.
```

## 原因

`CoachingTipCard` コンポーネントで `useState` の初期化時に `getRandomTipByCategory()` を呼び出していたため、SSR（サーバー側レンダリング）とクライアントの初期化で異なる `Math.random()` の結果が生成され、描画内容が不一致になっていた。

```tsx
// 修正前（問題のあるコード）
const [current, setCurrent] = useState<CoachingTip>(
  () => getRandomTipByCategory(category)  // SSR とクライアントで異なる値
);
```

## 修正内容

初期値をカテゴリ内の最初のTip（固定値）に変更し、`useEffect` でマウント後にランダム選択するよう修正した。これにより SSR とクライアントの初期描画内容が一致し、Hydration エラーが解消される。

```tsx
// 修正後
const [current, setCurrent] = useState<CoachingTip>(
  () => getTipsByCategory(category)[0]  // 固定値でSSRと一致
);

useEffect(() => {
  setCurrent(getRandomTipByCategory(category));  // マウント後にランダム選択
}, [category]);
```

## 影響

- ミーティング詳細ページのコンソールエラーが解消される
- 初期表示はカテゴリ内の最初のTipになるが、マウント直後にランダムなTipに切り替わるため UX への影響は最小限
- 「別のTip 🎲」ボタンによる再選択機能は変わらず動作する

## テスト計画

- [ ] ミーティング詳細ページを開き、コンソールに Hydration エラーが出ないことを確認
- [ ] コーチングアシストのTipがランダムに表示されることを確認
- [ ] 「別のTip 🎲」ボタンが正常に機能することを確認
- [ ] 各コーチングカテゴリ（傾聴・質問・承認・フィードバック・ベストプラクティス）すべてで動作確認