### PR TITLE
ux: ダッシュボードのリマインダーバナーに表示上限を追加する (issue #81)

### DIFF
--- a/src/components/dashboard/reminder-alert-banner.tsx
+++ b/src/components/dashboard/reminder-alert-banner.tsx
@@ -64,6 +64,7 @@ export function ReminderAlertBanner({ reminders }: Props) {
         <div className="mt-3 flex justify-center">
           <button
             type="button"
+            aria-expanded={isExpanded}
             onClick={() => setIsExpanded((prev) => !prev)}
             className="flex items-center gap-1 text-xs text-destructive hover:text-destructive/80 font-medium transition-colors"
           >


### PR DESCRIPTION
## Summary
- `ReminderAlertBanner` をクライアントコンポーネントに変更し、デフォルト5件表示に制限
- 6件以上の場合は「すべて表示（N件）▼」ボタンを表示し、クリックで全件インライン展開
- 「折りたたむ ▲」ボタンで5件表示に戻せる
- `aria-expanded` 属性でアクセシビリティを強化
- データ取得・ページ構造への変更なし

Closes #81

## Test plan
- [ ] `npm test -- reminder-alert-banner` で全テスト PASS 確認
- [ ] `npm test` で全テスト回帰なし確認
- [ ] ダッシュボードを開いてリマインダーが5件に制限されることを目視確認
- [ ] 「すべて表示」クリックで全件展開されることを確認
- [ ] 「折りたたむ」クリックで5件に戻ることを確認
- [ ] リマインダーが5件以下の場合はボタンが表示されないことを確認