### PR TITLE
ux: ダッシュボードのリマインダー行をクリックしてメンバー詳細に遷移できるようにする (issue #108)

### DIFF
--- a/src/components/dashboard/__tests__/recommended-meetings-section.test.tsx
+++ b/src/components/dashboard/__tests__/recommended-meetings-section.test.tsx
@@ -41,6 +41,13 @@ describe("RecommendedMeetingsSection", () => {
     expect(screen.getByText(/次回:/)).toBeDefined();
   });
 
+  it("メンバー名がメンバー詳細ページへのリンクになっている", () => {
+    render(<RecommendedMeetingsSection members={mockMembers} />);
+    const link = screen.getByRole("link", { name: "山田 太郎" });
+    expect(link).toBeDefined();
+    expect((link as HTMLAnchorElement).getAttribute("href")).toBe("/members/m1");
+  });
+
   it("shows empty message when no members need meetings", () => {
     render(<RecommendedMeetingsSection members={[]} />);
     expect(screen.getByText("全員と最近1on1を実施済みです")).toBeDefined();

--- a/src/components/dashboard/__tests__/reminder-alert-banner.test.tsx
+++ b/src/components/dashboard/__tests__/reminder-alert-banner.test.tsx
@@ -61,6 +61,29 @@ describe("ReminderAlertBanner", () => {
     expect(screen.getByText("鈴木花子")).toBeDefined();
   });
 
+  it("メンバー名がメンバー詳細ページへのリンクになっている", () => {
+    render(
+      <ReminderAlertBanner
+        reminders={[makeReminder({ memberId: "member-1", memberName: "テストメンバー" })]}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "テストメンバー" });
+    expect(link).toBeDefined();
+    expect((link as HTMLAnchorElement).getAttribute("href")).toContain("/members/member-1");
+  });
+
+  it("複数リマインダーの場合、各メンバー名がそれぞれの詳細ページへリンクする", () => {
+    const reminders = [
+      makeReminder({ memberId: "m1", memberName: "田中太郎" }),
+      makeReminder({ memberId: "m2", memberName: "鈴木花子" }),
+    ];
+    render(<ReminderAlertBanner reminders={reminders} />);
+    const link1 = screen.getByRole("link", { name: "田中太郎" });
+    const link2 = screen.getByRole("link", { name: "鈴木花子" });
+    expect((link1 as HTMLAnchorElement).getAttribute("href")).toContain("/members/m1");
+    expect((link2 as HTMLAnchorElement).getAttribute("href")).toContain("/members/m2");
+  });
+
   it("「1on1準備」リンクが各メンバーに表示される", () => {
     render(<ReminderAlertBanner reminders={[makeReminder({ memberId: "member-abc" })]} />);
     const link = screen.getByRole("link", { name: /1on1準備/ });

--- a/src/components/dashboard/__tests__/scheduled-meetings-section.test.tsx
+++ b/src/components/dashboard/__tests__/scheduled-meetings-section.test.tsx
@@ -48,8 +48,15 @@ describe("ScheduledMeetingsSection", () => {
 
   it("shows 1on1準備 button with correct link", () => {
     render(<ScheduledMeetingsSection meetings={[todayMeeting]} />);
-    const link = screen.getByRole("link");
+    const link = screen.getByRole("link", { name: /1on1準備/ });
     expect(link.getAttribute("href")).toBe("/members/m1/meetings/prepare");
+  });
+
+  it("メンバー名がメンバー詳細ページへのリンクになっている", () => {
+    render(<ScheduledMeetingsSection meetings={[todayMeeting]} />);
+    const link = screen.getByRole("link", { name: "山田 太郎" });
+    expect(link).toBeDefined();
+    expect(link.getAttribute("href")).toBe("/members/m1");
   });
 
   it("renders multiple members", () => {

--- a/src/components/dashboard/recommended-meetings-section.tsx
+++ b/src/components/dashboard/recommended-meetings-section.tsx
@@ -30,7 +30,12 @@ export function RecommendedMeetingsSection({ members }: { members: RecommendedMe
           <AvatarInitial name={member.name} size="sm" />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
-              <p className="text-sm font-medium truncate">{member.name}</p>
+              <Link
+                href={`/members/${member.id}`}
+                className="text-sm font-medium truncate hover:underline"
+              >
+                {member.name}
+              </Link>
               <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
                 {getMeetingIntervalLabel(member.meetingIntervalDays)}
               </span>

--- a/src/components/dashboard/reminder-alert-banner.tsx
+++ b/src/components/dashboard/reminder-alert-banner.tsx
@@ -40,7 +40,12 @@ export function ReminderAlertBanner({ reminders }: Props) {
             className="flex items-center justify-between gap-3 rounded-lg bg-background/60 px-3 py-2 text-sm"
           >
             <div className="flex items-center gap-2 min-w-0">
-              <span className="font-medium text-foreground truncate">{reminder.memberName}</span>
+              <Link
+                href={`/members/${reminder.memberId}`}
+                className="font-medium text-foreground truncate hover:underline"
+              >
+                {reminder.memberName}
+              </Link>
               <span className="text-muted-foreground shrink-0">
                 {reminder.daysSinceLastMeeting === null
                   ? "未実施"

--- a/src/components/dashboard/scheduled-meetings-section.tsx
+++ b/src/components/dashboard/scheduled-meetings-section.tsx
@@ -60,7 +60,12 @@ export function ScheduledMeetingsSection({ meetings }: Props) {
             <AvatarInitial name={meeting.name} size="sm" />
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
-                <p className="text-sm font-medium truncate">{meeting.name}</p>
+                <Link
+                  href={`/members/${meeting.id}`}
+                  className="text-sm font-medium truncate hover:underline"
+                >
+                  {meeting.name}
+                </Link>
                 <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
                   {getMeetingIntervalLabel(meeting.meetingIntervalDays)}
                 </span>


### PR DESCRIPTION
## 概要

issue #108 の対応。ダッシュボードの各セクションでメンバー名をクリックするとメンバー詳細ページ (`/members/:id`) に遷移できるようにした。

## 変更内容

### 変更ファイル

- `src/components/dashboard/reminder-alert-banner.tsx` — メンバー名 `<span>` を `<Link href="/members/:memberId">` に変更
- `src/components/dashboard/recommended-meetings-section.tsx` — メンバー名 `<p>` を `<Link href="/members/:id">` に変更
- `src/components/dashboard/scheduled-meetings-section.tsx` — メンバー名 `<p>` を `<Link href="/members/:id">` に変更
- `src/components/dashboard/__tests__/reminder-alert-banner.test.tsx` — メンバー名リンクの検証テスト追加
- `src/components/dashboard/__tests__/recommended-meetings-section.test.tsx` — メンバー名リンクの検証テスト追加
- `src/components/dashboard/__tests__/scheduled-meetings-section.test.tsx` — メンバー名リンクの検証テスト追加・既存テスト修正

## 機能

- **メンバー名クリックでメンバー詳細へ遷移**: ミーティングリマインダー・1on1すべきメンバー・今週の1on1予定の3セクション全てで対応
- **ホバー時アンダーライン**: `hover:underline` でリンクであることを視覚的に伝える
- **「1on1準備」ボタンは維持**: 既存の遷移ボタンはそのまま機能する

## テスト計画

- [x] `npm test` — 99ファイル 973テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ダッシュボードのリマインダーバナーでメンバー名クリック → `/members/:id` に遷移することを確認
- [ ] 「1on1すべきメンバー」セクションでメンバー名クリック → `/members/:id` に遷移することを確認
- [ ] 「今週の1on1予定」セクションでメンバー名クリック → `/members/:id` に遷移することを確認
- [ ] 各セクションの「1on1準備」ボタンが引き続き正常に動作することを確認
- [ ] メンバー名ホバー時にアンダーラインが表示されることを確認

Closes #108