### PR TITLE
feat: 準備画面に前回ミーティングの未完了アクションを引き継ぎ表示する (issue #116)

### DIFF
--- a/src/app/members/[id]/meetings/new/page.tsx
+++ b/src/app/members/[id]/meetings/new/page.tsx
@@ -23,6 +23,17 @@ function parsePreparedTopics(raw: string | string[] | undefined) {
   }
 }
 
+function parseFollowUpActionIds(raw: string | string[] | undefined): string[] {
+  if (typeof raw !== "string") return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
 export default async function NewMeetingPage({ params, searchParams }: Props) {
   const { id } = await params;
   const member = await getMember(id);
@@ -31,9 +42,12 @@ export default async function NewMeetingPage({ params, searchParams }: Props) {
   }
 
   const resolvedSearchParams = await searchParams;
-  const previousMeeting = await getPreviousMeeting(id);
-  const pendingActions = await getPendingActionItems(id);
+  const [previousMeeting, pendingActions] = await Promise.all([
+    getPreviousMeeting(id),
+    getPendingActionItems(id),
+  ]);
   const initialTopics = parsePreparedTopics(resolvedSearchParams.preparedTopics);
+  const followUpActionIds = parseFollowUpActionIds(resolvedSearchParams.followUpActionIds);
 
   return (
     <div className="animate-fade-in-up">
@@ -55,6 +69,7 @@ export default async function NewMeetingPage({ params, searchParams }: Props) {
           <PreviousMeetingSidebar
             previousMeeting={previousMeeting}
             pendingActions={pendingActions}
+            followUpActionIds={followUpActionIds}
           />
         </div>
       </div>

--- a/src/app/members/[id]/meetings/prepare/page.tsx
+++ b/src/app/members/[id]/meetings/prepare/page.tsx
@@ -2,7 +2,10 @@ import { notFound } from "next/navigation";
 
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { MeetingPrepare } from "@/components/meeting/meeting-prepare";
-import { getPendingActionItems } from "@/lib/actions/action-item-actions";
+import {
+  getLastMeetingPendingActions,
+  getPendingActionItems,
+} from "@/lib/actions/action-item-actions";
 import { getRecentMeetings } from "@/lib/actions/meeting-actions";
 import { getMember } from "@/lib/actions/member-actions";
 
@@ -15,8 +18,11 @@ export default async function PrepareMeetingPage({ params }: Props) {
     notFound();
   }
 
-  const recentMeetings = await getRecentMeetings(id, 5);
-  const pendingActions = await getPendingActionItems(id);
+  const [recentMeetings, pendingActions, carryoverData] = await Promise.all([
+    getRecentMeetings(id, 5),
+    getPendingActionItems(id),
+    getLastMeetingPendingActions(id),
+  ]);
 
   return (
     <div className="animate-fade-in-up">
@@ -34,6 +40,7 @@ export default async function PrepareMeetingPage({ params }: Props) {
         memberId={id}
         recentMeetings={recentMeetings}
         pendingActions={pendingActions}
+        carryoverData={carryoverData}
       />
     </div>
   );

--- a/src/components/meeting/__tests__/carryover-action-list.test.tsx
+++ b/src/components/meeting/__tests__/carryover-action-list.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CarryoverActionList } from "../carryover-action-list";
+
+const meetingDate = new Date("2024-09-01");
+
+const actions = [
+  { id: "1", title: "TODO タスク", status: "TODO", dueDate: new Date("2024-09-10") },
+  { id: "2", title: "進行中タスク", status: "IN_PROGRESS", dueDate: null },
+];
+
+describe("CarryoverActionList", () => {
+  afterEach(() => cleanup());
+
+  it("アクションアイテムのタイトルが表示される", () => {
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={actions}
+        selectedIds={new Set()}
+        onToggle={() => {}}
+      />,
+    );
+    expect(screen.getByText("TODO タスク")).toBeInTheDocument();
+    expect(screen.getByText("進行中タスク")).toBeInTheDocument();
+  });
+
+  it("TODO ステータスバッジが表示される", () => {
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={[actions[0]!]}
+        selectedIds={new Set()}
+        onToggle={() => {}}
+      />,
+    );
+    expect(screen.getByText("未着手")).toBeInTheDocument();
+  });
+
+  it("IN_PROGRESS ステータスバッジが表示される", () => {
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={[actions[1]!]}
+        selectedIds={new Set()}
+        onToggle={() => {}}
+      />,
+    );
+    expect(screen.getByText("進行中")).toBeInTheDocument();
+  });
+
+  it("期日が表示される", () => {
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={[actions[0]!]}
+        selectedIds={new Set()}
+        onToggle={() => {}}
+      />,
+    );
+    // 期日の日付テキストが存在することを確認
+    expect(screen.getAllByText(/2024/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("選択済みアイテムはチェックボックスがチェックされている", () => {
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={actions}
+        selectedIds={new Set(["1"])}
+        onToggle={() => {}}
+      />,
+    );
+    const checkbox = screen.getByLabelText("TODO タスクを今回のフォローアップ対象にする");
+    expect(checkbox).toBeChecked();
+  });
+
+  it("チェックボックスをクリックすると onToggle が呼ばれる", async () => {
+    const onToggle = vi.fn();
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={[actions[0]!]}
+        selectedIds={new Set()}
+        onToggle={onToggle}
+      />,
+    );
+    const checkbox = screen.getByLabelText("TODO タスクを今回のフォローアップ対象にする");
+    await userEvent.click(checkbox);
+    expect(onToggle).toHaveBeenCalledWith("1");
+  });
+
+  it("選択件数メッセージが表示される", () => {
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={actions}
+        selectedIds={new Set(["1", "2"])}
+        onToggle={() => {}}
+      />,
+    );
+    expect(screen.getByText("2件を今回のフォローアップ対象に設定")).toBeInTheDocument();
+  });
+
+  it("選択がない場合は件数メッセージが表示されない", () => {
+    render(
+      <CarryoverActionList
+        meetingDate={meetingDate}
+        actions={actions}
+        selectedIds={new Set()}
+        onToggle={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/件を今回のフォローアップ対象に設定/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/meeting/__tests__/meeting-prepare.test.tsx
+++ b/src/components/meeting/__tests__/meeting-prepare.test.tsx
@@ -78,6 +78,15 @@ const mockPendingActions = [
   },
 ];
 
+const mockCarryoverData = {
+  meetingId: "meeting-1",
+  meetingDate: new Date("2026-02-17"),
+  actions: [
+    { id: "c1", title: "引き継ぎタスク1", status: "TODO", dueDate: new Date("2026-03-01") },
+    { id: "c2", title: "引き継ぎタスク2", status: "IN_PROGRESS", dueDate: null },
+  ],
+};
+
 describe("MeetingPrepare", () => {
   afterEach(() => cleanup());
 
@@ -87,6 +96,7 @@ describe("MeetingPrepare", () => {
         memberId="m1"
         recentMeetings={mockRecentMeetings}
         pendingActions={mockPendingActions}
+        carryoverData={null}
       />,
     );
     expect(screen.getByText("進捗報告")).toBeDefined();
@@ -100,6 +110,7 @@ describe("MeetingPrepare", () => {
         memberId="m1"
         recentMeetings={mockRecentMeetings}
         pendingActions={mockPendingActions}
+        carryoverData={null}
       />,
     );
     expect(screen.getByText("資料作成")).toBeDefined();
@@ -107,19 +118,28 @@ describe("MeetingPrepare", () => {
   });
 
   it("shows empty state when no recent meetings", () => {
-    render(<MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} />);
+    render(
+      <MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} carryoverData={null} />,
+    );
     expect(screen.getByText("過去のミーティング記録はありません")).toBeDefined();
   });
 
   it("shows empty state when no pending actions", () => {
-    render(<MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} />);
+    render(
+      <MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} carryoverData={null} />,
+    );
     expect(screen.getByText("未完了のアクションはありません")).toBeDefined();
   });
 
   it("copies topic to agenda when copy button is clicked", async () => {
     const user = userEvent.setup();
     render(
-      <MeetingPrepare memberId="m1" recentMeetings={mockRecentMeetings} pendingActions={[]} />,
+      <MeetingPrepare
+        memberId="m1"
+        recentMeetings={mockRecentMeetings}
+        pendingActions={[]}
+        carryoverData={null}
+      />,
     );
     const copyButtons = screen.getAllByRole("button", { name: /コピー/ });
     await user.click(copyButtons[0]);
@@ -132,14 +152,18 @@ describe("MeetingPrepare", () => {
   });
 
   it("renders template selector", () => {
-    render(<MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} />);
+    render(
+      <MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} carryoverData={null} />,
+    );
     expect(screen.getByText("定期チェックイン")).toBeDefined();
     expect(screen.getByText("キャリア面談")).toBeDefined();
   });
 
   it("populates topics when template is selected", async () => {
     const user = userEvent.setup();
-    render(<MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} />);
+    render(
+      <MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} carryoverData={null} />,
+    );
     await user.click(screen.getByRole("button", { name: /定期チェックイン/ }));
     const inputs = screen.getAllByPlaceholderText("話題のタイトル");
     expect(inputs[0]).toHaveProperty("value", "今週の進捗報告");
@@ -148,14 +172,59 @@ describe("MeetingPrepare", () => {
 
   it("can add a topic manually", async () => {
     const user = userEvent.setup();
-    render(<MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} />);
+    render(
+      <MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} carryoverData={null} />,
+    );
     await user.click(screen.getByRole("button", { name: /話題を追加/ }));
     const inputs = screen.getAllByPlaceholderText("話題のタイトル");
     expect(inputs.length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders start meeting button", () => {
-    render(<MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} />);
+    render(
+      <MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} carryoverData={null} />,
+    );
     expect(screen.getByRole("link", { name: /ミーティングを開始/ })).toBeDefined();
+  });
+
+  it("carryoverData がある場合は「前回からの引き継ぎ」セクションが表示される", () => {
+    render(
+      <MeetingPrepare
+        memberId="m1"
+        recentMeetings={[]}
+        pendingActions={[]}
+        carryoverData={mockCarryoverData}
+      />,
+    );
+    expect(screen.getByText("前回からの引き継ぎ")).toBeDefined();
+    expect(screen.getByText("引き継ぎタスク1")).toBeDefined();
+    expect(screen.getByText("引き継ぎタスク2")).toBeDefined();
+  });
+
+  it("carryoverData が null の場合は「前回からの引き継ぎ」セクションが非表示", () => {
+    render(
+      <MeetingPrepare memberId="m1" recentMeetings={[]} pendingActions={[]} carryoverData={null} />,
+    );
+    expect(screen.queryByText("前回からの引き継ぎ")).toBeNull();
+  });
+
+  it("フォローアップ対象チェックで buildStartUrl に followUpActionIds が含まれる", async () => {
+    const user = userEvent.setup();
+    render(
+      <MeetingPrepare
+        memberId="m1"
+        recentMeetings={[]}
+        pendingActions={[]}
+        carryoverData={mockCarryoverData}
+      />,
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[0]!);
+
+    const startLink = screen.getByRole("link", { name: /ミーティングを開始/ });
+    const href = startLink.getAttribute("href") ?? "";
+    expect(href).toContain("followUpActionIds");
+    expect(href).toContain("c1");
   });
 });

--- a/src/components/meeting/__tests__/previous-meeting-sidebar.test.tsx
+++ b/src/components/meeting/__tests__/previous-meeting-sidebar.test.tsx
@@ -135,4 +135,46 @@ describe("PreviousMeetingSidebar", () => {
       expect(mockRefresh).toHaveBeenCalled();
     });
   });
+
+  it("followUpActionIds に含まれるアクションに「引き継ぎ」バッジが表示される", () => {
+    render(
+      <PreviousMeetingSidebar
+        previousMeeting={previousMeeting}
+        pendingActions={pendingActions}
+        followUpActionIds={["action-1"]}
+      />,
+    );
+    expect(screen.getByText("引き継ぎ")).toBeDefined();
+  });
+
+  it("followUpActionIds が空の場合は「引き継ぎ」バッジが表示されない", () => {
+    render(
+      <PreviousMeetingSidebar
+        previousMeeting={previousMeeting}
+        pendingActions={pendingActions}
+        followUpActionIds={[]}
+      />,
+    );
+    expect(screen.queryByText("引き継ぎ")).toBeNull();
+  });
+
+  it("followUpActionIds が指定されない場合は「引き継ぎ」バッジが表示されない", () => {
+    render(
+      <PreviousMeetingSidebar previousMeeting={previousMeeting} pendingActions={pendingActions} />,
+    );
+    expect(screen.queryByText("引き継ぎ")).toBeNull();
+  });
+
+  it("フォローアップ対象アクションが先頭に表示される", () => {
+    render(
+      <PreviousMeetingSidebar
+        previousMeeting={previousMeeting}
+        pendingActions={pendingActions}
+        followUpActionIds={["action-2"]}
+      />,
+    );
+    const items = screen.getAllByRole("checkbox");
+    // action-2 (設計書更新) が先頭になる
+    expect(items[0]).toHaveAttribute("aria-label", "設計書更新を完了にする");
+  });
 });

