### PR TITLE
ux: 「1on1を準備」ボタンをプライマリボタンに変更する (issue #107)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -57,10 +57,10 @@ export default async function MemberDetailPage({ params, searchParams }: Props) 
         </div>
         <div className="flex gap-2">
           <Link href={`/members/${id}/meetings/prepare`}>
-            <Button variant="outline">1on1 を準備</Button>
+            <Button>1on1 を準備</Button>
           </Link>
           <Link href={`/members/${id}/meetings/new`}>
-            <Button>新規1on1</Button>
+            <Button variant="outline">新規1on1</Button>
           </Link>
           <MemberActionsDropdown
             member={{


### PR DESCRIPTION
## 概要

issue #107 の対応。メンバー詳細ページのボタン視覚的優先度を、推奨ワークフロー（準備 → 実施）に合わせて修正する。

## 変更内容

### 変更ファイル
- `src/app/members/[id]/page.tsx` — 「1on1を準備」を `variant="default"`（プライマリ）に、「新規1on1」を `variant="outline"`（セカンダリ）に変更

## テスト計画

- [x] `npm test` — 99ファイル 969テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー詳細ページ（`/members/:id`）でボタン配置・スタイルを目視確認

Closes #107