### PR TITLE
feat: ミーティング詳細ページにアクションアイテム直接追加機能を追加する (issue #89)

### DIFF
--- a/src/components/action/__tests__/action-list-compact.test.tsx
+++ b/src/components/action/__tests__/action-list-compact.test.tsx
@@ -25,10 +25,12 @@ vi.mock("sonner", () => ({
 
 const mockUpdateActionItemStatus = vi.fn();
 const mockUpdateActionItem = vi.fn();
+const mockCreateActionItemForMeeting = vi.fn();
 
 vi.mock("@/lib/actions/action-item-actions", () => ({
   updateActionItemStatus: (...args: unknown[]) => mockUpdateActionItemStatus(...args),
   updateActionItem: (...args: unknown[]) => mockUpdateActionItem(...args),
+  createActionItemForMeeting: (...args: unknown[]) => mockCreateActionItemForMeeting(...args),
 }));
 
 afterEach(() => {
@@ -211,6 +213,95 @@ describe("ActionListCompact", () => {
     const saveBtn = screen.getByRole("button", { name: /保存/ });
     await user.click(saveBtn);
     expect(toast.error).toHaveBeenCalledWith(TOAST_MESSAGES.actionItem.updateError);
+  });
+
+  describe("アクション追加フォーム", () => {
+    it("meetingId が指定されたとき追加ボタンが表示される", () => {
+      render(
+        <ActionListCompact actionItems={baseItems} meetingId="meeting-1" memberId="member-1" />,
+      );
+      expect(screen.getByRole("button", { name: /アクション追加/ })).toBeDefined();
+    });
+
+    it("meetingId が指定されないとき追加ボタンが表示されない", () => {
+      render(<ActionListCompact actionItems={baseItems} />);
+      expect(screen.queryByRole("button", { name: /アクション追加/ })).toBeNull();
+    });
+
+    it("追加ボタンクリックでインラインフォームが表示される", async () => {
+      const user = userEvent.setup();
+      render(
+        <ActionListCompact actionItems={baseItems} meetingId="meeting-1" memberId="member-1" />,
+      );
+      await user.click(screen.getByRole("button", { name: /アクション追加/ }));
+      expect(screen.getByPlaceholderText("アクションのタイトル")).toBeDefined();
+    });
+
+    it("タイトルが空の場合、保存ボタンが無効になる", async () => {
+      const user = userEvent.setup();
+      render(
+        <ActionListCompact actionItems={baseItems} meetingId="meeting-1" memberId="member-1" />,
+      );
+      await user.click(screen.getByRole("button", { name: /アクション追加/ }));
+      const addBtn = screen.getByRole("button", { name: /追加/ });
+      expect(addBtn).toHaveProperty("disabled", true);
+    });
+
+    it("保存ボタンクリックで createActionItemForMeeting が呼ばれる", async () => {
+      const user = userEvent.setup();
+      mockCreateActionItemForMeeting.mockResolvedValue({ success: true, data: {} });
+      render(
+        <ActionListCompact actionItems={baseItems} meetingId="meeting-1" memberId="member-1" />,
+      );
+      await user.click(screen.getByRole("button", { name: /アクション追加/ }));
+      await user.type(screen.getByPlaceholderText("アクションのタイトル"), "新しいタスク");
+      await user.click(screen.getByRole("button", { name: /追加/ }));
+      expect(mockCreateActionItemForMeeting).toHaveBeenCalledWith(
+        "meeting-1",
+        "member-1",
+        expect.objectContaining({ title: "新しいタスク" }),
+      );
+    });
+
+    it("追加成功時にトーストが表示される", async () => {
+      const user = userEvent.setup();
+      mockCreateActionItemForMeeting.mockResolvedValue({ success: true, data: {} });
+      render(
+        <ActionListCompact actionItems={baseItems} meetingId="meeting-1" memberId="member-1" />,
+      );
+      await user.click(screen.getByRole("button", { name: /アクション追加/ }));
+      await user.type(screen.getByPlaceholderText("アクションのタイトル"), "新しいタスク");
+      await user.click(screen.getByRole("button", { name: /追加/ }));
+      expect(toast.success).toHaveBeenCalledWith(TOAST_MESSAGES.actionItem.createSuccess);
+    });
+
+    it("追加失敗時にエラートーストが表示される", async () => {
+      const user = userEvent.setup();
+      mockCreateActionItemForMeeting.mockResolvedValue({ success: false, error: "Error" });
+      render(
+        <ActionListCompact actionItems={baseItems} meetingId="meeting-1" memberId="member-1" />,
+      );
+      await user.click(screen.getByRole("button", { name: /アクション追加/ }));
+      await user.type(screen.getByPlaceholderText("アクションのタイトル"), "新しいタスク");
+      await user.click(screen.getByRole("button", { name: /追加/ }));
+      expect(toast.error).toHaveBeenCalledWith(TOAST_MESSAGES.actionItem.createError);
+    });
+
+    it("キャンセルボタンでフォームが閉じる", async () => {
+      const user = userEvent.setup();
+      render(
+        <ActionListCompact actionItems={baseItems} meetingId="meeting-1" memberId="member-1" />,
+      );
+      await user.click(screen.getByRole("button", { name: /アクション追加/ }));
+      expect(screen.getByPlaceholderText("アクションのタイトル")).toBeDefined();
+      await user.click(screen.getByRole("button", { name: /キャンセル/ }));
+      expect(screen.queryByPlaceholderText("アクションのタイトル")).toBeNull();
+    });
+
+    it("アイテムが空のとき meetingId があれば追加ボタンが表示される", () => {
+      render(<ActionListCompact actionItems={[]} meetingId="meeting-1" memberId="member-1" />);
+      expect(screen.getByRole("button", { name: /アクション追加/ })).toBeDefined();
+    });
   });
 
   describe("期限日バッジ", () => {

--- a/src/components/action/action-list-compact.tsx
+++ b/src/components/action/action-list-compact.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil, SquareCheck } from "lucide-react";
+import { Pencil, Plus, SquareCheck } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useOptimistic, useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -11,7 +11,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
-import { updateActionItem, updateActionItemStatus } from "@/lib/actions/action-item-actions";
+import {
+  createActionItemForMeeting,
+  updateActionItem,
+  updateActionItemStatus,
+} from "@/lib/actions/action-item-actions";
 import { TOAST_MESSAGES } from "@/lib/toast-messages";
 
 type TagData = {
@@ -36,7 +40,16 @@ type EditFormState = {
   dueDate: string;
 };
 
-type Props = { actionItems: ActionItemRow[] };
+type AddFormState = {
+  title: string;
+  dueDate: string;
+};
+
+type Props = {
+  actionItems: ActionItemRow[];
+  meetingId?: string;
+  memberId?: string;
+};
 
 const statusLabels: Record<string, string> = {
   TODO: "未着手",
@@ -53,7 +66,7 @@ function nextStatus(current: string): string {
   return current === "TODO" ? "IN_PROGRESS" : current === "IN_PROGRESS" ? "DONE" : "TODO";
 }
 
-export function ActionListCompact({ actionItems }: Props) {
+export function ActionListCompact({ actionItems, meetingId, memberId }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -62,13 +75,17 @@ export function ActionListCompact({ actionItems }: Props) {
     description: "",
     dueDate: "",
   });
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addForm, setAddForm] = useState<AddFormState>({ title: "", dueDate: "" });
   const [optimisticItems, setOptimisticItems] = useOptimistic(
     actionItems,
     (currentItems, { id, status }: { id: string; status: string }) =>
       currentItems.map((item) => (item.id === id ? { ...item, status } : item)),
   );
 
-  if (actionItems.length === 0) {
+  const canAdd = Boolean(meetingId && memberId);
+
+  if (actionItems.length === 0 && !canAdd) {
     return <EmptyState icon={SquareCheck} title="アクションアイテムはありません" size="compact" />;
   }
 
@@ -115,8 +132,35 @@ export function ActionListCompact({ actionItems }: Props) {
     });
   }
 
+  function handleAddSave() {
+    if (!meetingId || !memberId) return;
+    startTransition(async () => {
+      const result = await createActionItemForMeeting(meetingId, memberId, {
+        title: addForm.title,
+        description: "",
+        dueDate: addForm.dueDate || undefined,
+      });
+      if (result.success) {
+        toast.success(TOAST_MESSAGES.actionItem.createSuccess);
+        setShowAddForm(false);
+        setAddForm({ title: "", dueDate: "" });
+        router.refresh();
+      } else {
+        toast.error(TOAST_MESSAGES.actionItem.createError);
+      }
+    });
+  }
+
+  function handleAddCancel() {
+    setShowAddForm(false);
+    setAddForm({ title: "", dueDate: "" });
+  }
+
   return (
     <div className={`flex flex-col gap-2 ${isPending ? "opacity-80" : ""}`}>
+      {optimisticItems.length === 0 && canAdd && !showAddForm && (
+        <p className="text-sm text-muted-foreground">アクションアイテムはありません</p>
+      )}
       {optimisticItems.map((item) =>
         editingId === item.id ? (
           <div key={item.id} className="flex flex-col gap-2 p-2 border rounded">
@@ -181,6 +225,44 @@ export function ActionListCompact({ actionItems }: Props) {
             </div>
           </div>
         ),
+      )}
+      {showAddForm && (
+        <div className="flex flex-col gap-2 p-2 border rounded animate-fade-in-up">
+          <div className="flex flex-col gap-2">
+            <Input
+              value={addForm.title}
+              onChange={(e) => setAddForm({ ...addForm, title: e.target.value })}
+              placeholder="アクションのタイトル"
+              autoFocus
+            />
+            <Input
+              type="date"
+              value={addForm.dueDate}
+              onChange={(e) => setAddForm({ ...addForm, dueDate: e.target.value })}
+            />
+          </div>
+          <div className="flex gap-2 justify-end">
+            <Button variant="outline" size="sm" onClick={handleAddCancel}>
+              キャンセル
+            </Button>
+            <Button size="sm" onClick={handleAddSave} disabled={!addForm.title.trim()}>
+              追加
+            </Button>
+          </div>
+        </div>
+      )}
+      {canAdd && !showAddForm && (
+        <div className="flex justify-end mt-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowAddForm(true)}
+            aria-label="アクション追加"
+          >
+            <Plus className="w-4 h-4 mr-1" />
+            アクション追加
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/src/components/meeting/__tests__/meeting-detail.test.tsx
+++ b/src/components/meeting/__tests__/meeting-detail.test.tsx
@@ -16,6 +16,8 @@ vi.mock("@/lib/mood", () => ({
 }));
 
 const baseProps = {
+  meetingId: "meeting-1",
+  memberId: "member-1",
   date: new Date("2026-02-20T10:00:00.000Z"),
   topics: [
     {

--- a/src/components/meeting/meeting-detail-page-client.tsx
+++ b/src/components/meeting/meeting-detail-page-client.tsx
@@ -179,6 +179,8 @@ export function MeetingDetailPageClient({
         </Button>
       </div>
       <MeetingDetail
+        meetingId={meetingId}
+        memberId={memberId}
         date={date}
         mood={mood}
         conditionHealth={conditionHealth}

--- a/src/components/meeting/meeting-detail.tsx
+++ b/src/components/meeting/meeting-detail.tsx
@@ -26,6 +26,8 @@ type ActionItem = {
 };
 
 type Props = {
+  meetingId: string;
+  memberId: string;
   date: Date;
   mood?: number | null;
   conditionHealth?: number | null;
@@ -39,6 +41,8 @@ type Props = {
 };
 
 export function MeetingDetail({
+  meetingId,
+  memberId,
   date,
   mood,
   conditionHealth,
@@ -143,6 +147,8 @@ export function MeetingDetail({
             ...a,
             meeting: { date: a.meeting.date },
           }))}
+          meetingId={meetingId}
+          memberId={memberId}
         />
       </div>
     </div>

--- a/src/lib/actions/__tests__/action-item-actions.test.ts
+++ b/src/lib/actions/__tests__/action-item-actions.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { prisma } from "@/lib/prisma";
 
 import {
+  createActionItemForMeeting,
   getActionItems,
   getPendingActionItems,
   updateActionItem,
@@ -12,6 +13,7 @@ import { createMeeting } from "../meeting-actions";
 import { createMember } from "../member-actions";
 
 let memberId: string;
+let meetingId: string;
 
 beforeEach(async () => {
   await prisma.actionItem.deleteMany();
@@ -21,6 +23,14 @@ beforeEach(async () => {
   const result = await createMember({ name: "Test Member" });
   if (!result.success) throw new Error(result.error);
   memberId = result.data.id;
+  const meetingResult = await createMeeting({
+    memberId,
+    date: new Date().toISOString(),
+    topics: [],
+    actionItems: [],
+  });
+  if (!meetingResult.success) throw new Error(meetingResult.error);
+  meetingId = meetingResult.data.id;
 });
 
 describe("getActionItems", () => {
@@ -229,5 +239,52 @@ describe("updateActionItem", () => {
       description: "",
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("createActionItemForMeeting", () => {
+  it("アクションアイテムを追加できる", async () => {
+    const result = await createActionItemForMeeting(meetingId, memberId, {
+      title: "新しいアクション",
+      description: "",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.title).toBe("新しいアクション");
+    expect(result.data.meetingId).toBe(meetingId);
+    expect(result.data.memberId).toBe(memberId);
+  });
+
+  it("期限日を設定できる", async () => {
+    const result = await createActionItemForMeeting(meetingId, memberId, {
+      title: "期限付きアクション",
+      description: "",
+      dueDate: "2026-04-01",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.dueDate).not.toBeNull();
+  });
+
+  it("空のタイトルはバリデーションエラーになる", async () => {
+    const result = await createActionItemForMeeting(meetingId, memberId, {
+      title: "",
+      description: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("sortOrder は既存アイテム数に基づいて設定される", async () => {
+    await createActionItemForMeeting(meetingId, memberId, {
+      title: "アクション1",
+      description: "",
+    });
+    const result = await createActionItemForMeeting(meetingId, memberId, {
+      title: "アクション2",
+      description: "",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.sortOrder).toBe(1);
   });
 });

--- a/src/lib/actions/action-item-actions.ts
+++ b/src/lib/actions/action-item-actions.ts
@@ -128,3 +128,27 @@ export async function updateActionItem(
     return result;
   });
 }
+
+export async function createActionItemForMeeting(
+  meetingId: string,
+  memberId: string,
+  input: UpdateActionItemInput,
+): Promise<ActionResult<ActionItem>> {
+  return runAction(async () => {
+    const validated = updateActionItemSchema.parse(input);
+    const existingCount = await prisma.actionItem.count({ where: { meetingId } });
+    const dueDate = validated.dueDate ? new Date(validated.dueDate) : null;
+    const result = await prisma.actionItem.create({
+      data: {
+        meetingId,
+        memberId,
+        title: validated.title,
+        description: validated.description,
+        sortOrder: existingCount,
+        dueDate,
+      },
+    });
+    revalidatePath("/", "layout");
+    return result;
+  });
+}

--- a/src/lib/toast-messages.ts
+++ b/src/lib/toast-messages.ts
@@ -24,6 +24,8 @@ export const TOAST_MESSAGES = {
     statusChangeError: "ステータスの更新に失敗しました",
     updateSuccess: "アクションアイテムを更新しました",
     updateError: "アクションアイテムの更新に失敗しました",
+    createSuccess: "アクションアイテムを追加しました",
+    createError: "アクションアイテムの追加に失敗しました",
   },
   prepare: {
     topicCopied: "話題をアジェンダにコピーしました",


### PR DESCRIPTION
## 概要

issue #89 の対応。ミーティング詳細ページ（閲覧モード）のアクションアイテムセクションに「+ アクション追加」ボタンを追加し、1on1 終了後でも直接アクションを追加できるようにする。

## 変更内容

### 変更ファイル
- `src/lib/actions/action-item-actions.ts` — `createActionItemForMeeting` Server Action を追加
- `src/lib/toast-messages.ts` — actionItem に `createSuccess` / `createError` メッセージを追加
- `src/components/action/action-list-compact.tsx` — `meetingId` / `memberId` props を追加し、インライン追加フォームを実装
- `src/components/meeting/meeting-detail.tsx` — `meetingId` / `memberId` props を追加して ActionListCompact へ伝播
- `src/components/meeting/meeting-detail-page-client.tsx` — `meetingId` / `memberId` を MeetingDetail へ渡す

### テストファイル
- `src/lib/actions/__tests__/action-item-actions.test.ts` — createActionItemForMeeting のテスト 4 件を追加
- `src/components/action/__tests__/action-list-compact.test.tsx` — 追加フォームのテスト 8 件を追加
- `src/components/meeting/__tests__/meeting-detail.test.tsx` — 新規 props を反映

## 機能

- **インライン追加フォーム**: 「+ アクション追加」ボタンをクリックするとタイトル・期限日の入力フォームがその場で展開される
- **バリデーション**: タイトルが空の場合は保存ボタンを無効化
- **アイテム 0 件時**: `meetingId` が指定されている場合はメッセージ表示 + 追加ボタンを表示（EmptyState は非表示）
- **後方互換性**: `meetingId` / `memberId` は省略可能（他の画面では追加ボタンが表示されない）

## テスト計画

- [x] `npm test` — 98 ファイル 933 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ミーティング詳細ページで「+ アクション追加」ボタンが表示されることを確認
- [ ] ボタンクリックでインラインフォームが展開されることを確認
- [ ] アクション追加後に一覧に即時反映されることを確認
- [ ] タイトル空欄時に保存ボタンが無効になることを確認
- [ ] キャンセルでフォームが閉じることを確認

Closes #89