--- a/src/components/meeting/carryover-action-list.tsx
+++ b/src/components/meeting/carryover-action-list.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { formatDate } from "@/lib/format";
+
+type CarryoverAction = {
+  id: string;
+  title: string;
+  status: string;
+  dueDate: Date | null;
+};
+
+type Props = {
+  meetingDate: Date;
+  actions: CarryoverAction[];
+  selectedIds: Set<string>;
+  onToggle: (id: string) => void;
+};
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "IN_PROGRESS") {
+    return (
+      <Badge variant="default" className="text-xs shrink-0">
+        進行中
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="text-xs shrink-0">
+      未着手
+    </Badge>
+  );
+}
+
+export function CarryoverActionList({ meetingDate, actions, selectedIds, onToggle }: Props) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-muted-foreground">
+        前回 ({formatDate(meetingDate)}) の未完了アクション
+      </p>
+      <div className="flex flex-col gap-2">
+        {actions.map((action) => {
+          const isSelected = selectedIds.has(action.id);
+          return (
+            <div
+              key={action.id}
+              className={`flex items-center gap-2 text-sm rounded p-2 cursor-pointer transition-colors ${
+                isSelected ? "bg-primary/10 border border-primary/30" : "hover:bg-muted/50"
+              }`}
+              onClick={() => onToggle(action.id)}
+            >
+              <input
+                type="checkbox"
+                id={`carryover-${action.id}`}
+                checked={isSelected}
+                onChange={() => onToggle(action.id)}
+                className="rounded"
+                aria-label={`${action.title}を今回のフォローアップ対象にする`}
+                onClick={(e) => e.stopPropagation()}
+              />
+              <StatusBadge status={action.status} />
+              <span className="flex-1 truncate">{action.title}</span>
+              {action.dueDate && (
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {formatDate(action.dueDate)}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {selectedIds.size > 0 && (
+        <p className="text-xs text-primary font-medium">
+          {selectedIds.size}件を今回のフォローアップ対象に設定
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/meeting/meeting-prepare.tsx
+++ b/src/components/meeting/meeting-prepare.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { CarryoverActionList } from "@/components/meeting/carryover-action-list";
 import { PastMeetingsAccordion } from "@/components/meeting/past-meetings-accordion";
 import { PrepareActionChecklist } from "@/components/meeting/prepare-action-checklist";
 import { TemplateSelector } from "@/components/meeting/template-selector";
@@ -40,10 +41,24 @@ type PendingAction = {
   meeting: { date: Date };
 };
 
+type CarryoverActionItem = {
+  id: string;
+  title: string;
+  status: string;
+  dueDate: Date | null;
+};
+
+type CarryoverData = {
+  meetingId: string;
+  meetingDate: Date;
+  actions: CarryoverActionItem[];
+} | null;
+
 type Props = {
   memberId: string;
   recentMeetings: MeetingData[];
   pendingActions: PendingAction[];
+  carryoverData: CarryoverData;
 };
 
 const categoryOptions = [
@@ -58,9 +73,10 @@ function createEmptyTopic(sortOrder: number): TopicDraft {
   return { category: "WORK_PROGRESS", title: "", notes: "", sortOrder };
 }
 
-export function MeetingPrepare({ memberId, recentMeetings, pendingActions }: Props) {
+export function MeetingPrepare({ memberId, recentMeetings, pendingActions, carryoverData }: Props) {
   const [topics, setTopics] = useState<TopicDraft[]>([createEmptyTopic(0)]);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>();
+  const [selectedFollowUpIds, setSelectedFollowUpIds] = useState<Set<string>>(new Set());
 
   function handleTemplateSelect(template: MeetingTemplate) {
     setSelectedTemplateId(template.id);
@@ -103,11 +119,26 @@ export function MeetingPrepare({ memberId, recentMeetings, pendingActions }: Pro
     toast.success(TOAST_MESSAGES.prepare.topicCopied);
   }
 
+  function handleCarryoverToggle(id: string) {
+    setSelectedFollowUpIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
   function buildStartUrl(): string {
     const validTopics = topics.filter((t) => t.title.trim() !== "");
     const params = new URLSearchParams();
     if (validTopics.length > 0) {
       params.set("preparedTopics", JSON.stringify(validTopics));
+    }
+    if (selectedFollowUpIds.size > 0) {
+      params.set("followUpActionIds", JSON.stringify(Array.from(selectedFollowUpIds)));
     }
     const query = params.toString();
     return `/members/${memberId}/meetings/new${query ? `?${query}` : ""}`;
@@ -117,6 +148,22 @@ export function MeetingPrepare({ memberId, recentMeetings, pendingActions }: Pro
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
       {/* Left column: Previous meetings review & pending actions */}
       <div className="flex flex-col gap-4">
+        {carryoverData && (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">前回からの引き継ぎ</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <CarryoverActionList
+                meetingDate={carryoverData.meetingDate}
+                actions={carryoverData.actions}
+                selectedIds={selectedFollowUpIds}
+                onToggle={handleCarryoverToggle}
+              />
+            </CardContent>
+          </Card>
+        )}
+
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">未完了アクション</CardTitle>

--- a/src/components/meeting/previous-meeting-sidebar.tsx
+++ b/src/components/meeting/previous-meeting-sidebar.tsx
@@ -12,9 +12,18 @@ import { formatDate } from "@/lib/format";
 type Topic = { id: string; category: string; title: string; notes: string };
 type ActionItem = { id: string; title: string; status: string; dueDate: Date | null };
 type MeetingData = { id: string; date: Date; topics: Topic[]; actionItems: ActionItem[] } | null;
-type Props = { previousMeeting: MeetingData; pendingActions: ActionItem[] };
+type Props = {
+  previousMeeting: MeetingData;
+  pendingActions: ActionItem[];
+  followUpActionIds?: string[];
+};
 
-export function PreviousMeetingSidebar({ previousMeeting, pendingActions }: Props) {
+export function PreviousMeetingSidebar({
+  previousMeeting,
+  pendingActions,
+  followUpActionIds = [],
+}: Props) {
+  const followUpSet = new Set(followUpActionIds);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [optimisticActions, setOptimisticActions] = useOptimistic(
@@ -34,6 +43,12 @@ export function PreviousMeetingSidebar({ previousMeeting, pendingActions }: Prop
     });
   }
 
+  const sortedActions = [...optimisticActions].sort((a, b) => {
+    const aIsFollowUp = followUpSet.has(a.id) ? 0 : 1;
+    const bIsFollowUp = followUpSet.has(b.id) ? 0 : 1;
+    return aIsFollowUp - bIsFollowUp;
+  });
+
   return (
     <div className="flex flex-col gap-4">
       <Card>
@@ -45,26 +60,40 @@ export function PreviousMeetingSidebar({ previousMeeting, pendingActions }: Prop
             <p className="text-sm text-muted-foreground">なし</p>
           ) : (
             <div className={`flex flex-col gap-2 ${isPending ? "opacity-80" : ""}`}>
-              {optimisticActions.map((action) => (
-                <div
-                  key={action.id}
-                  className={`flex items-center gap-2 text-sm ${action.status === "DONE" ? "line-through text-muted-foreground" : ""}`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={action.status === "DONE"}
-                    onChange={() => markDone(action.id)}
-                    className="rounded"
-                    aria-label={`${action.title}を完了にする`}
-                  />
-                  <span>{action.title}</span>
-                  {action.dueDate && (
-                    <span className="text-xs text-muted-foreground ml-auto">
-                      {formatDate(action.dueDate)}
-                    </span>
-                  )}
-                </div>
-              ))}
+              {sortedActions.map((action) => {
+                const isFollowUp = followUpSet.has(action.id);
+                return (
+                  <div
+                    key={action.id}
+                    className={`flex items-center gap-2 text-sm rounded p-1 ${
+                      action.status === "DONE"
+                        ? "line-through text-muted-foreground"
+                        : isFollowUp
+                          ? "bg-primary/10 border border-primary/20"
+                          : ""
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={action.status === "DONE"}
+                      onChange={() => markDone(action.id)}
+                      className="rounded"
+                      aria-label={`${action.title}を完了にする`}
+                    />
+                    {isFollowUp && action.status !== "DONE" && (
+                      <Badge variant="secondary" className="text-xs shrink-0 px-1">
+                        引き継ぎ
+                      </Badge>
+                    )}
+                    <span className="flex-1">{action.title}</span>
+                    {action.dueDate && (
+                      <span className="text-xs text-muted-foreground ml-auto">
+                        {formatDate(action.dueDate)}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )}
         </CardContent>

--- a/src/lib/actions/__tests__/action-item-actions.test.ts
+++ b/src/lib/actions/__tests__/action-item-actions.test.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import {
   createActionItemForMeeting,
   getActionItems,
+  getLastMeetingPendingActions,
   getPendingActionItems,
   updateActionItem,
   updateActionItemStatus,
@@ -327,5 +328,107 @@ describe("createActionItemForMeeting", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.data.sortOrder).toBe(1);
+  });
+});
+
+describe("getLastMeetingPendingActions", () => {
+  it("前回ミーティングの未完了アクションを返す", async () => {
+    await createMeeting({
+      memberId,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [
+        { title: "未完了タスク", description: "" },
+        { title: "完了タスク", description: "" },
+      ],
+    });
+
+    const items = await prisma.actionItem.findMany({ where: { memberId } });
+    const doneItem = items.find((i) => i.title === "完了タスク");
+    if (doneItem) {
+      await prisma.actionItem.update({
+        where: { id: doneItem.id },
+        data: { status: "DONE" },
+      });
+    }
+
+    const result = await getLastMeetingPendingActions(memberId);
+    expect(result).not.toBeNull();
+    expect(result!.actions).toHaveLength(1);
+    expect(result!.actions[0].title).toBe("未完了タスク");
+    expect(result!.actions[0].status).not.toBe("DONE");
+  });
+
+  it("前回ミーティングが存在しない場合は null を返す", async () => {
+    const newMemberResult = await createMember({ name: "新規メンバー引き継ぎ" });
+    if (!newMemberResult.success) throw new Error(newMemberResult.error);
+    const newMemberId = newMemberResult.data.id;
+
+    const result = await getLastMeetingPendingActions(newMemberId);
+    expect(result).toBeNull();
+  });
+
+  it("前回ミーティングの全アクションが完了済みの場合は null を返す", async () => {
+    await createMeeting({
+      memberId,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [{ title: "完了タスク", description: "" }],
+    });
+
+    const items = await prisma.actionItem.findMany({ where: { memberId } });
+    for (const item of items) {
+      await prisma.actionItem.update({
+        where: { id: item.id },
+        data: { status: "DONE" },
+      });
+    }
+
+    const result = await getLastMeetingPendingActions(memberId);
+    expect(result).toBeNull();
+  });
+
+  it("最新のミーティングのアクションのみを返す", async () => {
+    // beforeEach で今日のミーティングが作成されるため、未来の日付を使用する
+    const futureDate1 = new Date();
+    futureDate1.setFullYear(futureDate1.getFullYear() + 1);
+    const futureDate2 = new Date();
+    futureDate2.setFullYear(futureDate2.getFullYear() + 2);
+
+    await createMeeting({
+      memberId,
+      date: futureDate1.toISOString(),
+      topics: [],
+      actionItems: [{ title: "古いタスク", description: "" }],
+    });
+    await createMeeting({
+      memberId,
+      date: futureDate2.toISOString(),
+      topics: [],
+      actionItems: [{ title: "新しいタスク", description: "" }],
+    });
+
+    const result = await getLastMeetingPendingActions(memberId);
+    expect(result).not.toBeNull();
+    expect(result!.actions).toHaveLength(1);
+    expect(result!.actions[0].title).toBe("新しいタスク");
+  });
+
+  it("meetingDate と meetingId を返す", async () => {
+    // beforeEach で今日のミーティングが作成されるため、未来の日付を使用する
+    const futureDate = new Date();
+    futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+    await createMeeting({
+      memberId,
+      date: futureDate.toISOString(),
+      topics: [],
+      actionItems: [{ title: "タスク", description: "" }],
+    });
+
+    const result = await getLastMeetingPendingActions(memberId);
+    expect(result).not.toBeNull();
+    expect(result!.meetingId).toBeDefined();
+    expect(result!.meetingDate).toBeInstanceOf(Date);
   });
 });

--- a/src/lib/actions/action-item-actions.ts
+++ b/src/lib/actions/action-item-actions.ts
@@ -143,6 +143,53 @@ export async function updateActionItem(
   });
 }
 
+export type CarryoverAction = {
+  id: string;
+  title: string;
+  status: string;
+  dueDate: Date | null;
+};
+
+export type LastMeetingPendingActionsResult = {
+  meetingId: string;
+  meetingDate: Date;
+  actions: CarryoverAction[];
+} | null;
+
+export async function getLastMeetingPendingActions(
+  memberId: string,
+): Promise<LastMeetingPendingActionsResult> {
+  const lastMeeting = await prisma.meeting.findFirst({
+    where: { memberId },
+    orderBy: { date: "desc" },
+    select: { id: true, date: true },
+  });
+
+  if (!lastMeeting) return null;
+
+  const actions = await prisma.actionItem.findMany({
+    where: {
+      meetingId: lastMeeting.id,
+      status: { not: "DONE" },
+    },
+    orderBy: [{ dueDate: "asc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      dueDate: true,
+    },
+  });
+
+  if (actions.length === 0) return null;
+
+  return {
+    meetingId: lastMeeting.id,
+    meetingDate: lastMeeting.date,
+    actions,
+  };
+}
+
 export async function createActionItemForMeeting(
   meetingId: string,
   memberId: string,


### PR DESCRIPTION
## 概要

issue #116 の対応。準備画面（`/members/[id]/meetings/prepare`）に「前回からの引き継ぎ」セクションを追加し、前回ミーティングの未完了アクションアイテムを確認・フォローアップ対象として選択できるようにする。

## 変更内容

### 新規ファイル
- `src/components/meeting/carryover-action-list.tsx` — 引き継ぎアクション一覧コンポーネント（チェックボックス付き）
- `src/components/meeting/__tests__/carryover-action-list.test.tsx` — コンポーネントテスト（8件）

### 変更ファイル
- `src/lib/actions/action-item-actions.ts` — `getLastMeetingPendingActions` Server Action を追加
- `src/lib/actions/__tests__/action-item-actions.test.ts` — 新 Action のテスト追加（5件）
- `src/app/members/[id]/meetings/prepare/page.tsx` — 並列データフェッチで `carryoverData` を取得
- `src/components/meeting/meeting-prepare.tsx` — 引き継ぎセクション統合・`followUpActionIds` URL パラメータ対応
- `src/components/meeting/__tests__/meeting-prepare.test.tsx` — `carryoverData` props 対応・新テスト追加
- `src/app/members/[id]/meetings/new/page.tsx` — `followUpActionIds` URL パラメータのパース追加
- `src/components/meeting/previous-meeting-sidebar.tsx` — フォローアップ対象に「引き継ぎ」バッジ表示・優先ソート
- `src/components/meeting/__tests__/previous-meeting-sidebar.test.tsx` — `followUpActionIds` 関連テスト追加

## 機能

- **前回からの引き継ぎセクション**: 準備画面の左カラムに追加。前回ミーティング（最新）の未完了アクション（TODO/IN_PROGRESS）を表示
- **ステータス・期日確認**: 各アイテムに「未着手」「進行中」バッジと期日を表示
- **フォローアップ対象選択**: チェックボックスで選択し、選択件数をリアルタイム表示
- **記録画面への引き渡し**: 選択したIDを `followUpActionIds` URL パラメータで記録画面へ
- **記録画面での優先表示**: `PreviousMeetingSidebar` でフォローアップ対象を先頭表示・「引き継ぎ」バッジ付き
- **前回ミーティングなし時の非表示**: `carryoverData` が null の場合はセクション自体を非表示（AC4）

## テスト計画

- [x] `npm test` — 4ファイル 57テスト全パス（新規・変更テスト対象）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] 前回ミーティングに未完了アクションがあるメンバーの準備画面を開く
- [ ] 「前回からの引き継ぎ」セクションが表示されることを確認
- [ ] フォローアップ対象にチェックを付ける
- [ ] 「ミーティングを開始」をクリック → 記録画面でフォローアップアクションが優先表示・「引き継ぎ」バッジを確認
- [ ] 前回ミーティングがないメンバーの準備画面でセクションが非表示を確認

Closes #116