### PR TITLE
ux: アクション一覧にページネーションを追加する (issue #103)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 
 import { ActionFilters } from "@/components/action/action-filters";
 import { ActionListFull } from "@/components/action/action-list-full";
+import { ActionPagination } from "@/components/action/action-pagination";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { Badge } from "@/components/ui/badge";
 import type { DateFilterType, SortByType } from "@/lib/actions/action-item-actions";
@@ -14,6 +15,7 @@ export const dynamic = "force-dynamic";
 
 const DATE_FILTERS: DateFilterType[] = ["all", "overdue", "this-week", "this-month"];
 const SORT_OPTIONS: SortByType[] = ["dueDate", "createdAt", "memberName"];
+const PER_PAGE = 20;
 
 type Props = {
   searchParams: Promise<{
@@ -23,6 +25,7 @@ type Props = {
     q?: string;
     dateFilter?: string;
     sort?: string;
+    page?: string;
   }>;
 };
 
@@ -36,6 +39,8 @@ export default async function ActionsPage({ searchParams }: Props) {
     keyword?: string;
     dateFilter?: DateFilterType;
     sortBy?: SortByType;
+    page?: number;
+    perPage?: number;
   } = {};
 
   if (params.status && ["TODO", "IN_PROGRESS", "DONE"].includes(params.status)) {
@@ -57,7 +62,11 @@ export default async function ActionsPage({ searchParams }: Props) {
     filters.sortBy = params.sort as SortByType;
   }
 
-  const [actionItems, members, allTags] = await Promise.all([
+  const currentPage = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
+  filters.page = currentPage;
+  filters.perPage = PER_PAGE;
+
+  const [{ items: actionItems, total, totalPages }, members, allTags] = await Promise.all([
     getActionItems(filters),
     getMembers(),
     getTags(),
@@ -77,6 +86,19 @@ export default async function ActionsPage({ searchParams }: Props) {
     !!filters.keyword ||
     (!!filters.dateFilter && filters.dateFilter !== "all");
 
+  function buildPageUrl(page: number): string {
+    const p = new URLSearchParams();
+    if (params.status) p.set("status", params.status);
+    if (params.memberId) p.set("memberId", params.memberId);
+    if (params.tag) p.set("tag", params.tag);
+    if (params.q) p.set("q", params.q);
+    if (params.dateFilter) p.set("dateFilter", params.dateFilter);
+    if (params.sort) p.set("sort", params.sort);
+    if (page > 1) p.set("page", String(page));
+    const query = p.toString();
+    return `/actions${query ? `?${query}` : ""}`;
+  }
+
   return (
     <div className="animate-fade-in-up">
       <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "アクション一覧" }]} />
@@ -84,11 +106,11 @@ export default async function ActionsPage({ searchParams }: Props) {
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">アクション一覧</h1>
         {hasFilter ? (
           <Badge variant="secondary" className="text-sm">
-            {actionItemsWithTags.length} 件
+            {total} 件
           </Badge>
         ) : (
           <Badge variant="outline" className="text-sm text-muted-foreground">
-            {actionItemsWithTags.length} 件
+            {total} 件
           </Badge>
         )}
       </div>
@@ -96,6 +118,11 @@ export default async function ActionsPage({ searchParams }: Props) {
         <ActionFilters members={memberList} tags={tagList} />
       </Suspense>
       <ActionListFull actionItems={actionItemsWithTags} statusFilter={filters.status} />
+      <ActionPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        buildPageUrl={buildPageUrl}
+      />
     </div>
   );
 }

--- a/src/components/action/__tests__/action-filters.test.tsx
+++ b/src/components/action/__tests__/action-filters.test.tsx
@@ -63,6 +63,16 @@ describe("buildFilterUrl", () => {
   it("sort パラメータを設定できる", () => {
     expect(buildFilterUrl("", "sort", "createdAt")).toBe("/actions?sort=createdAt");
   });
+
+  it("フィルター変更時に page パラメータを削除する", () => {
+    expect(buildFilterUrl("status=TODO&page=3", "status", "IN_PROGRESS")).toBe(
+      "/actions?status=IN_PROGRESS",
+    );
+  });
+
+  it("フィルターが 'all' のときも page パラメータを削除する", () => {
+    expect(buildFilterUrl("status=TODO&page=2", "status", "all")).toBe("/actions?");
+  });
 });
 
 describe("ActionFilters", () => {

--- a/src/components/action/__tests__/action-pagination.test.tsx
+++ b/src/components/action/__tests__/action-pagination.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ActionPagination } from "../action-pagination";
+
+afterEach(() => {
+  cleanup();
+});
+
+const buildPageUrl = (page: number) => `/actions?page=${page}`;
+
+describe("ActionPagination", () => {
+  it("totalPages が 1 のとき何も表示しない", () => {
+    const { container } = render(
+      <ActionPagination currentPage={1} totalPages={1} buildPageUrl={buildPageUrl} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("totalPages が 0 のとき何も表示しない", () => {
+    const { container } = render(
+      <ActionPagination currentPage={1} totalPages={0} buildPageUrl={buildPageUrl} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("複数ページのとき前へ・次へボタンが表示される", () => {
+    render(<ActionPagination currentPage={2} totalPages={3} buildPageUrl={buildPageUrl} />);
+    expect(screen.getByRole("link", { name: "前のページ" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "次のページ" })).toBeDefined();
+  });
+
+  it("1ページ目のとき前へボタンが無効", () => {
+    render(<ActionPagination currentPage={1} totalPages={3} buildPageUrl={buildPageUrl} />);
+    expect(screen.queryByRole("link", { name: "前のページ" })).toBeNull();
+  });
+
+  it("最終ページのとき次へボタンが無効", () => {
+    render(<ActionPagination currentPage={3} totalPages={3} buildPageUrl={buildPageUrl} />);
+    expect(screen.queryByRole("link", { name: "次のページ" })).toBeNull();
+  });
+
+  it("7ページ以下のとき全ページ番号が表示される", () => {
+    render(<ActionPagination currentPage={1} totalPages={5} buildPageUrl={buildPageUrl} />);
+    expect(screen.getByRole("link", { name: "2ページ目" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "5ページ目" })).toBeDefined();
+  });
+
+  it("現在のページ番号はリンクでなくボタン表示", () => {
+    render(<ActionPagination currentPage={2} totalPages={5} buildPageUrl={buildPageUrl} />);
+    // 現在ページ (2) はリンクではなくボタン表示
+    const currentPageBtn = screen.getByText("2");
+    expect(currentPageBtn.closest("a")).toBeNull();
+  });
+
+  it("8ページ以上のとき省略記号が表示される", () => {
+    render(<ActionPagination currentPage={5} totalPages={10} buildPageUrl={buildPageUrl} />);
+    const ellipses = screen.getAllByText("…");
+    expect(ellipses.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("前へリンクが正しいURLを持つ", () => {
+    render(<ActionPagination currentPage={3} totalPages={5} buildPageUrl={buildPageUrl} />);
+    const prevLink = screen.getByRole("link", { name: "前のページ" });
+    expect(prevLink.getAttribute("href")).toBe("/actions?page=2");
+  });
+
+  it("次へリンクが正しいURLを持つ", () => {
+    render(<ActionPagination currentPage={2} totalPages={5} buildPageUrl={buildPageUrl} />);
+    const nextLink = screen.getByRole("link", { name: "次のページ" });
+    expect(nextLink.getAttribute("href")).toBe("/actions?page=3");
+  });
+});

--- a/src/components/action/action-filters.tsx
+++ b/src/components/action/action-filters.tsx
@@ -26,6 +26,8 @@ export function buildFilterUrl(currentParams: string, key: string, value: string
   } else {
     params.set(key, value);
   }
+  // フィルター変更時はページを1にリセット
+  params.delete("page");
   return `/actions?${params.toString()}`;
 }
 

--- a/src/components/action/action-pagination.tsx
+++ b/src/components/action/action-pagination.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  currentPage: number;
+  totalPages: number;
+  buildPageUrl: (page: number) => string;
+};
+
+export function ActionPagination({ currentPage, totalPages, buildPageUrl }: Props) {
+  if (totalPages <= 1) return null;
+
+  const pages = buildPageNumbers(currentPage, totalPages);
+
+  return (
+    <div className="flex items-center justify-center gap-1 mt-6">
+      <Button variant="outline" size="icon" asChild disabled={currentPage <= 1}>
+        {currentPage <= 1 ? (
+          <span aria-disabled="true">
+            <ChevronLeft className="h-4 w-4" />
+          </span>
+        ) : (
+          <Link href={buildPageUrl(currentPage - 1)} aria-label="前のページ">
+            <ChevronLeft className="h-4 w-4" />
+          </Link>
+        )}
+      </Button>
+
+      {pages.map((p, i) =>
+        p === "..." ? (
+          <span key={`ellipsis-${i}`} className="px-2 text-muted-foreground text-sm">
+            …
+          </span>
+        ) : (
+          <Button
+            key={p}
+            variant={p === currentPage ? "default" : "outline"}
+            size="icon"
+            asChild={p !== currentPage}
+          >
+            {p === currentPage ? (
+              <span>{p}</span>
+            ) : (
+              <Link href={buildPageUrl(p as number)} aria-label={`${p}ページ目`}>
+                {p}
+              </Link>
+            )}
+          </Button>
+        ),
+      )}
+
+      <Button variant="outline" size="icon" asChild disabled={currentPage >= totalPages}>
+        {currentPage >= totalPages ? (
+          <span aria-disabled="true">
+            <ChevronRight className="h-4 w-4" />
+          </span>
+        ) : (
+          <Link href={buildPageUrl(currentPage + 1)} aria-label="次のページ">
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        )}
+      </Button>
+    </div>
+  );
+}
+
+function buildPageNumbers(currentPage: number, totalPages: number): (number | "...")[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const pages: (number | "...")[] = [1];
+
+  if (currentPage > 3) pages.push("...");
+
+  const start = Math.max(2, currentPage - 1);
+  const end = Math.min(totalPages - 1, currentPage + 1);
+  for (let i = start; i <= end; i++) pages.push(i);
+
+  if (currentPage < totalPages - 2) pages.push("...");
+  pages.push(totalPages);
+
+  return pages;
+}

--- a/src/lib/actions/__tests__/action-item-actions.test.ts
+++ b/src/lib/actions/__tests__/action-item-actions.test.ts
@@ -41,9 +41,9 @@ describe("getActionItems", () => {
       topics: [],
       actionItems: [{ title: "Task A", description: "" }],
     });
-    const items = await getActionItems();
-    expect(items).toHaveLength(1);
-    expect(items[0].member).toBeDefined();
+    const result = await getActionItems();
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].member).toBeDefined();
   });
 
   it("filters by status", async () => {
@@ -56,12 +56,12 @@ describe("getActionItems", () => {
         { title: "Task B", description: "" },
       ],
     });
-    const items = await getActionItems();
-    expect(items).toHaveLength(2);
-    await updateActionItemStatus(items[0].id, "DONE");
-    const todoItems = await getActionItems({ status: "TODO" });
-    expect(todoItems).toHaveLength(1);
-    expect(todoItems[0].title).toBe("Task B");
+    const allResult = await getActionItems();
+    expect(allResult.items).toHaveLength(2);
+    await updateActionItemStatus(allResult.items[0].id, "DONE");
+    const todoResult = await getActionItems({ status: "TODO" });
+    expect(todoResult.items).toHaveLength(1);
+    expect(todoResult.items[0].title).toBe("Task B");
   });
 
   it("filters by member", async () => {
@@ -80,8 +80,49 @@ describe("getActionItems", () => {
       actionItems: [{ title: "Task B", description: "" }],
     });
     const filtered = await getActionItems({ memberId });
-    expect(filtered).toHaveLength(1);
-    expect(filtered[0].title).toBe("Task A");
+    expect(filtered.items).toHaveLength(1);
+    expect(filtered.items[0].title).toBe("Task A");
+  });
+
+  it("pagination: perPage=2 で2件のみ返す", async () => {
+    await createMeeting({
+      memberId,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [
+        { title: "Task A", description: "" },
+        { title: "Task B", description: "" },
+        { title: "Task C", description: "" },
+      ],
+    });
+    const result = await getActionItems({ page: 1, perPage: 2 });
+    expect(result.items).toHaveLength(2);
+    expect(result.total).toBe(3);
+    expect(result.totalPages).toBe(2);
+    expect(result.page).toBe(1);
+  });
+
+  it("pagination: page=2 で残りの件数を返す", async () => {
+    await createMeeting({
+      memberId,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [
+        { title: "Task A", description: "" },
+        { title: "Task B", description: "" },
+        { title: "Task C", description: "" },
+      ],
+    });
+    const result = await getActionItems({ page: 2, perPage: 2 });
+    expect(result.items).toHaveLength(1);
+    expect(result.total).toBe(3);
+    expect(result.totalPages).toBe(2);
+  });
+
+  it("ページを指定しない場合はデフォルトで page=1, perPage=20 を使用する", async () => {
+    const result = await getActionItems();
+    expect(result.page).toBe(1);
+    expect(result.perPage).toBe(20);
   });
 });
 
@@ -97,7 +138,7 @@ describe("getPendingActionItems", () => {
       ],
     });
     const all = await getActionItems();
-    await updateActionItemStatus(all.find((a) => a.title === "Done")!.id, "DONE");
+    await updateActionItemStatus(all.items.find((a) => a.title === "Done")!.id, "DONE");
     const pending = await getPendingActionItems(memberId);
     expect(pending).toHaveLength(1);
     expect(pending[0].title).toBe("Pending");
@@ -112,12 +153,12 @@ describe("updateActionItemStatus", () => {
       topics: [],
       actionItems: [{ title: "Task", description: "" }],
     });
-    const items = await getActionItems();
-    const result = await updateActionItemStatus(items[0].id, "IN_PROGRESS");
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.status).toBe("IN_PROGRESS");
-    expect(result.data.completedAt).toBeNull();
+    const result = await getActionItems();
+    const updateResult = await updateActionItemStatus(result.items[0].id, "IN_PROGRESS");
+    expect(updateResult.success).toBe(true);
+    if (!updateResult.success) return;
+    expect(updateResult.data.status).toBe("IN_PROGRESS");
+    expect(updateResult.data.completedAt).toBeNull();
   });
 
   it("sets completedAt when marking DONE", async () => {
@@ -127,12 +168,12 @@ describe("updateActionItemStatus", () => {
       topics: [],
       actionItems: [{ title: "Task", description: "" }],
     });
-    const items = await getActionItems();
-    const result = await updateActionItemStatus(items[0].id, "DONE");
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.status).toBe("DONE");
-    expect(result.data.completedAt).not.toBeNull();
+    const result = await getActionItems();
+    const updateResult = await updateActionItemStatus(result.items[0].id, "DONE");
+    expect(updateResult.success).toBe(true);
+    if (!updateResult.success) return;
+    expect(updateResult.data.status).toBe("DONE");
+    expect(updateResult.data.completedAt).not.toBeNull();
   });
 
   it("clears completedAt when reverting from DONE", async () => {
@@ -142,12 +183,12 @@ describe("updateActionItemStatus", () => {
       topics: [],
       actionItems: [{ title: "Task", description: "" }],
     });
-    const items = await getActionItems();
-    await updateActionItemStatus(items[0].id, "DONE");
-    const result = await updateActionItemStatus(items[0].id, "TODO");
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.completedAt).toBeNull();
+    const result = await getActionItems();
+    await updateActionItemStatus(result.items[0].id, "DONE");
+    const revertResult = await updateActionItemStatus(result.items[0].id, "TODO");
+    expect(revertResult.success).toBe(true);
+    if (!revertResult.success) return;
+    expect(revertResult.data.completedAt).toBeNull();
   });
 
   it("returns error for invalid status", async () => {
@@ -157,9 +198,9 @@ describe("updateActionItemStatus", () => {
       topics: [],
       actionItems: [{ title: "Task", description: "" }],
     });
-    const items = await getActionItems();
-    const result = await updateActionItemStatus(items[0].id, "INVALID");
-    expect(result.success).toBe(false);
+    const result = await getActionItems();
+    const updateResult = await updateActionItemStatus(result.items[0].id, "INVALID");
+    expect(updateResult.success).toBe(false);
   });
 });
 
