### PR TITLE
feat: アクション一覧にキーワード検索・日付フィルター・ソート機能を追加する (issue #83)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -3,6 +3,8 @@ import { Suspense } from "react";
 import { ActionFilters } from "@/components/action/action-filters";
 import { ActionListFull } from "@/components/action/action-list-full";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { Badge } from "@/components/ui/badge";
+import type { DateFilterType, SortByType } from "@/lib/actions/action-item-actions";
 import { getActionItems } from "@/lib/actions/action-item-actions";
 import { getMembers } from "@/lib/actions/member-actions";
 import { getTags } from "@/lib/actions/tag-actions";
@@ -10,11 +12,32 @@ import type { ActionItemStatusType } from "@/lib/validations/action-item";
 
 export const dynamic = "force-dynamic";
 
-type Props = { searchParams: Promise<{ status?: string; memberId?: string; tag?: string }> };
+const DATE_FILTERS: DateFilterType[] = ["all", "overdue", "this-week", "this-month"];
+const SORT_OPTIONS: SortByType[] = ["dueDate", "createdAt", "memberName"];
+
+type Props = {
+  searchParams: Promise<{
+    status?: string;
+    memberId?: string;
+    tag?: string;
+    q?: string;
+    dateFilter?: string;
+    sort?: string;
+  }>;
+};
 
 export default async function ActionsPage({ searchParams }: Props) {
   const params = await searchParams;
-  const filters: { status?: ActionItemStatusType; memberId?: string; tagIds?: string[] } = {};
+
+  const filters: {
+    status?: ActionItemStatusType;
+    memberId?: string;
+    tagIds?: string[];
+    keyword?: string;
+    dateFilter?: DateFilterType;
+    sortBy?: SortByType;
+  } = {};
+
   if (params.status && ["TODO", "IN_PROGRESS", "DONE"].includes(params.status)) {
     filters.status = params.status as ActionItemStatusType;
   }
@@ -23,6 +46,15 @@ export default async function ActionsPage({ searchParams }: Props) {
   }
   if (params.tag) {
     filters.tagIds = [params.tag];
+  }
+  if (params.q) {
+    filters.keyword = params.q;
+  }
+  if (params.dateFilter && DATE_FILTERS.includes(params.dateFilter as DateFilterType)) {
+    filters.dateFilter = params.dateFilter as DateFilterType;
+  }
+  if (params.sort && SORT_OPTIONS.includes(params.sort as SortByType)) {
+    filters.sortBy = params.sort as SortByType;
   }
 
   const [actionItems, members, allTags] = await Promise.all([
@@ -38,10 +70,28 @@ export default async function ActionsPage({ searchParams }: Props) {
     tags: item.tags.map((tt) => tt.tag),
   }));
 
+  const hasFilter =
+    !!filters.status ||
+    !!filters.memberId ||
+    !!filters.tagIds ||
+    !!filters.keyword ||
+    (!!filters.dateFilter && filters.dateFilter !== "all");
+
   return (
     <div className="animate-fade-in-up">
       <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "アクション一覧" }]} />
-      <h1 className="text-2xl font-semibold tracking-tight mb-6 text-foreground">アクション一覧</h1>
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">アクション一覧</h1>
+        {hasFilter ? (
+          <Badge variant="secondary" className="text-sm">
+            {actionItemsWithTags.length} 件
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-sm text-muted-foreground">
+            {actionItemsWithTags.length} 件
+          </Badge>
+        )}
+      </div>
       <Suspense>
         <ActionFilters members={memberList} tags={tagList} />
       </Suspense>

--- a/src/components/action/__tests__/action-filters.test.tsx
+++ b/src/components/action/__tests__/action-filters.test.tsx
@@ -30,6 +30,10 @@ describe("buildFilterUrl", () => {
     expect(buildFilterUrl("status=TODO", "status", "all")).toBe("/actions?");
   });
 
+  it("value が空文字のとき該当キーを削除する", () => {
+    expect(buildFilterUrl("status=TODO&memberId=abc", "status", "")).toBe("/actions?memberId=abc");
+  });
+
   it("value が 'all' でないとき該当キーをセットする", () => {
     expect(buildFilterUrl("", "status", "TODO")).toBe("/actions?status=TODO");
   });
