### PR TITLE
docs: セットアップ手順のシードコマンドを修正する

### DIFF
--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -25,7 +25,7 @@ cp .env.example .env
 
 # データベースのセットアップ
 npx prisma migrate dev
-npx prisma db seed
+npm run db:seed
 
 # Prisma クライアントの生成
 npx prisma generate

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -37,7 +37,7 @@ npx prisma generate
 npx prisma migrate deploy
 
 # シードデータの投入
-npx prisma db seed
+npm run db:seed
 ```
 
 ## トラブルシューティング


### PR DESCRIPTION
## 概要

`npx prisma db seed` は `package.json` に `prisma.seed` 設定がない場合に動作しないため、実際のスクリプト定義に統一する。

## 変更内容

### 変更ファイル
- `docs/CONTRIB.md` — 初期セットアップ手順の `npx prisma db seed` → `npm run db:seed` に修正
- `docs/RUNBOOK.md` — 初回セットアップ手順の `npx prisma db seed` → `npm run db:seed` に修正

## テスト計画

- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 変更ファイルは .md のため対象外（既存 TSエラーは今回の変更と無関係）