### PR TITLE
ux: コンディション入力スケールに絵文字ラベルを追加する (issue #104)

### DIFF
--- a/src/components/meeting/__tests__/condition-selector.test.tsx
+++ b/src/components/meeting/__tests__/condition-selector.test.tsx
@@ -101,4 +101,29 @@ describe("ConditionSelector", () => {
     expect(minLabels).toHaveLength(3);
     expect(maxLabels).toHaveLength(3);
   });
+
+  it("体調・気分軸にスケール端絵文字 😞（最小）と 😊（最大）が表示されること", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    const minEmojis = screen.getAllByText("😞");
+    const maxEmojis = screen.getAllByText("😊");
+    // 体調と気分の2軸分
+    expect(minEmojis).toHaveLength(2);
+    expect(maxEmojis).toHaveLength(2);
+  });
+
+  it("業務量軸にスケール端絵文字 😌（最小）と 😰（最大）が表示されること", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    expect(screen.getByText("😌")).toBeInTheDocument();
+    expect(screen.getByText("😰")).toBeInTheDocument();
+  });
+
+  it("各軸のスケール端絵文字が合計6つ表示されること（min×3, max×3）", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    // min絵文字: 😞×2（体調・気分）+ 😌×1（業務量）= 3つ
+    // max絵文字: 😊×2（体調・気分）+ 😰×1（業務量）= 3つ
+    const minEmojis = screen.getAllByText(/^(😞|😌)$/);
+    const maxEmojis = screen.getAllByText(/^(😊|😰)$/);
+    expect(minEmojis).toHaveLength(3);
+    expect(maxEmojis).toHaveLength(3);
+  });
 });

--- a/src/components/meeting/condition-selector.tsx
+++ b/src/components/meeting/condition-selector.tsx
@@ -8,6 +8,8 @@ interface ConditionAxis {
   icon: string;
   minLabel: string;
   maxLabel: string;
+  minEmoji: string;
+  maxEmoji: string;
   options: { value: number; label: string }[];
 }
 
@@ -18,6 +20,8 @@ const CONDITION_AXES: ConditionAxis[] = [
     icon: "🏥",
     minLabel: "悪い",
     maxLabel: "良い",
+    minEmoji: "😞",
+    maxEmoji: "😊",
     options: [
       { value: 1, label: "とても悪い" },
       { value: 2, label: "悪い" },
@@ -32,6 +36,8 @@ const CONDITION_AXES: ConditionAxis[] = [
     icon: "💭",
     minLabel: "悪い",
     maxLabel: "良い",
+    minEmoji: "😞",
+    maxEmoji: "😊",
     options: [
       { value: 1, label: "とても悪い" },
       { value: 2, label: "悪い" },
@@ -46,6 +52,8 @@ const CONDITION_AXES: ConditionAxis[] = [
     icon: "📊",
     minLabel: "少ない",
     maxLabel: "多い",
+    minEmoji: "😌",
+    maxEmoji: "😰",
     options: [
       { value: 1, label: "とても少ない" },
       { value: 2, label: "少ない" },
@@ -91,9 +99,12 @@ export function ConditionSelector({
               <span className="text-sm font-medium text-slate-700">{axis.label}</span>
             </div>
             <div className="flex items-center gap-2">
-              <span className="w-10 shrink-0 text-right text-xs text-slate-400">
-                {axis.minLabel}
-              </span>
+              <div className="flex w-14 shrink-0 flex-col items-end">
+                <span aria-hidden="true" className="text-base leading-none">
+                  {axis.minEmoji}
+                </span>
+                <span className="text-xs text-slate-400">{axis.minLabel}</span>
+              </div>
               <div className="flex items-center gap-1">
                 {axis.options.map((option) => (
                   <button
@@ -104,7 +115,7 @@ export function ConditionSelector({
                     onClick={() => handleSelect(axis.field, option.value)}
                     className={`flex h-8 w-8 items-center justify-center rounded-md text-sm font-medium transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-primary ${
                       currentValue === option.value
-                        ? "bg-primary text-white ring-2 ring-primary scale-105"
+                        ? "scale-105 bg-primary text-white ring-2 ring-primary"
                         : "bg-slate-100 text-slate-600 hover:bg-slate-200"
                     }`}
                   >
@@ -112,7 +123,12 @@ export function ConditionSelector({
                   </button>
                 ))}
               </div>
-              <span className="w-8 shrink-0 text-xs text-slate-400">{axis.maxLabel}</span>
+              <div className="flex w-10 shrink-0 flex-col items-start">
+                <span aria-hidden="true" className="text-base leading-none">
+                  {axis.maxEmoji}
+                </span>
+                <span className="text-xs text-slate-400">{axis.maxLabel}</span>
+              </div>
             </div>
           </div>
         );


### PR DESCRIPTION
## 概要

issue #104 の対応。1on1 記録フォームのコンディション入力（体調・気分・業務量）の 1〜5 スケールに絵文字ラベルを追加し、スケールの方向（最小・最大）を視覚的に伝えられるようにした。

## 変更内容

### 変更ファイル
- `src/components/meeting/condition-selector.tsx` — `ConditionAxis` 型に `minEmoji` / `maxEmoji` フィールドを追加。各軸のボタン両端に絵文字＋テキストラベルを表示するよう JSX を更新
- `src/components/meeting/__tests__/condition-selector.test.tsx` — スケール端絵文字の表示を確認するテストを 3 件追加

## 機能

スケール両端の表示が以下のように変わった：

| 軸 | 最小（1） | 最大（5） |
|---|---|---|
| 体調 | 😞 悪い | 😊 良い |
| 気分 | 😞 悪い | 😊 良い |
| 業務量 | 😌 少ない | 😰 多い |

絵文字とテキストを縦積みで表示し、数字ボタンの直感的な理解を補助する。

## テスト計画

- [x] `npm test` — 99 ファイル 954 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー詳細 → 「新規 1on1」でコンディションセクションを目視確認
- [ ] 各軸ボタン両端に絵文字＋テキストが正しく表示されることを確認

Closes #104