### PR TITLE
feat: メンバー一覧ページを追加する (issue #82)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -38,7 +38,13 @@ export default async function MemberDetailPage({ params, searchParams }: Props) 
 
   return (
     <div className="animate-fade-in-up">
-      <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: member.name }]} />
+      <Breadcrumb
+        items={[
+          { label: "ダッシュボード", href: "/" },
+          { label: "メンバー一覧", href: "/members" },
+          { label: member.name },
+        ]}
+      />
       <div className="flex justify-between items-start mb-8">
         <div className="flex items-center gap-4">
           <AvatarInitial name={member.name} size="lg" />

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,0 +1,29 @@
+import { UserPlus } from "lucide-react";
+import Link from "next/link";
+
+import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { MemberListPage } from "@/components/member/member-list-page";
+import { Button } from "@/components/ui/button";
+import { getMembers } from "@/lib/actions/member-actions";
+
+export const dynamic = "force-dynamic";
+
+export default async function MembersPage() {
+  const members = await getMembers();
+
+  return (
+    <div className="animate-fade-in-up">
+      <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "メンバー一覧" }]} />
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">メンバー一覧</h1>
+        <Link href="/members/new">
+          <Button>
+            <UserPlus className="w-4 h-4 mr-2" />
+            メンバーを追加
+          </Button>
+        </Link>
+      </div>
+      <MemberListPage members={members} />
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BarChart2, LayoutDashboard, ListChecks, Menu, UserPlus, X } from "lucide-react";
+import { BarChart2, LayoutDashboard, ListChecks, Menu, UserPlus, Users, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -23,6 +23,7 @@ type SidebarProps = {
 
 const navItems = [
   { href: "/", label: "ダッシュボード", icon: LayoutDashboard },
+  { href: "/members", label: "メンバー一覧", icon: Users },
   { href: "/members/new", label: "メンバー追加", icon: UserPlus },
   { href: "/actions", label: "アクション一覧", icon: ListChecks },
   { href: "/analytics", label: "ミーティング分析", icon: BarChart2 },
@@ -40,7 +41,10 @@ function NavLinks({
   return (
     <nav className="flex flex-col gap-1">
       {navItems.map((item) => {
-        const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+        const isActive =
+          item.href === "/" || item.href === "/members"
+            ? pathname === item.href
+            : pathname.startsWith(item.href);
         const badge = item.href === "/actions" && actionCount != null && actionCount > 0;
         return (
           <Link

--- a/src/components/member/__tests__/member-list-page.test.tsx
+++ b/src/components/member/__tests__/member-list-page.test.tsx
@@ -1,0 +1,133 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MemberListPage } from "../member-list-page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+const makeDate = (daysAgo: number) => {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return d;
+};
+
+const members = [
+  {
+    id: "1",
+    name: "田中太郎",
+    department: "エンジニアリング",
+    position: "シニアエンジニア",
+    _count: { actionItems: 2 },
+    meetings: [{ date: makeDate(3) }],
+    overdueActionCount: 0,
+  },
+  {
+    id: "2",
+    name: "鈴木花子",
+    department: "マーケティング",
+    position: "マネージャー",
+    _count: { actionItems: 0 },
+    meetings: [{ date: makeDate(20) }],
+    overdueActionCount: 1,
+  },
+  {
+    id: "3",
+    name: "佐藤次郎",
+    department: "エンジニアリング",
+    position: "エンジニア",
+    _count: { actionItems: 1 },
+    meetings: [],
+    overdueActionCount: 0,
+  },
+];
+
+describe("MemberListPage", () => {
+  it("フィルターなしで全メンバーを表示する", () => {
+    render(<MemberListPage members={members} />);
+    expect(screen.getByText("田中太郎")).toBeDefined();
+    expect(screen.getByText("鈴木花子")).toBeDefined();
+    expect(screen.getByText("佐藤次郎")).toBeDefined();
+  });
+
+  it("名前で検索するとマッチするメンバーだけ表示する", async () => {
+    const user = userEvent.setup();
+    render(<MemberListPage members={members} />);
+    const searchInput = screen.getByPlaceholderText("名前で検索...");
+    await user.type(searchInput, "田中");
+    expect(screen.getByText("田中太郎")).toBeDefined();
+    expect(screen.queryByText("鈴木花子")).toBeNull();
+    expect(screen.queryByText("佐藤次郎")).toBeNull();
+  });
+
+  it("部署でフィルタするとマッチするメンバーだけ表示する", async () => {
+    const user = userEvent.setup();
+    render(<MemberListPage members={members} />);
+    const deptSelect = screen.getByRole("combobox", { name: "部署で絞り込む" });
+    await user.selectOptions(deptSelect, "マーケティング");
+    expect(screen.queryByText("田中太郎")).toBeNull();
+    expect(screen.getByText("鈴木花子")).toBeDefined();
+    expect(screen.queryByText("佐藤次郎")).toBeNull();
+  });
+
+  it("役職でフィルタするとマッチするメンバーだけ表示する", async () => {
+    const user = userEvent.setup();
+    render(<MemberListPage members={members} />);
+    const posSelect = screen.getByRole("combobox", { name: "役職で絞り込む" });
+    await user.selectOptions(posSelect, "エンジニア");
+    expect(screen.queryByText("田中太郎")).toBeNull();
+    expect(screen.queryByText("鈴木花子")).toBeNull();
+    expect(screen.getByText("佐藤次郎")).toBeDefined();
+  });
+
+  it("名前検索と部署フィルタを組み合わせて絞り込める", async () => {
+    const user = userEvent.setup();
+    render(<MemberListPage members={members} />);
+    const deptSelect = screen.getByRole("combobox", { name: "部署で絞り込む" });
+    await user.selectOptions(deptSelect, "エンジニアリング");
+    const searchInput = screen.getByPlaceholderText("名前で検索...");
+    await user.type(searchInput, "田中");
+    expect(screen.getByText("田中太郎")).toBeDefined();
+    expect(screen.queryByText("佐藤次郎")).toBeNull();
+  });
+
+  it("部署セレクトに一意の部署選択肢が表示される", () => {
+    render(<MemberListPage members={members} />);
+    const deptSelect = screen.getByRole("combobox", { name: "部署で絞り込む" });
+    // エンジニアリングとマーケティングのオプションが存在する
+    expect(deptSelect.querySelector("option[value='エンジニアリング']")).not.toBeNull();
+    expect(deptSelect.querySelector("option[value='マーケティング']")).not.toBeNull();
+    // エンジニアリングは2件あるが選択肢は1件だけ
+    const options = deptSelect.querySelectorAll("option[value='エンジニアリング']");
+    expect(options.length).toBe(1);
+  });
+
+  it("フィルター結果が0件のとき空状態メッセージを表示する", async () => {
+    const user = userEvent.setup();
+    render(<MemberListPage members={members} />);
+    const searchInput = screen.getByPlaceholderText("名前で検索...");
+    await user.type(searchInput, "存在しない人");
+    expect(screen.getByText("条件に一致するメンバーが見つかりません")).toBeDefined();
+  });
+
+  it("メンバー数バッジを表示する", () => {
+    render(<MemberListPage members={members} />);
+    expect(screen.getByText("3人")).toBeDefined();
+  });
+
+  it("フィルター後はメンバー数バッジが更新される", async () => {
+    const user = userEvent.setup();
+    render(<MemberListPage members={members} />);
+    const deptSelect = screen.getByRole("combobox", { name: "部署で絞り込む" });
+    await user.selectOptions(deptSelect, "エンジニアリング");
+    expect(screen.getByText("2人")).toBeDefined();
+  });
+});

--- a/src/components/member/member-list-page.tsx
+++ b/src/components/member/member-list-page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Search, Users } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { MemberList } from "@/components/member/member-list";
+import { Input } from "@/components/ui/input";
+
+type MemberWithStats = {
+  readonly id: string;
+  readonly name: string;
+  readonly department: string | null;
+  readonly position: string | null;
+  readonly _count: { readonly actionItems: number };
+  readonly meetings: readonly { readonly date: Date }[];
+  readonly overdueActionCount: number;
+};
+
+type Props = {
+  readonly members: readonly MemberWithStats[];
+};
+
+export function MemberListPage({ members }: Props) {
+  const [search, setSearch] = useState("");
+  const [department, setDepartment] = useState("");
+  const [position, setPosition] = useState("");
+
+  const departments = useMemo(() => {
+    const set = new Set(members.map((m) => m.department).filter(Boolean) as string[]);
+    return Array.from(set).sort();
+  }, [members]);
+
+  const positions = useMemo(() => {
+    const set = new Set(members.map((m) => m.position).filter(Boolean) as string[]);
+    return Array.from(set).sort();
+  }, [members]);
+
+  const filtered = useMemo(() => {
+    return members.filter((m) => {
+      const matchesSearch = search === "" || m.name.includes(search);
+      const matchesDept = department === "" || m.department === department;
+      const matchesPos = position === "" || m.position === position;
+      return matchesSearch && matchesDept && matchesPos;
+    });
+  }, [members, search, department, position]);
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <div className="relative flex-1 max-w-xs">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input
+            type="text"
+            placeholder="名前で検索..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <select
+          aria-label="部署で絞り込む"
+          value={department}
+          onChange={(e) => setDepartment(e.target.value)}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">すべての部署</option>
+          {departments.map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+        </select>
+
+        <select
+          aria-label="役職で絞り込む"
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">すべての役職</option>
+          {positions.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+
+        <div className="flex items-center text-sm text-muted-foreground sm:ml-auto shrink-0">
+          <Users className="w-4 h-4 mr-1.5" />
+          <span>{filtered.length}人</span>
+        </div>
+      </div>
+
+      {filtered.length === 0 && members.length > 0 ? (
+        <div className="rounded-xl border bg-card p-12 text-center">
+          <p className="text-muted-foreground">条件に一致するメンバーが見つかりません</p>
+        </div>
+      ) : (
+        <MemberList members={filtered} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

issue #82 の対応。`/members` に専用のメンバー一覧ページを追加する。

## 変更内容

### 新規ファイル
- `src/app/members/page.tsx` — メンバー一覧ページ（Server Component）
- `src/components/member/member-list-page.tsx` — フィルター付き一覧コンポーネント（Client Component）
- `src/components/member/__tests__/member-list-page.test.tsx` — テスト（9件）

### 変更ファイル
- `src/components/layout/sidebar.tsx` — 「メンバー一覧」ナビリンク追加・アクティブ判定修正
- `src/app/members/[id]/page.tsx` — パンくずに「メンバー一覧」を追加

## 機能

- **名前検索**: テキスト入力でリアルタイムに絞り込み
- **部署フィルター**: ドロップダウンで部署を絞り込み（メンバーデータから動的生成）
- **役職フィルター**: ドロップダウンで役職を絞り込み（同上）
- **件数表示**: フィルター結果の人数をリアルタイム表示
- **既存ソート機能**: `MemberList` の最終1on1日・未完了アクション数ソートをそのまま利用
- **空状態**: 条件に一致するメンバーがいない場合のメッセージ表示

## テスト計画

- [x] `npm test` — 98ファイル 894テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ブラウザで `/members` ページの表示・フィルター動作を確認
- [ ] サイドバーの「メンバー一覧」リンクをクリックして遷移確認
- [ ] メンバー詳細ページのパンくずで「メンバー一覧」に戻れることを確認

Closes #82