### PR TITLE
ux: ミーティング作成フォームの話題入力エリアをデフォルトで折りたたむ (issue #109)

### DIFF
--- a/src/components/meeting/__tests__/sortable-topic-item.test.tsx
+++ b/src/components/meeting/__tests__/sortable-topic-item.test.tsx
@@ -38,6 +38,7 @@ describe("SortableTopicItem", () => {
     // getByTestId throws if not found, so reaching the expect means it exists
     expect(screen.getByTestId("drag-handle-topic-0")).toBeTruthy();
     expect(screen.getByDisplayValue("進捗報告")).toBeTruthy();
+    // notes に値があるため詳細セクションは自動展開される
     expect(screen.getByDisplayValue("メモ内容")).toBeTruthy();
     expect(screen.getByRole("button", { name: "削除" })).toBeTruthy();
   });
@@ -70,6 +71,7 @@ describe("SortableTopicItem", () => {
   it("calls onUpdate when notes change", async () => {
     const user = userEvent.setup();
     render(<SortableTopicItem {...defaultProps} />);
+    // notes に値があるため詳細セクションは自動展開される
     const textarea = screen.getByDisplayValue("メモ内容");
     await user.type(textarea, "X");
     expect(defaultProps.onUpdate).toHaveBeenCalledWith(0, "notes", "メモ内容X");
@@ -80,5 +82,65 @@ describe("SortableTopicItem", () => {
     render(<SortableTopicItem {...defaultProps} />);
     await user.click(screen.getByRole("button", { name: "削除" }));
     expect(defaultProps.onRemove).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("SortableTopicItem - デフォルト折りたたみ", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const emptyProps = {
+    ...defaultProps,
+    notes: "",
+    tags: [],
+  };
+
+  it("notes が空のとき、メモは非表示", () => {
+    render(<SortableTopicItem {...emptyProps} />);
+    expect(screen.queryByPlaceholderText("詳細メモ")).toBeNull();
+  });
+
+  it("notes が空のとき、「詳細を追加」ボタンが表示される", () => {
+    render(<SortableTopicItem {...emptyProps} />);
+    expect(screen.getByRole("button", { name: /詳細を追加/ })).toBeTruthy();
+  });
+
+  it("「詳細を追加」をクリックするとメモが表示される", async () => {
+    const user = userEvent.setup();
+    render(<SortableTopicItem {...emptyProps} />);
+    await user.click(screen.getByRole("button", { name: /詳細を追加/ }));
+    expect(screen.getByPlaceholderText("詳細メモ")).toBeTruthy();
+  });
+
+  it("展開後に「詳細を隠す」ボタンが表示される", async () => {
+    const user = userEvent.setup();
+    render(<SortableTopicItem {...emptyProps} />);
+    await user.click(screen.getByRole("button", { name: /詳細を追加/ }));
+    expect(screen.getByRole("button", { name: /詳細を隠す/ })).toBeTruthy();
+  });
+
+  it("「詳細を隠す」をクリックするとメモが非表示になる", async () => {
+    const user = userEvent.setup();
+    render(<SortableTopicItem {...emptyProps} />);
+    await user.click(screen.getByRole("button", { name: /詳細を追加/ }));
+    await user.click(screen.getByRole("button", { name: /詳細を隠す/ }));
+    expect(screen.queryByPlaceholderText("詳細メモ")).toBeNull();
+  });
+
+  it("notes に値があれば詳細セクションが自動展開される", () => {
+    render(<SortableTopicItem {...emptyProps} notes="既存のメモ" />);
+    expect(screen.getByPlaceholderText("詳細メモ")).toBeTruthy();
+  });
+
+  it("tags に値があれば詳細セクションが自動展開される", () => {
+    render(
+      <SortableTopicItem
+        {...emptyProps}
+        tags={[{ id: "tag-1", name: "重要", color: "#ff0000" }]}
+      />,
+    );
+    expect(screen.getByPlaceholderText("詳細メモ")).toBeTruthy();
   });
 });

--- a/src/components/meeting/sortable-topic-item.tsx
+++ b/src/components/meeting/sortable-topic-item.tsx
@@ -2,7 +2,8 @@
 
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical } from "lucide-react";
+import { ChevronDown, ChevronUp, GripVertical } from "lucide-react";
+import { useState } from "react";
 
 import { TagBadge } from "@/components/tag/tag-badge";
 import { TagInput } from "@/components/tag/tag-input";
@@ -61,6 +62,8 @@ export function SortableTopicItem({
     id,
   });
 
+  const [isExpanded, setIsExpanded] = useState(() => notes.length > 0 || tags.length > 0);
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -117,29 +120,57 @@ export function SortableTopicItem({
           </Button>
         )}
       </div>
-      <div>
-        <Label>メモ</Label>
-        <Textarea
-          value={notes}
-          onChange={(e) => onUpdate(index, "notes", e.target.value)}
-          placeholder="詳細メモ"
-          rows={2}
-        />
-      </div>
-      <div>
-        <Label>タグ</Label>
-        {onTagsChange ? (
-          <TagInput selectedTags={tags} onTagsChange={handleTagsChange} />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="self-start h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+        onClick={() => setIsExpanded((prev) => !prev)}
+      >
+        {isExpanded ? (
+          <>
+            <ChevronUp className="w-3 h-3 mr-1" />
+            詳細を隠す
+          </>
         ) : (
-          tags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-1">
-              {tags.map((tag) => (
-                <TagBadge key={tag.id ?? tag.name} name={tag.name} color={tag.color} size="sm" />
-              ))}
-            </div>
-          )
+          <>
+            <ChevronDown className="w-3 h-3 mr-1" />
+            詳細を追加
+          </>
         )}
-      </div>
+      </Button>
+      {isExpanded && (
+        <>
+          <div>
+            <Label>メモ</Label>
+            <Textarea
+              value={notes}
+              onChange={(e) => onUpdate(index, "notes", e.target.value)}
+              placeholder="詳細メモ"
+              rows={2}
+            />
+          </div>
+          <div>
+            <Label>タグ</Label>
+            {onTagsChange ? (
+              <TagInput selectedTags={tags} onTagsChange={handleTagsChange} />
+            ) : (
+              tags.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-1">
+                  {tags.map((tag) => (
+                    <TagBadge
+                      key={tag.id ?? tag.name}
+                      name={tag.name}
+                      color={tag.color}
+                      size="sm"
+                    />
+                  ))}
+                </div>
+              )
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

issue #109 の対応。ミーティング作成フォームの話題エリアで、メモ・タグフィールドをデフォルト折りたたみにし、「詳細を追加」ボタンで展開できるようにした。

## 変更内容

### 変更ファイル
- `src/components/meeting/sortable-topic-item.tsx` — メモ・タグを折りたたみ/展開するトグル機能を追加
- `src/components/meeting/__tests__/sortable-topic-item.test.tsx` — 折りたたみ・展開・自動展開のテストケースを追加

## 機能

- **デフォルト折りたたみ（案A）**: タイトル・カテゴリのみ常時表示。メモ・タグは非表示
- **「詳細を追加 ▾」ボタン**: クリックでメモ・タグを展開。展開中は「詳細を隠す ▴」に切り替わる
- **自動展開**: 既存データ（notes または tags）がある場合は初期表示から展開状態にする

## テスト計画

- [x] `npm test` — 99 ファイル 976 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] 新規ミーティング作成画面で話題のメモ・タグがデフォルト非表示であることを確認
- [ ] 「詳細を追加」をクリックするとメモ・タグが展開されることを確認
- [ ] テンプレートから話題を選択した場合（notes なし）に折りたたまれていることを確認
- [ ] 編集モード（既存 notes あり）で自動展開されることを確認

Closes #109