### PR TITLE
ux: コンディション評価スケールに最小・最大ラベルを追加する (issue #85)

### DIFF
--- a/src/components/meeting/__tests__/condition-selector.test.tsx
+++ b/src/components/meeting/__tests__/condition-selector.test.tsx
@@ -78,4 +78,27 @@ describe("ConditionSelector", () => {
     await user.click(buttons[1]);
     expect(handleChange).toHaveBeenCalledWith("conditionHealth", null);
   });
+
+  it("体調行に最小ラベル「悪い」と最大ラベル「良い」が表示されること", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    const allBadText = screen.getAllByText("悪い");
+    const allGoodText = screen.getAllByText("良い");
+    expect(allBadText.length).toBeGreaterThanOrEqual(1);
+    expect(allGoodText.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("業務量行に最小ラベル「少ない」と最大ラベル「多い」が表示されること", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    expect(screen.getByText("少ない")).toBeInTheDocument();
+    expect(screen.getByText("多い")).toBeInTheDocument();
+  });
+
+  it("各軸の最小・最大ラベルが合計6つ表示されること（min×3, max×3）", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    // 体調: 悪い/良い, 気分: 悪い/良い, 業務量: 少ない/多い
+    const minLabels = screen.getAllByText(/^(悪い|少ない)$/);
+    const maxLabels = screen.getAllByText(/^(良い|多い)$/);
+    expect(minLabels).toHaveLength(3);
+    expect(maxLabels).toHaveLength(3);
+  });
 });

--- a/src/components/meeting/condition-selector.tsx
+++ b/src/components/meeting/condition-selector.tsx
@@ -6,6 +6,8 @@ interface ConditionAxis {
   field: ConditionField;
   label: string;
   icon: string;
+  minLabel: string;
+  maxLabel: string;
   options: { value: number; label: string }[];
 }
 
@@ -14,6 +16,8 @@ const CONDITION_AXES: ConditionAxis[] = [
     field: "conditionHealth",
     label: "体調",
     icon: "🏥",
+    minLabel: "悪い",
+    maxLabel: "良い",
     options: [
       { value: 1, label: "とても悪い" },
       { value: 2, label: "悪い" },
@@ -26,6 +30,8 @@ const CONDITION_AXES: ConditionAxis[] = [
     field: "conditionMood",
     label: "気分",
     icon: "💭",
+    minLabel: "悪い",
+    maxLabel: "良い",
     options: [
       { value: 1, label: "とても悪い" },
       { value: 2, label: "悪い" },
@@ -38,6 +44,8 @@ const CONDITION_AXES: ConditionAxis[] = [
     field: "conditionWorkload",
     label: "業務量",
     icon: "📊",
+    minLabel: "少ない",
+    maxLabel: "多い",
     options: [
       { value: 1, label: "とても少ない" },
       { value: 2, label: "少ない" },
@@ -82,23 +90,29 @@ export function ConditionSelector({
               <span className="text-base">{axis.icon}</span>
               <span className="text-sm font-medium text-slate-700">{axis.label}</span>
             </div>
-            <div className="flex items-center gap-1">
-              {axis.options.map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  aria-label={`${axis.label}: ${option.label}`}
-                  aria-pressed={currentValue === option.value}
-                  onClick={() => handleSelect(axis.field, option.value)}
-                  className={`flex h-8 w-8 items-center justify-center rounded-md text-sm font-medium transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-primary ${
-                    currentValue === option.value
-                      ? "bg-primary text-white ring-2 ring-primary scale-105"
-                      : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-                  }`}
-                >
-                  {option.value}
-                </button>
-              ))}
+            <div className="flex items-center gap-2">
+              <span className="w-10 shrink-0 text-right text-xs text-slate-400">
+                {axis.minLabel}
+              </span>
+              <div className="flex items-center gap-1">
+                {axis.options.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-label={`${axis.label}: ${option.label}`}
+                    aria-pressed={currentValue === option.value}
+                    onClick={() => handleSelect(axis.field, option.value)}
+                    className={`flex h-8 w-8 items-center justify-center rounded-md text-sm font-medium transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-primary ${
+                      currentValue === option.value
+                        ? "bg-primary text-white ring-2 ring-primary scale-105"
+                        : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                    }`}
+                  >
+                    {option.value}
+                  </button>
+                ))}
+              </div>
+              <span className="w-8 shrink-0 text-xs text-slate-400">{axis.maxLabel}</span>
             </div>
           </div>
         );


### PR DESCRIPTION
## 概要

issue #85 の対応。ミーティング記録画面のコンディション評価スケール（体調・気分・業務量）の両端に意味ラベルを追加し、1 と 5 が何を意味するのかをユーザーが直感的に理解できるようにする。

## 変更内容

### 変更ファイル
- `src/components/meeting/condition-selector.tsx` — `ConditionAxis` に `minLabel` / `maxLabel` を追加し、スケール両端にラベルを表示
- `src/components/meeting/__tests__/condition-selector.test.tsx` — min/max ラベル表示のテストを 3 件追加

## 機能

各コンディション軸のスケール表示が以下に変わります:

| 軸 | Before | After |
|---|---|---|
| 体調 | `[1][2][3][4][5]` | `悪い [1][2][3][4][5] 良い` |
| 気分 | `[1][2][3][4][5]` | `悪い [1][2][3][4][5] 良い` |
| 業務量 | `[1][2][3][4][5]` | `少ない [1][2][3][4][5] 多い` |

ラベルは `text-xs text-slate-400` で控えめに表示し、既存の UI を邪魔しないデザインにしています。

## テスト計画

- [x] `npm test` — 1 ファイル 10 テスト全パス（新規 3 テスト含む）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] `/members/[id]/meetings/new` でコンディション評価スケールの両端ラベルが表示されること
- [ ] スケールのボタン操作（選択・解除）が引き続き正常に動作すること

Closes #85