@@ -47,19 +51,36 @@ describe("buildFilterUrl", () => {
   it("空のパラメータに値を追加する", () => {
     expect(buildFilterUrl("", "memberId", "member-1")).toBe("/actions?memberId=member-1");
   });
+
+  it("dateFilter パラメータを設定できる", () => {
+    expect(buildFilterUrl("", "dateFilter", "overdue")).toBe("/actions?dateFilter=overdue");
+  });
+
+  it("dateFilter が 'all' のときパラメータを削除する", () => {
+    expect(buildFilterUrl("dateFilter=overdue", "dateFilter", "all")).toBe("/actions?");
+  });
+
+  it("sort パラメータを設定できる", () => {
+    expect(buildFilterUrl("", "sort", "createdAt")).toBe("/actions?sort=createdAt");
+  });
 });
 
 describe("ActionFilters", () => {
-  it("2つのフィルターセレクトが表示される", () => {
+  it("4つのフィルターセレクトが表示される（ステータス・メンバー・期限・並び順）", () => {
     render(<ActionFilters members={mockMembers} />);
     const triggers = screen.getAllByRole("combobox");
-    expect(triggers.length).toBe(2);
+    expect(triggers.length).toBe(4);
   });
 
   it("空のメンバーリストでもレンダリングされる", () => {
     render(<ActionFilters members={[]} />);
     const triggers = screen.getAllByRole("combobox");
-    expect(triggers.length).toBe(2);
+    expect(triggers.length).toBe(4);
+  });
+
+  it("キーワード検索のインプットが表示される", () => {
+    render(<ActionFilters members={mockMembers} />);
+    expect(screen.getByPlaceholderText("アクション名・内容で検索...")).toBeDefined();
   });
 
   it("searchParams にステータスがないとき 'すべて' がデフォルト表示される", () => {
@@ -72,6 +93,18 @@ describe("ActionFilters", () => {
     mockSearchParamsGet.mockReturnValue(null);
     render(<ActionFilters members={mockMembers} />);
     expect(screen.getByText("全メンバー")).toBeDefined();
+  });
+
+  it("期限フィルタのデフォルトとして 'すべての期限' が表示される", () => {
+    mockSearchParamsGet.mockReturnValue(null);
+    render(<ActionFilters members={mockMembers} />);
+    expect(screen.getByText("すべての期限")).toBeDefined();
+  });
+
+  it("ソートのデフォルトとして '期限日順' が表示される", () => {
+    mockSearchParamsGet.mockReturnValue(null);
+    render(<ActionFilters members={mockMembers} />);
+    expect(screen.getByText("期限日順")).toBeDefined();
   });
 
   // Note: Radix UI Select の onValueChange テストは jsdom 環境では

--- a/src/components/action/action-filters.tsx
+++ b/src/components/action/action-filters.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { Search } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 
 import { TagFilter } from "@/components/tag/tag-filter";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -10,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useDebounce } from "@/hooks/use-debounce";
 
 type Member = { id: string; name: string };
 type Tag = { id: string; name: string; color: string };
@@ -17,7 +21,7 @@ type Props = { members: Member[]; tags?: Tag[] };
 
 export function buildFilterUrl(currentParams: string, key: string, value: string): string {
   const params = new URLSearchParams(currentParams);
-  if (value === "all") {
+  if (value === "all" || value === "") {
     params.delete(key);
   } else {
     params.set(key, value);
@@ -28,44 +32,90 @@ export function buildFilterUrl(currentParams: string, key: string, value: string
 export function ActionFilters({ members, tags = [] }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState(searchParams.get("q") ?? "");
+  const debouncedKeyword = useDebounce(keyword, 300);
 
   function updateFilter(key: string, value: string) {
     router.push(buildFilterUrl(searchParams.toString(), key, value));
   }
 
+  useEffect(() => {
+    router.push(buildFilterUrl(searchParams.toString(), "q", debouncedKeyword));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedKeyword]);
+
   return (
-    <div className="flex gap-4 mb-4 flex-wrap">
-      <Select
-        value={searchParams.get("status") ?? "all"}
-        onValueChange={(val) => updateFilter("status", val)}
-      >
-        <SelectTrigger className="w-40">
-          <SelectValue placeholder="ステータス" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">すべて</SelectItem>
-          <SelectItem value="TODO">未着手</SelectItem>
-          <SelectItem value="IN_PROGRESS">進行中</SelectItem>
-          <SelectItem value="DONE">完了</SelectItem>
-        </SelectContent>
-      </Select>
-      <Select
-        value={searchParams.get("memberId") ?? "all"}
-        onValueChange={(val) => updateFilter("memberId", val)}
-      >
-        <SelectTrigger className="w-48">
-          <SelectValue placeholder="メンバー" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">全メンバー</SelectItem>
-          {members.map((m) => (
-            <SelectItem key={m.id} value={m.id}>
-              {m.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      {tags.length > 0 && <TagFilter tags={tags} />}
+    <div className="flex flex-col gap-3 mb-4">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          type="search"
+          placeholder="アクション名・内容で検索..."
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+      <div className="flex gap-3 flex-wrap">
+        <Select
+          value={searchParams.get("status") ?? "all"}
+          onValueChange={(val) => updateFilter("status", val)}
+        >
+          <SelectTrigger className="w-36">
+            <SelectValue placeholder="ステータス" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">すべて</SelectItem>
+            <SelectItem value="TODO">未着手</SelectItem>
+            <SelectItem value="IN_PROGRESS">進行中</SelectItem>
+            <SelectItem value="DONE">完了</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={searchParams.get("memberId") ?? "all"}
+          onValueChange={(val) => updateFilter("memberId", val)}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue placeholder="メンバー" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">全メンバー</SelectItem>
+            {members.map((m) => (
+              <SelectItem key={m.id} value={m.id}>
+                {m.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={searchParams.get("dateFilter") ?? "all"}
+          onValueChange={(val) => updateFilter("dateFilter", val)}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="期限" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">すべての期限</SelectItem>
+            <SelectItem value="overdue">期限切れ</SelectItem>
+            <SelectItem value="this-week">今週期限</SelectItem>
+            <SelectItem value="this-month">今月期限</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={searchParams.get("sort") ?? "dueDate"}
+          onValueChange={(val) => updateFilter("sort", val)}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="並び順" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="dueDate">期限日順</SelectItem>
+            <SelectItem value="createdAt">作成日順</SelectItem>
+            <SelectItem value="memberName">メンバー名順</SelectItem>
+          </SelectContent>
+        </Select>
+        {tags.length > 0 && <TagFilter tags={tags} />}
+      </div>
     </div>
   );
 }

--- a/src/lib/actions/action-item-actions.ts
+++ b/src/lib/actions/action-item-actions.ts
@@ -12,11 +12,46 @@ import {
 
 import { type ActionResult, runAction } from "./types";
 
+export type DateFilterType = "all" | "overdue" | "this-week" | "this-month";
+export type SortByType = "dueDate" | "createdAt" | "memberName";
+
 type ActionItemFilters = {
   status?: ActionItemStatusType;
   memberId?: string;
   tagIds?: string[];
+  keyword?: string;
+  dateFilter?: DateFilterType;
+  sortBy?: SortByType;
 };
+
+function buildDateFilter(dateFilter: DateFilterType): Prisma.ActionItemWhereInput {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  if (dateFilter === "overdue") {
+    return { dueDate: { lt: today }, status: { not: "DONE" } };
+  }
+  if (dateFilter === "this-week") {
+    const dayOfWeek = today.getDay();
+    const weekStart = new Date(today);
+    weekStart.setDate(today.getDate() - dayOfWeek);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 7);
+    return { dueDate: { gte: weekStart, lt: weekEnd } };
+  }
+  if (dateFilter === "this-month") {
+    const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+    const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 1);
+    return { dueDate: { gte: monthStart, lt: monthEnd } };
+  }
+  return {};
+}
+
+function buildOrderBy(sortBy: SortByType): Prisma.ActionItemOrderByWithRelationInput[] {
+  if (sortBy === "createdAt") return [{ createdAt: "desc" }];
+  if (sortBy === "memberName") return [{ member: { name: "asc" } }, { dueDate: "asc" }];
+  return [{ dueDate: "asc" }, { createdAt: "desc" }];
+}
 
 export async function getActionItems(filters: ActionItemFilters = {}) {
   const where: Prisma.ActionItemWhereInput = {};
@@ -25,9 +60,21 @@ export async function getActionItems(filters: ActionItemFilters = {}) {
   if (filters.tagIds && filters.tagIds.length > 0) {
     where.tags = { some: { tagId: { in: filters.tagIds } } };
   }
+  if (filters.keyword) {
+    where.OR = [
+      { title: { contains: filters.keyword } },
+      { description: { contains: filters.keyword } },
+    ];
+  }
+  if (filters.dateFilter && filters.dateFilter !== "all") {
+    Object.assign(where, buildDateFilter(filters.dateFilter));
+  }
+
+  const orderBy = buildOrderBy(filters.sortBy ?? "dueDate");
+
   return prisma.actionItem.findMany({
     where,
-    orderBy: [{ dueDate: "asc" }, { createdAt: "desc" }],
+    orderBy,
     include: {
       member: { select: { id: true, name: true } },
       meeting: { select: { id: true, date: true } },


### PR DESCRIPTION
## Summary

Closes #83

- **キーワード検索**: アクション名・説明文の部分一致検索ボックスを追加（debounce 300ms）
- **日付フィルター**: 「すべての期限 / 期限切れ / 今週期限 / 今月期限」の4種類を追加
- **ソート機能**: 「期限日順 / 作成日順 / メンバー名順」の3種類を追加
- **件数バッジ**: フィルタ適用後の件数をページ見出し横に表示

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/lib/actions/action-item-actions.ts` | `getActionItems()` に `keyword`, `dateFilter`, `sortBy` パラメータを追加 |
| `src/app/actions/page.tsx` | 新 searchParams の読み取りと件数バッジの追加 |
| `src/components/action/action-filters.tsx` | キーワード検索・日付フィルター・ソートの UI を追加 |
| `src/components/action/__tests__/action-filters.test.tsx` | 新機能のテストを追加（16件全パス） |

## Test plan

- [ ] キーワード検索でタイトル・説明文の絞り込みができること
- [ ] 「期限切れ」フィルタで dueDate < today かつ未完了のアイテムのみ表示されること
- [ ] 「今週期限」「今月期限」で該当期間のアイテムのみ表示されること
- [ ] ソートで期限日順・作成日順・メンバー名順に並び替えができること
- [ ] フィルタ適用後の件数バッジが正しく更新されること
- [ ] 既存のステータス・メンバー・タグフィルタが引き続き動作すること
- [ ] `npm test` — 16件パス（action-filters.test.tsx）
- [ ] `npx tsc --noEmit` — 型エラーなし
- [ ] `npm run format:check` — Prettier エラーなし