@@ -171,14 +212,14 @@ describe("updateActionItem", () => {
       topics: [],
       actionItems: [{ title: "Original", description: "" }],
     });
-    const items = await getActionItems();
-    const result = await updateActionItem(items[0].id, {
+    const result = await getActionItems();
+    const updateResult = await updateActionItem(result.items[0].id, {
       title: "Updated",
       description: "",
     });
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.title).toBe("Updated");
+    expect(updateResult.success).toBe(true);
+    if (!updateResult.success) return;
+    expect(updateResult.data.title).toBe("Updated");
   });
 
   it("説明と期限日を更新できる", async () => {
@@ -188,16 +229,16 @@ describe("updateActionItem", () => {
       topics: [],
       actionItems: [{ title: "Task", description: "" }],
     });
-    const items = await getActionItems();
-    const result = await updateActionItem(items[0].id, {
+    const result = await getActionItems();
+    const updateResult = await updateActionItem(result.items[0].id, {
       title: "Task",
       description: "Added desc",
       dueDate: "2026-03-15",
     });
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.description).toBe("Added desc");
-    expect(result.data.dueDate).not.toBeNull();
+    expect(updateResult.success).toBe(true);
+    if (!updateResult.success) return;
+    expect(updateResult.data.description).toBe("Added desc");
+    expect(updateResult.data.dueDate).not.toBeNull();
   });
 
   it("空のタイトルはバリデーションエラーになる", async () => {
@@ -207,12 +248,12 @@ describe("updateActionItem", () => {
       topics: [],
       actionItems: [{ title: "Task", description: "" }],
     });
-    const items = await getActionItems();
-    const result = await updateActionItem(items[0].id, {
+    const result = await getActionItems();
+    const updateResult = await updateActionItem(result.items[0].id, {
       title: "",
       description: "",
     });
-    expect(result.success).toBe(false);
+    expect(updateResult.success).toBe(false);
   });
 
   it("空文字の dueDate は null として保存される", async () => {
@@ -222,23 +263,23 @@ describe("updateActionItem", () => {
       topics: [],
       actionItems: [{ title: "Task", description: "", dueDate: "2026-03-01" }],
     });
-    const items = await getActionItems();
-    const result = await updateActionItem(items[0].id, {
+    const result = await getActionItems();
+    const updateResult = await updateActionItem(result.items[0].id, {
       title: "Task",
       description: "",
       dueDate: "",
     });
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.dueDate).toBeNull();
+    expect(updateResult.success).toBe(true);
+    if (!updateResult.success) return;
+    expect(updateResult.data.dueDate).toBeNull();
   });
 
   it("存在しないIDはエラーになる", async () => {
-    const result = await updateActionItem("nonexistent-id", {
+    const updateResult = await updateActionItem("nonexistent-id", {
       title: "Task",
       description: "",
     });
-    expect(result.success).toBe(false);
+    expect(updateResult.success).toBe(false);
   });
 });
 

--- a/src/lib/actions/action-item-actions.ts
+++ b/src/lib/actions/action-item-actions.ts
@@ -22,6 +22,8 @@ type ActionItemFilters = {
   keyword?: string;
   dateFilter?: DateFilterType;
   sortBy?: SortByType;
+  page?: number;
+  perPage?: number;
 };
 
 function buildDateFilter(dateFilter: DateFilterType): Prisma.ActionItemWhereInput {
@@ -71,16 +73,28 @@ export async function getActionItems(filters: ActionItemFilters = {}) {
   }
 
   const orderBy = buildOrderBy(filters.sortBy ?? "dueDate");
+  const page = Math.max(1, filters.page ?? 1);
+  const perPage = filters.perPage ?? 20;
+  const skip = (page - 1) * perPage;
 
-  return prisma.actionItem.findMany({
-    where,
-    orderBy,
-    include: {
-      member: { select: { id: true, name: true } },
-      meeting: { select: { id: true, date: true } },
-      tags: { include: { tag: true } },
-    },
-  });
+  const [items, total] = await Promise.all([
+    prisma.actionItem.findMany({
+      where,
+      orderBy,
+      skip,
+      take: perPage,
+      include: {
+        member: { select: { id: true, name: true } },
+        meeting: { select: { id: true, date: true } },
+        tags: { include: { tag: true } },
+      },
+    }),
+    prisma.actionItem.count({ where }),
+  ]);
+
+  const totalPages = Math.ceil(total / perPage);
+
+  return { items, total, page, perPage, totalPages };
 }
 
 export async function getPendingActionItems(memberId: string) {


### PR DESCRIPTION
## 概要

issue #103 の対応。\`/actions\` ページで全件をフラットに表示していた問題を解決するため、1ページ20件のURLベースページネーションを追加する。

## 変更内容

### 新規ファイル
- \`src/components/action/action-pagination.tsx\` — 前後ナビゲーション・省略記号付きページ番号コンポーネント
- \`src/components/action/__tests__/action-pagination.test.tsx\` — ActionPagination のユニットテスト（10件）

### 変更ファイル
- \`src/lib/actions/action-item-actions.ts\` — \`getActionItems()\` にページネーション対応（\`skip\`/\`take\`、\`total\`/\`totalPages\` 返却）
- \`src/app/actions/page.tsx\` — \`page\` search param 読み取り・ActionPagination 組み込み・件数バッジを総件数表示に変更
- \`src/components/action/action-filters.tsx\` — フィルター変更時に \`page\` パラメータをリセット
- \`src/lib/actions/__tests__/action-item-actions.test.ts\` — ページネーションテスト3件追加・戻り値アクセスを \`.items\` 経由に修正
- \`src/components/action/__tests__/action-filters.test.tsx\` — \`page\` リセット動作のテスト2件追加

## 機能

- **ページネーション**: 1ページ20件・URLベース（\`?page=N\`）
- **フィルター保持**: ページ移動時に既存のフィルター（status・memberId・tag・q・dateFilter・sort）を保持
- **ページリセット**: フィルター変更時は自動的に1ページ目に戻る
- **件数表示**: 件数バッジはフィルター後の総件数を表示

## テスト計画

- [x] \`npm test\` — 99ファイル 951テスト全パス
- [x] \`npm run format:check\` — Prettier チェック通過
- [x] \`npx tsc --noEmit\` — 型チェック通過
- [ ] \`/actions\` にアクセスし、ページネーションが表示されることを確認
- [ ] フィルター変更後にページが1にリセットされることを確認
- [ ] 「前へ」「次へ」ボタンの動作確認

Closes #103