### PR TITLE
ux: ダッシュボードのリマインダーリストに「もっと見る」機能を改善する (issue #105)

### DIFF
--- a/src/components/dashboard/__tests__/reminder-alert-banner.test.tsx
+++ b/src/components/dashboard/__tests__/reminder-alert-banner.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { OverdueReminder } from "@/lib/actions/reminder-actions";
@@ -74,5 +74,60 @@ describe("ReminderAlertBanner", () => {
     );
     render(<ReminderAlertBanner reminders={reminders} />);
     expect(screen.getByText(/3件/)).toBeDefined();
+  });
+
+  describe("表示件数上限と「もっと見る」機能", () => {
+    const makeManyReminders = (count: number): OverdueReminder[] =>
+      Array.from({ length: count }, (_, i) =>
+        makeReminder({ memberId: `member-${i}`, memberName: `メンバー${i + 1}` }),
+      );
+
+    it("6件以上のリマインダーがある場合、初期表示は5件のみ", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(6)} />);
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems).toHaveLength(5);
+    });
+
+    it("5件以下のリマインダーは全件表示する", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(4)} />);
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems).toHaveLength(4);
+    });
+
+    it("6件以上のとき「もっと見る」ボタンが表示される", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(8)} />);
+      expect(screen.getByRole("button", { name: /もっと見る/ })).toBeDefined();
+    });
+
+    it("5件以下のとき「もっと見る」ボタンは表示されない", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(5)} />);
+      expect(screen.queryByRole("button", { name: /もっと見る/ })).toBeNull();
+    });
+
+    it("「もっと見る」ボタンに残り件数が表示される（例: +3件）", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(8)} />);
+      expect(screen.getByRole("button", { name: /\+3件/ })).toBeDefined();
+    });
+
+    it("「もっと見る」ボタンをクリックすると全件表示される", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(8)} />);
+      fireEvent.click(screen.getByRole("button", { name: /もっと見る/ }));
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems).toHaveLength(8);
+    });
+
+    it("展開後に「折りたたむ」ボタンが表示される", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(8)} />);
+      fireEvent.click(screen.getByRole("button", { name: /もっと見る/ }));
+      expect(screen.getByRole("button", { name: /折りたたむ/ })).toBeDefined();
+    });
+
+    it("「折りたたむ」ボタンをクリックすると5件に戻る", () => {
+      render(<ReminderAlertBanner reminders={makeManyReminders(8)} />);
+      fireEvent.click(screen.getByRole("button", { name: /もっと見る/ }));
+      fireEvent.click(screen.getByRole("button", { name: /折りたたむ/ }));
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems).toHaveLength(5);
+    });
   });
 });

--- a/src/components/dashboard/reminder-alert-banner.tsx
+++ b/src/components/dashboard/reminder-alert-banner.tsx
@@ -75,7 +75,7 @@ export function ReminderAlertBanner({ reminders }: Props) {
               </>
             ) : (
               <>
-                すべて表示（{reminders.length}件）
+                もっと見る (+{reminders.length - DEFAULT_LIMIT}件)
                 <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
               </>
             )}


### PR DESCRIPTION
## 概要

issue #105 の対応。ダッシュボードのミーティングリマインダーに「もっと見る」ボタンのテキストを issue 仕様に合わせて改善し、展開/折りたたみ機能のテストを追加した。

## 変更内容

### 変更ファイル

- `src/components/dashboard/reminder-alert-banner.tsx` — ボタンテキストを「すべて表示（N件）」から「もっと見る (+N件)」に変更
- `src/components/dashboard/__tests__/reminder-alert-banner.test.tsx` — 展開/折りたたみ機能のテストを8ケース追加

## 機能

- **ボタンテキスト改善**: 「もっと見る (+N件)」形式で残り件数を明示（例: `もっと見る (+43件)`）
- **既存動作**: 初期5件表示 → 「もっと見る」で全件展開 → 「折りたたむ」で5件に戻る

## テスト計画

- [x] `npm test` — 99ファイル 962テスト全通過
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ダッシュボードでリマインダーが6件以上ある状態を確認し「もっと見る」ボタンが正しく表示される

### 追加テストケース（8ケース）

- 6件以上のリマインダーがある場合、初期表示は5件のみ
- 5件以下のリマインダーは全件表示する
- 6件以上のとき「もっと見る」ボタンが表示される
- 5件以下のとき「もっと見る」ボタンは表示されない
- 「もっと見る」ボタンに残り件数が表示される（例: +3件）
- 「もっと見る」ボタンをクリックすると全件表示される
- 展開後に「折りたたむ」ボタンが表示される
- 「折りたたむ」ボタンをクリックすると5件に戻る

Closes #105