### PR TITLE
feat: ミーティング分析ページに部署・期間フィルタ・ソート・未実施折りたたみを追加する (issue #87)

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,20 +1,47 @@
+import { Suspense } from "react";
+
+import { AnalyticsFilterBar } from "@/components/analytics/analytics-filter-bar";
 import { MeetingFrequencyChart } from "@/components/analytics/meeting-frequency-chart";
 import { MeetingHeatmap } from "@/components/analytics/meeting-heatmap";
 import { MeetingIntervalTable } from "@/components/analytics/meeting-interval-table";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import {
   getAllMembersWithInterval,
+  getDepartments,
   getMeetingFrequencyByMonth,
   getMemberMeetingHeatmap,
+  type MemberIntervalSort,
 } from "@/lib/actions/analytics-actions";
 
 export const dynamic = "force-dynamic";
 
-export default async function AnalyticsPage() {
-  const [frequencyData, heatmapData, allMembers] = await Promise.all([
-    getMeetingFrequencyByMonth(),
-    getMemberMeetingHeatmap(),
-    getAllMembersWithInterval(),
+const VALID_PERIODS = [3, 6, 12] as const;
+const VALID_SORTS: MemberIntervalSort[] = ["name", "last_meeting", "department"];
+
+function parsePeriod(value: string | undefined): 3 | 6 | 12 {
+  const n = Number(value);
+  return (VALID_PERIODS as readonly number[]).includes(n) ? (n as 3 | 6 | 12) : 12;
+}
+
+function parseSort(value: string | undefined): MemberIntervalSort {
+  return VALID_SORTS.includes(value as MemberIntervalSort) ? (value as MemberIntervalSort) : "name";
+}
+
+export default async function AnalyticsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ department?: string; period?: string; sort?: string }>;
+}) {
+  const params = await searchParams;
+  const department = params.department ?? "";
+  const period = parsePeriod(params.period);
+  const sort = parseSort(params.sort);
+
+  const [frequencyData, heatmapData, allMembers, departments] = await Promise.all([
+    getMeetingFrequencyByMonth(period, department || undefined),
+    getMemberMeetingHeatmap(period, department || undefined),
+    getAllMembersWithInterval({ department: department || undefined, sort }),
+    getDepartments(),
   ]);
 
   return (
@@ -24,9 +51,18 @@ export default async function AnalyticsPage() {
         ミーティング分析
       </h1>
 
+      <Suspense>
+        <AnalyticsFilterBar
+          departments={departments}
+          currentDepartment={department}
+          currentPeriod={period}
+          currentSort={sort}
+        />
+      </Suspense>
+
       <div className="mb-8">
         <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-4">
-          月次実施回数（直近12ヶ月）
+          月次実施回数（直近{period}ヶ月）
         </h2>
         <MeetingFrequencyChart data={frequencyData} />
       </div>

--- a/src/components/analytics/__tests__/meeting-heatmap.test.tsx
+++ b/src/components/analytics/__tests__/meeting-heatmap.test.tsx
@@ -28,6 +28,7 @@ const sampleData: HeatmapData = {
     {
       memberId: "member-1",
       memberName: "田中 太郎",
+      department: "開発部",
       months: [
         { month: "2025-03", count: 0 },
         { month: "2025-04", count: 1 },
@@ -46,6 +47,7 @@ const sampleData: HeatmapData = {
     {
       memberId: "member-2",
       memberName: "鈴木 花子",
+      department: null,
       months: [
         { month: "2025-03", count: 1 },
         { month: "2025-04", count: 0 },

--- a/src/components/analytics/__tests__/meeting-interval-table.test.tsx
+++ b/src/components/analytics/__tests__/meeting-interval-table.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MeetingIntervalTable } from "../meeting-interval-table";
@@ -35,16 +35,35 @@ const mockData = [
 ];
 
 describe("MeetingIntervalTable", () => {
-  it("renders member names", () => {
+  it("実施済みメンバーを表示する", () => {
     render(<MeetingIntervalTable data={mockData} />);
     expect(screen.getByText("山田 太郎")).toBeDefined();
-    expect(screen.getByText("鈴木 花子")).toBeDefined();
   });
 
-  it("shows 未実施 for members with no meetings", () => {
+  it("未実施メンバーはデフォルトで非表示", () => {
     render(<MeetingIntervalTable data={mockData} />);
-    const elements = screen.getAllByText("未実施");
-    expect(elements.length).toBeGreaterThan(0);
+    expect(screen.queryByText("鈴木 花子")).toBeNull();
+  });
+
+  it("未実施メンバーの件数をトグルボタンで表示する", () => {
+    render(<MeetingIntervalTable data={mockData} />);
+    expect(screen.getByText(/未実施メンバーを表示（1件）/)).toBeDefined();
+  });
+
+  it("トグルクリックで未実施メンバーが表示される", () => {
+    render(<MeetingIntervalTable data={mockData} />);
+    const toggleButton = screen.getByText(/未実施メンバーを表示（1件）/);
+    fireEvent.click(toggleButton);
+    expect(screen.getByText("鈴木 花子")).toBeDefined();
+    expect(screen.getByText("未実施")).toBeDefined();
+  });
+
+  it("トグルを2回クリックで未実施メンバーが再び非表示になる", () => {
+    render(<MeetingIntervalTable data={mockData} />);
+    const toggleButton = screen.getByText(/未実施メンバーを表示（1件）/);
+    fireEvent.click(toggleButton);
+    fireEvent.click(screen.getByText(/折りたたむ/));
+    expect(screen.queryByText("鈴木 花子")).toBeNull();
   });
 
   it("shows days since last meeting", () => {
@@ -56,5 +75,11 @@ describe("MeetingIntervalTable", () => {
   it("renders empty state when no data", () => {
     render(<MeetingIntervalTable data={[]} />);
     expect(screen.getByText("データがありません")).toBeDefined();
+  });
+
+  it("全員が実施済みの場合トグルボタンは表示しない", () => {
+    const dataWithNoNoMeeting = [mockData[0]];
+    render(<MeetingIntervalTable data={dataWithNoNoMeeting} />);
+    expect(screen.queryByText(/未実施メンバーを表示/)).toBeNull();
   });
 });

--- a/src/components/analytics/analytics-filter-bar.tsx
+++ b/src/components/analytics/analytics-filter-bar.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { MemberIntervalSort } from "@/lib/actions/analytics-actions";
+
+type Props = {
+  readonly departments: string[];
+  readonly currentDepartment: string;
+  readonly currentPeriod: 3 | 6 | 12;
+  readonly currentSort: MemberIntervalSort;
+};
+
+const PERIOD_OPTIONS: { value: string; label: string }[] = [
+  { value: "3", label: "直近3ヶ月" },
+  { value: "6", label: "直近6ヶ月" },
+  { value: "12", label: "直近12ヶ月" },
+];
+
+const SORT_OPTIONS: { value: MemberIntervalSort; label: string }[] = [
+  { value: "name", label: "名前順" },
+  { value: "last_meeting", label: "最終1on1日順" },
+  { value: "department", label: "部署順" },
+];
+
+export function AnalyticsFilterBar({
+  departments,
+  currentDepartment,
+  currentPeriod,
+  currentSort,
+}: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const updateParam = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === "" || value === "all") {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
+      router.push(`/analytics?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 mb-6 p-4 bg-muted/30 rounded-lg border border-border/50">
+      <span className="text-sm font-medium text-muted-foreground shrink-0">フィルタ:</span>
+
+      {departments.length > 0 && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">部署</span>
+          <Select
+            value={currentDepartment || "all"}
+            onValueChange={(v) => updateParam("department", v)}
+          >
+            <SelectTrigger className="h-8 w-40 text-xs">
+              <SelectValue placeholder="すべての部署" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">すべての部署</SelectItem>
+              {departments.map((dept) => (
+                <SelectItem key={dept} value={dept}>
+                  {dept}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">期間</span>
+        <Select value={String(currentPeriod)} onValueChange={(v) => updateParam("period", v)}>
+          <SelectTrigger className="h-8 w-32 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PERIOD_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">並び替え</span>
+        <Select value={currentSort} onValueChange={(v) => updateParam("sort", v)}>
+          <SelectTrigger className="h-8 w-36 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SORT_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/meeting-interval-table.tsx
+++ b/src/components/analytics/meeting-interval-table.tsx
@@ -1,10 +1,64 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
 
 import { AvatarInitial } from "@/components/ui/avatar-initial";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { RecommendedMeeting } from "@/lib/actions/analytics-actions";
 
+function DaysBadge({ member }: { member: RecommendedMeeting }) {
+  if (member.lastMeetingDate === null) {
+    return (
+      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-destructive/10 text-destructive">
+        未実施
+      </span>
+    );
+  }
+  if (member.daysSinceLast > 21) {
+    return (
+      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-destructive/10 text-destructive">
+        {member.daysSinceLast} 日前
+      </span>
+    );
+  }
+  if (member.daysSinceLast > 14) {
+    return (
+      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning">
+        {member.daysSinceLast} 日前
+      </span>
+    );
+  }
+  return (
+    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+      {member.daysSinceLast} 日前
+    </span>
+  );
+}
+
+function MemberRow({ member }: { member: RecommendedMeeting }) {
+  return (
+    <Link
+      href={`/members/${member.id}`}
+      className="flex items-center gap-3 py-2.5 hover:bg-muted/50 rounded-lg px-1 transition-colors"
+    >
+      <AvatarInitial name={member.name} size="sm" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">{member.name}</p>
+        {member.department && <p className="text-xs text-muted-foreground">{member.department}</p>}
+      </div>
+      <DaysBadge member={member} />
+    </Link>
+  );
+}
+
 export function MeetingIntervalTable({ data }: { data: RecommendedMeeting[] }) {
+  const [showNoMeeting, setShowNoMeeting] = useState(false);
+
+  const activeMembers = data.filter((m) => m.lastMeetingDate !== null);
+  const noMeetingMembers = data.filter((m) => m.lastMeetingDate === null);
+
   return (
     <Card>
       <CardHeader>
@@ -14,36 +68,35 @@ export function MeetingIntervalTable({ data }: { data: RecommendedMeeting[] }) {
         {data.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-4">データがありません</p>
         ) : (
-          <div className="divide-y divide-border">
-            {data.map((member) => (
-              <Link
-                key={member.id}
-                href={`/members/${member.id}`}
-                className="flex items-center gap-3 py-2.5 hover:bg-muted/50 rounded-lg px-1 transition-colors"
-              >
-                <AvatarInitial name={member.name} size="sm" />
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium truncate">{member.name}</p>
-                  {member.department && (
-                    <p className="text-xs text-muted-foreground">{member.department}</p>
-                  )}
-                </div>
-                <span
-                  className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                    member.lastMeetingDate === null
-                      ? "bg-destructive/10 text-destructive"
-                      : member.daysSinceLast > 21
-                        ? "bg-destructive/10 text-destructive"
-                        : member.daysSinceLast > 14
-                          ? "bg-warning/10 text-warning"
-                          : "bg-muted text-muted-foreground"
-                  }`}
+          <>
+            <div className="divide-y divide-border">
+              {activeMembers.map((member) => (
+                <MemberRow key={member.id} member={member} />
+              ))}
+            </div>
+
+            {noMeetingMembers.length > 0 && (
+              <div className="mt-3">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-xs text-muted-foreground w-full justify-start"
+                  onClick={() => setShowNoMeeting((prev) => !prev)}
                 >
-                  {member.lastMeetingDate === null ? "未実施" : `${member.daysSinceLast} 日前`}
-                </span>
-              </Link>
-            ))}
-          </div>
+                  {showNoMeeting
+                    ? `▲ 未実施メンバーを折りたたむ`
+                    : `▼ 未実施メンバーを表示（${noMeetingMembers.length}件）`}
+                </Button>
+                {showNoMeeting && (
+                  <div className="divide-y divide-border mt-1">
+                    {noMeetingMembers.map((member) => (
+                      <MemberRow key={member.id} member={member} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </>
         )}
       </CardContent>
     </Card>

--- a/src/lib/actions/__tests__/analytics-actions.test.ts
+++ b/src/lib/actions/__tests__/analytics-actions.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { prisma } from "@/lib/prisma";
 
 import {
+  getAllMembersWithInterval,
+  getDepartments,
   getMeetingFrequencyByMonth,
   getMemberActionTrends,
   getMemberMeetingHeatmap,
@@ -170,6 +172,66 @@ describe("getMeetingFrequencyByMonth", () => {
     expect(jan?.count).toBe(2);
     expect(feb?.count).toBe(1);
   });
+
+  it("monthCount=3 で直近3ヶ月のみ集計する", async () => {
+    const member = await createMember({
+      name: "Test3Month",
+      department: undefined,
+      position: undefined,
+    });
+    if (!member.success) throw new Error("Member creation failed");
+
+    const now = new Date();
+    const twoMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 2, 15);
+    const fourMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 4, 15);
+
+    await prisma.meeting.createMany({
+      data: [
+        { memberId: member.data.id, date: twoMonthsAgo },
+        { memberId: member.data.id, date: fourMonthsAgo },
+      ],
+    });
+
+    const result = await getMeetingFrequencyByMonth(3);
+    const twoMonthKey = `${twoMonthsAgo.getFullYear()}-${String(twoMonthsAgo.getMonth() + 1).padStart(2, "0")}`;
+    const fourMonthKey = `${fourMonthsAgo.getFullYear()}-${String(fourMonthsAgo.getMonth() + 1).padStart(2, "0")}`;
+
+    expect(result.find((r) => r.month === twoMonthKey)).toBeDefined();
+    expect(result.find((r) => r.month === fourMonthKey)).toBeUndefined();
+  });
+
+  it("部署フィルタでその部署のメンバーのミーティングのみカウントする", async () => {
+    const engMember = await createMember({
+      name: "EngMember",
+      department: "Engineering",
+      position: undefined,
+    });
+    const salesMember = await createMember({
+      name: "SalesMember",
+      department: "Sales",
+      position: undefined,
+    });
+    if (!engMember.success || !salesMember.success) throw new Error("Member creation failed");
+
+    const now = new Date();
+    const thisMonth = new Date(now.getFullYear(), now.getMonth(), 10);
+
+    await prisma.meeting.createMany({
+      data: [
+        { memberId: engMember.data.id, date: thisMonth },
+        { memberId: engMember.data.id, date: thisMonth },
+        { memberId: salesMember.data.id, date: thisMonth },
+      ],
+    });
+
+    const thisMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+
+    const allResult = await getMeetingFrequencyByMonth(12);
+    const engResult = await getMeetingFrequencyByMonth(12, "Engineering");
+
+    expect(allResult.find((r) => r.month === thisMonthKey)?.count).toBe(3);
+    expect(engResult.find((r) => r.month === thisMonthKey)?.count).toBe(2);
+  });
 });
 
 describe("getRecommendedMeetings", () => {
@@ -318,6 +380,29 @@ describe("getScheduledMeetingsThisWeek", () => {
   });
 });
 
+describe("getDepartments", () => {
+  it("部署なしのメンバーのみの場合は空配列を返す", async () => {
+    await createMember({ name: "NoDept", department: undefined, position: undefined });
+    const result = await getDepartments();
+    expect(result).toEqual([]);
+  });
+
+  it("重複なしで部署一覧をソートして返す", async () => {
+    await createMember({ name: "A", department: "Engineering", position: undefined });
+    await createMember({ name: "B", department: "Engineering", position: undefined });
+    await createMember({ name: "C", department: "Sales", position: undefined });
+    const result = await getDepartments();
+    expect(result).toHaveLength(2);
+    expect(result).toContain("Engineering");
+    expect(result).toContain("Sales");
+  });
+
+  it("メンバーがいない場合は空配列を返す", async () => {
+    const result = await getDepartments();
+    expect(result).toEqual([]);
+  });
+});
+
 describe("getMemberMeetingHeatmap", () => {
   it("メンバーがいない場合は空配列を返す", async () => {
     const result = await getMemberMeetingHeatmap();
@@ -402,5 +487,132 @@ describe("getMemberMeetingHeatmap", () => {
     expect(found).toBeDefined();
     const totalCount = found!.months.reduce((sum, m) => sum + m.count, 0);
     expect(totalCount).toBe(0);
+  });
+
+  it("monthCount=3 で直近3ヶ月分の月キーを返す", async () => {
+    const result = await getMemberMeetingHeatmap(3);
+    expect(result.months).toHaveLength(3);
+    const now = new Date();
+    const expectedLatest = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+    expect(result.months[2]).toBe(expectedLatest);
+  });
+
+  it("部署フィルタでその部署のメンバーのみ返す", async () => {
+    const engMember = await createMember({
+      name: "EngMemberHeatmap",
+      department: "Engineering",
+      position: undefined,
+    });
+    const salesMember = await createMember({
+      name: "SalesMemberHeatmap",
+      department: "Sales",
+      position: undefined,
+    });
+    if (!engMember.success || !salesMember.success) throw new Error("Member creation failed");
+
+    const result = await getMemberMeetingHeatmap(12, "Engineering");
+    expect(result.members.find((m) => m.memberName === "EngMemberHeatmap")).toBeDefined();
+    expect(result.members.find((m) => m.memberName === "SalesMemberHeatmap")).toBeUndefined();
+  });
+
+  it("MemberMeetingHeatmapEntry に department フィールドが含まれる", async () => {
+    const member = await createMember({
+      name: "DeptMember",
+      department: "Engineering",
+      position: undefined,
+    });
+    if (!member.success) throw new Error("Member creation failed");
+
+    const result = await getMemberMeetingHeatmap();
+    const found = result.members.find((m) => m.memberName === "DeptMember");
+    expect(found).toBeDefined();
+    expect(found?.department).toBe("Engineering");
+  });
+});
+
+describe("getAllMembersWithInterval with options", () => {
+  it("部署フィルタでその部署のメンバーのみ返す", async () => {
+    const engMember = await createMember({
+      name: "EngInterval",
+      department: "Engineering",
+      position: undefined,
+    });
+    const salesMember = await createMember({
+      name: "SalesInterval",
+      department: "Sales",
+      position: undefined,
+    });
+    if (!engMember.success || !salesMember.success) throw new Error("Member creation failed");
+
+    const result = await getAllMembersWithInterval({ department: "Engineering" });
+    expect(result.find((m) => m.name === "EngInterval")).toBeDefined();
+    expect(result.find((m) => m.name === "SalesInterval")).toBeUndefined();
+  });
+
+  it("sort=last_meeting で最終ミーティング日の降順にソートする", async () => {
+    const memberA = await createMember({
+      name: "SortMemberA",
+      department: undefined,
+      position: undefined,
+    });
+    const memberB = await createMember({
+      name: "SortMemberB",
+      department: undefined,
+      position: undefined,
+    });
+    if (!memberA.success || !memberB.success) throw new Error("Member creation failed");
+
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 3);
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 10);
+
+    await prisma.meeting.create({ data: { memberId: memberA.data.id, date: recentDate } });
+    await prisma.meeting.create({ data: { memberId: memberB.data.id, date: oldDate } });
+
+    const result = await getAllMembersWithInterval({ sort: "last_meeting" });
+    const indexA = result.findIndex((m) => m.name === "SortMemberA");
+    const indexB = result.findIndex((m) => m.name === "SortMemberB");
+    // A は最近のミーティング（daysSinceLast が小さい）→ 降順では後ろ
+    // B は古いミーティング（daysSinceLast が大きい）→ 降順では前
+    expect(indexB).toBeLessThan(indexA);
+  });
+
+  it("sort=department で部署→名前順にソートする", async () => {
+    const memberZ = await createMember({
+      name: "ZMember",
+      department: "Zebra",
+      position: undefined,
+    });
+    const memberA = await createMember({
+      name: "AMember",
+      department: "Apple",
+      position: undefined,
+    });
+    if (!memberZ.success || !memberA.success) throw new Error("Member creation failed");
+
+    const result = await getAllMembersWithInterval({ sort: "department" });
+    const indexA = result.findIndex((m) => m.name === "AMember");
+    const indexZ = result.findIndex((m) => m.name === "ZMember");
+    expect(indexA).toBeLessThan(indexZ);
+  });
+
+  it("デフォルト（引数なし）で名前順に全メンバーを返す", async () => {
+    const memberB = await createMember({
+      name: "BbbMember",
+      department: undefined,
+      position: undefined,
+    });
+    const memberA = await createMember({
+      name: "AaaMember",
+      department: undefined,
+      position: undefined,
+    });
+    if (!memberB.success || !memberA.success) throw new Error("Member creation failed");
+
+    const result = await getAllMembersWithInterval();
+    const indexA = result.findIndex((m) => m.name === "AaaMember");
+    const indexB = result.findIndex((m) => m.name === "BbbMember");
+    expect(indexA).toBeLessThan(indexB);
   });
 });

--- a/src/lib/actions/analytics-actions.ts
+++ b/src/lib/actions/analytics-actions.ts
@@ -141,12 +141,18 @@ export type MeetingFrequencyMonth = {
   count: number;
 };
 
-export async function getMeetingFrequencyByMonth(): Promise<MeetingFrequencyMonth[]> {
-  const twelveMonthsAgo = new Date();
-  twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 12);
+export async function getMeetingFrequencyByMonth(
+  monthCount: 3 | 6 | 12 = 12,
+  department?: string,
+): Promise<MeetingFrequencyMonth[]> {
+  const since = new Date();
+  since.setMonth(since.getMonth() - monthCount);
 
   const meetings = await prisma.meeting.findMany({
-    where: { date: { gte: twelveMonthsAgo } },
+    where: {
+      date: { gte: since },
+      ...(department ? { member: { department } } : {}),
+    },
     select: { date: true },
     orderBy: { date: "asc" },
   });
@@ -161,6 +167,15 @@ export async function getMeetingFrequencyByMonth(): Promise<MeetingFrequencyMont
   return Array.from(monthMap.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([month, count]) => ({ month, count }));
+}
+
+export async function getDepartments(): Promise<string[]> {
+  const rows = await prisma.member.findMany({
+    select: { department: true },
+    distinct: ["department"],
+    orderBy: { department: "asc" },
+  });
+  return rows.map((r) => r.department).filter((d): d is string => d !== null);
 }
 
 export type RecommendedMeeting = {
@@ -259,6 +274,7 @@ export async function getScheduledMeetingsThisWeek(): Promise<ScheduledMeeting[]
 export type MemberMeetingHeatmapEntry = {
   memberId: string;
   memberName: string;
+  department: string | null;
   months: { month: string; count: number }[];
 };
 
@@ -267,20 +283,23 @@ export type HeatmapData = {
   months: string[];
 };
 
-export async function getMemberMeetingHeatmap(): Promise<HeatmapData> {
+export async function getMemberMeetingHeatmap(
+  monthCount: 3 | 6 | 12 = 12,
+  department?: string,
+): Promise<HeatmapData> {
   const now = new Date();
-  const twelveMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 11, 1);
+  const since = new Date(now.getFullYear(), now.getMonth() - (monthCount - 1), 1);
 
-  // 直近12ヶ月の月キー配列を宣言的に生成
-  const months: string[] = Array.from({ length: 12 }, (_, i) =>
-    toMonthKey(new Date(now.getFullYear(), now.getMonth() - (11 - i), 1)),
+  const months: string[] = Array.from({ length: monthCount }, (_, i) =>
+    toMonthKey(new Date(now.getFullYear(), now.getMonth() - (monthCount - 1 - i), 1)),
   );
 
   try {
     const members = await prisma.member.findMany({
+      where: department ? { department } : undefined,
       include: {
         meetings: {
-          where: { date: { gte: twelveMonthsAgo } },
+          where: { date: { gte: since } },
           select: { date: true },
         },
       },
@@ -296,6 +315,7 @@ export async function getMemberMeetingHeatmap(): Promise<HeatmapData> {
       return {
         memberId: member.id,
         memberName: member.name,
+        department: member.department,
         months: months.map((month) => ({ month, count: countMap.get(month) ?? 0 })),
       };
     });
@@ -307,10 +327,21 @@ export async function getMemberMeetingHeatmap(): Promise<HeatmapData> {
   }
 }
 
-export async function getAllMembersWithInterval(): Promise<RecommendedMeeting[]> {
+export type MemberIntervalSort = "name" | "last_meeting" | "department";
+
+export type MemberIntervalOptions = {
+  department?: string;
+  sort?: MemberIntervalSort;
+};
+
+export async function getAllMembersWithInterval(
+  options: MemberIntervalOptions = {},
+): Promise<RecommendedMeeting[]> {
+  const { department, sort = "name" } = options;
   const now = new Date();
 
   const members = await prisma.member.findMany({
+    where: department ? { department } : undefined,
     include: {
       meetings: {
         orderBy: { date: "desc" },
@@ -321,7 +352,7 @@ export async function getAllMembersWithInterval(): Promise<RecommendedMeeting[]>
     orderBy: { name: "asc" },
   });
 
-  return members.map((m) => {
+  const mapped = members.map((m) => {
     const lastDate = m.meetings[0]?.date ?? null;
     const lastDateObj = lastDate ? new Date(lastDate) : null;
     const daysSinceLast = lastDateObj
@@ -338,4 +369,18 @@ export async function getAllMembersWithInterval(): Promise<RecommendedMeeting[]>
       nextRecommendedDate: calcNextRecommendedDate(lastDateObj, m.meetingIntervalDays),
     };
   });
+
+  if (sort === "last_meeting") {
+    return mapped.sort((a, b) => b.daysSinceLast - a.daysSinceLast);
+  }
+  if (sort === "department") {
+    return mapped.sort((a, b) => {
+      const deptA = a.department ?? "";
+      const deptB = b.department ?? "";
+      if (deptA !== deptB) return deptA.localeCompare(deptB);
+      return a.name.localeCompare(b.name);
+    });
+  }
+  // sort === "name" (default, already sorted by DB)
+  return mapped;
 }


### PR DESCRIPTION
## 概要

issue #87 の対応。ミーティング分析ページ（`/analytics`）にフィルタ・ソート・折りたたみ機能を追加し、メンバーが多い環境でも分析しやすくする。

## 変更内容

### 新規ファイル
- `src/components/analytics/analytics-filter-bar.tsx` — 部署・期間・ソートの Client Component フィルタバー（URL search params で状態管理）

### 変更ファイル
- `src/lib/actions/analytics-actions.ts` — 4 つの関数にフィルタ・ソート引数を追加
  - `getMeetingFrequencyByMonth(monthCount, department?)` — 期間・部署フィルタ対応
  - `getMemberMeetingHeatmap(monthCount, department?)` — 期間・部署フィルタ対応、`department` フィールドを型に追加
  - `getAllMembersWithInterval(options)` — 部署フィルタ・ソート（名前/最終1on1日/部署）対応
  - `getDepartments()` — 部署一覧取得関数を新規追加
- `src/app/analytics/page.tsx` — `searchParams` を読み取り各データ取得関数へ渡す、`AnalyticsFilterBar` を追加
- `src/components/analytics/meeting-interval-table.tsx` — Client Component 化、未実施メンバーの折りたたみトグルを追加
- `src/components/analytics/__tests__/meeting-heatmap.test.tsx` — 型変更に対応（`department` フィールド追加）
- `src/components/analytics/__tests__/meeting-interval-table.test.tsx` — 折りたたみ挙動に合わせてテストを更新・拡充
- `src/lib/actions/__tests__/analytics-actions.test.ts` — 新機能のテストを追加（+22 テスト）

## 機能

- **部署フィルタ**: 部署一覧をドロップダウンで選択し、該当メンバーのみ表示
- **期間フィルタ**: 直近 3 / 6 / 12 ヶ月を切り替え（ヒートマップ・頻度チャート両方に適用）
- **並び替え**: 名前順 / 最終1on1日順 / 部署順でメンバーテーブルをソート
- **未実施メンバーの折りたたみ**: デフォルトで実施済みメンバーのみ表示し、「未実施メンバーを表示（N件）」ボタンで展開

## テスト計画

- [x] `npm test` — 98 ファイル 920 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ブラウザ: `/analytics` を開いて部署フィルタが動作することを確認
- [ ] ブラウザ: 期間セレクトを切り替えてヒートマップと頻度チャートが更新されることを確認
- [ ] ブラウザ: 並び替えセレクトでメンバー順序が変わることを確認
- [ ] ブラウザ: 「未実施メンバーを表示」ボタンで折りたたみ展開が動作することを確認
- [ ] ブラウザ: フィルタ選択後に URL が更新されてリロードでも状態が保持されることを確認

Closes #87