### PR TITLE
ux: ミーティングフォームに上部保存ボタンを追加する (issue #90)

### DIFF
--- a/src/components/meeting/__tests__/meeting-form.test.tsx
+++ b/src/components/meeting/__tests__/meeting-form.test.tsx
@@ -117,13 +117,34 @@ describe("MeetingForm", () => {
     expect(healthButtons.length).toBeGreaterThan(0);
   });
 
+  it("renders two save buttons (header and footer) in create mode", () => {
+    render(<MeetingForm memberId="m1" />);
+    const saveButtons = screen.getAllByRole("button", { name: "1on1を保存" });
+    expect(saveButtons).toHaveLength(2);
+  });
+
+  it("shows ClosingDialog when header save button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<MeetingForm memberId="m1" />);
+
+    const titleInput = screen.getByPlaceholderText("話題のタイトル");
+    await user.type(titleInput, "テスト話題");
+    // Click header save button (first one)
+    const saveButtons = screen.getAllByRole("button", { name: "1on1を保存" });
+    await user.click(saveButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();
+    });
+  });
+
   it("shows ClosingDialog when form is submitted", async () => {
     const user = userEvent.setup();
     render(<MeetingForm memberId="m1" />);
 
     const titleInput = screen.getByPlaceholderText("話題のタイトル");
     await user.type(titleInput, "テスト話題");
-    await user.click(screen.getByRole("button", { name: "1on1を保存" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を保存" })[0]);
 
     // ClosingDialog should appear
     await waitFor(() => {
@@ -141,7 +162,7 @@ describe("MeetingForm", () => {
 
     const titleInput = screen.getByPlaceholderText("話題のタイトル");
     await user.type(titleInput, "テスト話題");
-    await user.click(screen.getByRole("button", { name: "1on1を保存" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を保存" })[0]);
 
     // Wait for dialog to appear
     await waitFor(() => {
@@ -167,7 +188,7 @@ describe("MeetingForm", () => {
 
     const titleInput = screen.getByPlaceholderText("話題のタイトル");
     await user.type(titleInput, "テスト話題");
-    await user.click(screen.getByRole("button", { name: "1on1を保存" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を保存" })[0]);
 
     await waitFor(() => {
       expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();
@@ -192,7 +213,7 @@ describe("MeetingForm", () => {
 
     const titleInput = screen.getByPlaceholderText("話題のタイトル");
     await user.type(titleInput, "テスト話題");
-    await user.click(screen.getByRole("button", { name: "1on1を保存" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を保存" })[0]);
 
     await waitFor(() => {
       expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();
@@ -260,12 +281,14 @@ describe("MeetingForm (edit mode)", () => {
 
   it("shows update button text in edit mode", () => {
     render(<MeetingForm memberId="m1" initialData={mockInitialData} />);
-    expect(screen.getByRole("button", { name: "1on1を更新" })).toBeTruthy();
+    const updateButtons = screen.getAllByRole("button", { name: "1on1を更新" });
+    expect(updateButtons).toHaveLength(2);
   });
 
   it("shows save button text in create mode", () => {
     render(<MeetingForm memberId="m1" />);
-    expect(screen.getByRole("button", { name: "1on1を保存" })).toBeTruthy();
+    const saveButtons = screen.getAllByRole("button", { name: "1on1を保存" });
+    expect(saveButtons).toHaveLength(2);
   });
 
   it("pre-fills checkinNote from initialData", () => {
@@ -274,10 +297,16 @@ describe("MeetingForm (edit mode)", () => {
     expect(textarea).toHaveProperty("value", "体調良好");
   });
 
+  it("renders two update buttons in edit mode (header and footer)", () => {
+    render(<MeetingForm memberId="m1" initialData={mockInitialData} />);
+    const updateButtons = screen.getAllByRole("button", { name: "1on1を更新" });
+    expect(updateButtons).toHaveLength(2);
+  });
+
   it("shows ClosingDialog when update form is submitted", async () => {
     const user = userEvent.setup();
     render(<MeetingForm memberId="m1" initialData={mockInitialData} />);
-    await user.click(screen.getByRole("button", { name: "1on1を更新" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を更新" })[0]);
 
     await waitFor(() => {
       expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();
@@ -293,7 +322,7 @@ describe("MeetingForm (edit mode)", () => {
     const user = userEvent.setup();
     render(<MeetingForm memberId="m1" initialData={mockInitialData} onSuccess={onSuccess} />);
 
-    await user.click(screen.getByRole("button", { name: "1on1を更新" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を更新" })[0]);
 
     await waitFor(() => {
       expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();
@@ -325,7 +354,7 @@ describe("MeetingForm (edit mode)", () => {
     const user = userEvent.setup();
     render(<MeetingForm memberId="m1" initialData={mockInitialData} onSuccess={onSuccess} />);
 
-    await user.click(screen.getByRole("button", { name: "1on1を更新" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を更新" })[0]);
 
     await waitFor(() => {
       expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();
@@ -348,7 +377,7 @@ describe("MeetingForm (edit mode)", () => {
     const user = userEvent.setup();
     render(<MeetingForm memberId="m1" initialData={mockInitialData} />);
 
-    await user.click(screen.getByRole("button", { name: "1on1を更新" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を更新" })[0]);
 
     await waitFor(() => {
       expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();
@@ -383,7 +412,7 @@ describe("MeetingForm (edit mode)", () => {
     // Find the delete button for topics (not actions)
     await user.click(deleteButtons[1]); // second topic delete button
 
-    await user.click(screen.getByRole("button", { name: "1on1を更新" }));
+    await user.click(screen.getAllByRole("button", { name: "1on1を更新" })[0]);
 
     await waitFor(() => {
       expect(screen.getByText("ミーティングを保存しますか？")).toBeTruthy();

--- a/src/components/meeting/meeting-form.tsx
+++ b/src/components/meeting/meeting-form.tsx
@@ -345,15 +345,26 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
   return (
     <>
       <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="date">日付 *</Label>
-          <Input
-            id="date"
-            type="date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            required
-          />
+        <div className="flex items-end justify-between gap-4">
+          <div className="flex flex-col gap-2 flex-1">
+            <Label htmlFor="date">日付 *</Label>
+            <Input
+              id="date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" variant="outline" disabled={isSubmitting}>
+            {isSubmitting
+              ? isEditing
+                ? "更新中..."
+                : "保存中..."
+              : isEditing
+                ? "1on1を更新"
+                : "1on1を保存"}
+          </Button>
         </div>
 
         <CheckinSection


### PR DESCRIPTION
## 概要

issue #90 の対応。ミーティング記録フォームの日付フィールド行右側に「1on1を保存/更新」ボタンを追加し、フォーム最上部からスクロールなしで保存できるようにした。

## 変更内容

### 変更ファイル

- `src/components/meeting/meeting-form.tsx` — 日付フィールドを `flex justify-between` レイアウトに変更し、右側にヘッダー保存ボタンを追加
- `src/components/meeting/__tests__/meeting-form.test.tsx` — 上部ボタンのテスト2件追加、既存テストを複数ボタン対応に更新（21 → 24件）

## 機能

- **上部保存ボタン**: 日付フィールドの右横に「1on1を保存」（作成時）または「1on1を更新」（編集時）ボタンを配置。フォーム読み込み直後からスクロールなしで保存可能
- **既存スティッキーフッター維持**: 既存の `sticky bottom-0` ボタンはそのまま維持。上部ボタンと合わせて「上部 + 下部スティッキー」の二重アクセスポイントを実現
- **一貫した動作**: どちらのボタンも同じ `handleSubmit` → `ClosingDialog` → `executeSave` フローを経由

## テスト計画

- [x] `npm test` — 1ファイル 24テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ブラウザで `/members/[id]/meetings/new` を開き、上部の保存ボタンが日付フィールド右側に表示されることを確認
- [ ] 上部ボタンクリックで ClosingDialog が表示されること、そのまま保存できることを確認
- [ ] 下部スティッキーボタンも引き続き機能することを確認
- [ ] 編集フォームで「1on1を更新」ボタンが上下両方に表示されることを確認

Closes #90