### PR TITLE
ux: 保存確認ダイアログに話題・アクションタイトル一覧を表示する (issue #106)

### DIFF
--- a/src/components/meeting/__tests__/closing-dialog.test.tsx
+++ b/src/components/meeting/__tests__/closing-dialog.test.tsx
@@ -17,6 +17,8 @@ const baseSummaryProps = {
   checkinNote: "",
   topicCount: 2,
   actionItemCount: 3,
+  topicTitles: ["業務進捗 - 今週の進捗報告", "課題・相談 - 困っていること"],
+  actionItemTitles: ["QAテスト完了レポートを共有する"],
 };
 
 describe("ClosingDialog", () => {
@@ -99,6 +101,33 @@ describe("ClosingDialog", () => {
       );
       await user.click(screen.getByRole("button", { name: "戻る" }));
       expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("話題・アクションタイトル一覧", () => {
+    it("話題タイトルがダイアログ内に表示されること", () => {
+      render(
+        <ClosingDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onConfirm={vi.fn()}
+          summaryProps={baseSummaryProps}
+        />,
+      );
+      expect(screen.getByText("業務進捗 - 今週の進捗報告")).toBeDefined();
+      expect(screen.getByText("課題・相談 - 困っていること")).toBeDefined();
+    });
+
+    it("アクションアイテムタイトルがダイアログ内に表示されること", () => {
+      render(
+        <ClosingDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onConfirm={vi.fn()}
+          summaryProps={baseSummaryProps}
+        />,
+      );
+      expect(screen.getByText("QAテスト完了レポートを共有する")).toBeDefined();
     });
   });
 

--- a/src/components/meeting/__tests__/meeting-summary.test.tsx
+++ b/src/components/meeting/__tests__/meeting-summary.test.tsx
@@ -74,6 +74,47 @@ describe("MeetingSummary", () => {
     });
   });
 
+  describe("話題タイトル一覧", () => {
+    it("topicTitles が渡された場合にタイトルが表示されること", () => {
+      render(
+        <MeetingSummary
+          {...baseProps}
+          topicTitles={["業務進捗 - 今週の進捗報告", "課題・相談 - 困っていること"]}
+        />,
+      );
+      expect(screen.getByText("業務進捗 - 今週の進捗報告")).toBeDefined();
+      expect(screen.getByText("課題・相談 - 困っていること")).toBeDefined();
+    });
+
+    it("topicTitles が渡されない場合はタイトル一覧が表示されないこと", () => {
+      render(<MeetingSummary {...baseProps} />);
+      expect(screen.queryByText(/業務進捗/)).toBeNull();
+    });
+
+    it("topicTitles が空配列の場合はタイトル一覧が表示されないこと", () => {
+      render(<MeetingSummary {...baseProps} topicTitles={[]} />);
+      expect(screen.queryByRole("list")).toBeNull();
+    });
+  });
+
+  describe("アクションアイテムタイトル一覧", () => {
+    it("actionItemTitles が渡された場合にタイトルが表示されること", () => {
+      render(
+        <MeetingSummary
+          {...baseProps}
+          actionItemTitles={["QAテスト完了レポートを共有する", "設計書を更新する"]}
+        />,
+      );
+      expect(screen.getByText("QAテスト完了レポートを共有する")).toBeDefined();
+      expect(screen.getByText("設計書を更新する")).toBeDefined();
+    });
+
+    it("actionItemTitles が渡されない場合はタイトル一覧が表示されないこと", () => {
+      render(<MeetingSummary {...baseProps} />);
+      expect(screen.queryByText(/QAテスト/)).toBeNull();
+    });
+  });
+
   describe("アクションアイテム警告", () => {
     it("アクションアイテムが0件の場合に警告が表示されること", () => {
       render(<MeetingSummary {...baseProps} actionItemCount={0} />);

--- a/src/components/meeting/meeting-form.tsx
+++ b/src/components/meeting/meeting-form.tsx
@@ -339,8 +339,24 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
   const topicIds = topics.map((_, i) => `topic-${i}`);
   const actionIds = actionItems.map((_, i) => `action-${i}`);
 
-  const validTopicCount = topics.filter((t) => t.title.trim() !== "").length;
-  const validActionCount = actionItems.filter((a) => a.title.trim() !== "").length;
+  const validTopics = topics.filter((t) => t.title.trim() !== "");
+  const validActions = actionItems.filter((a) => a.title.trim() !== "");
+  const validTopicCount = validTopics.length;
+  const validActionCount = validActions.length;
+
+  const categoryLabelMap: Record<string, string> = {
+    WORK_PROGRESS: "業務進捗",
+    CAREER: "キャリア",
+    ISSUES: "課題・相談",
+    FEEDBACK: "フィードバック",
+    OTHER: "その他",
+  };
+
+  const topicTitles = validTopics.map((t) => {
+    const label = categoryLabelMap[t.category] ?? t.category;
+    return `${label} - ${t.title}`;
+  });
+  const actionItemTitles = validActions.map((a) => a.title);
 
   return (
     <>
@@ -503,6 +519,8 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
           checkinNote,
           topicCount: validTopicCount,
           actionItemCount: validActionCount,
+          topicTitles,
+          actionItemTitles,
         }}
       />
     </>

--- a/src/components/meeting/meeting-summary.tsx
+++ b/src/components/meeting/meeting-summary.tsx
@@ -10,6 +10,8 @@ export interface MeetingSummaryProps {
   checkinNote: string;
   topicCount: number;
   actionItemCount: number;
+  topicTitles?: string[];
+  actionItemTitles?: string[];
   showWarnings?: boolean;
 }
 
@@ -21,6 +23,8 @@ export function MeetingSummary({
   checkinNote,
   topicCount,
   actionItemCount,
+  topicTitles,
+  actionItemTitles,
   showWarnings = true,
 }: MeetingSummaryProps) {
   const hasAnyCondition =
@@ -66,14 +70,38 @@ export function MeetingSummary({
         </div>
       )}
 
-      <div className="flex items-center gap-2">
-        <span className="text-muted-foreground min-w-[4rem]">話題</span>
-        <span className="font-medium">{topicCount}件</span>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground min-w-[4rem]">話題</span>
+          <span className="font-medium">{topicCount}件</span>
+        </div>
+        {topicTitles && topicTitles.length > 0 && (
+          <ul className="flex flex-col gap-0.5 pl-[4.5rem]">
+            {topicTitles.map((title, i) => (
+              <li key={i} className="flex gap-1 text-muted-foreground">
+                <span>・</span>
+                <span>{title}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
 
-      <div className="flex items-center gap-2">
-        <span className="text-muted-foreground min-w-[4rem]">アクション</span>
-        <span className="font-medium">{actionItemCount}件</span>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground min-w-[4rem]">アクション</span>
+          <span className="font-medium">{actionItemCount}件</span>
+        </div>
+        {actionItemTitles && actionItemTitles.length > 0 && (
+          <ul className="flex flex-col gap-0.5 pl-[4.5rem]">
+            {actionItemTitles.map((title, i) => (
+              <li key={i} className="flex gap-1 text-muted-foreground">
+                <span>・</span>
+                <span>{title}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
 
       {showWarnings && actionItemCount === 0 && (


### PR DESCRIPTION
## 概要

issue #106 の対応。1on1 保存前の確認ダイアログ（ClosingDialog）に、件数しか表示されていなかった話題・アクションアイテムのタイトル一覧をバレットリスト形式で追加表示する。

## 変更内容

### 変更ファイル
- `src/components/meeting/meeting-summary.tsx` — `topicTitles?: string[]` / `actionItemTitles?: string[]` オプション prop を追加し、件数の下にリスト表示
- `src/components/meeting/meeting-form.tsx` — カテゴリ名付きタイトル（例: 業務進捗 - 今週の進捗報告）を生成して `summaryProps` に渡す
- `src/components/meeting/__tests__/meeting-summary.test.tsx` — 話題・アクションタイトル表示のテスト追加
- `src/components/meeting/__tests__/closing-dialog.test.tsx` — `baseSummaryProps` にタイトル配列を追加し、ダイアログ内表示のテスト追加

## 機能

- **タイトル一覧表示**: 話題の下に「・ カテゴリ名 - タイトル」形式、アクションの下に「・ タイトル」形式でリスト表示
- **後方互換**: `topicTitles` / `actionItemTitles` はオプション prop のため既存コードへの影響なし
- **カテゴリ日本語化**: `WORK_PROGRESS` → `業務進捗` 等のカテゴリラベルを自動変換

## テスト計画

- [x] `npm test` — 99 ファイル 969 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー詳細 → 新規1on1で話題・アクションを入力し「1on1を保存」をクリック → ダイアログにタイトル一覧が表示されることを確認

Closes #106