### PR TITLE
fix: アクション一覧のページネーションクラッシュを修正する (issue #147)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -86,19 +86,6 @@ export default async function ActionsPage({ searchParams }: Props) {
     !!filters.keyword ||
     (!!filters.dateFilter && filters.dateFilter !== "all");
 
-  function buildPageUrl(page: number): string {
-    const p = new URLSearchParams();
-    if (params.status) p.set("status", params.status);
-    if (params.memberId) p.set("memberId", params.memberId);
-    if (params.tag) p.set("tag", params.tag);
-    if (params.q) p.set("q", params.q);
-    if (params.dateFilter) p.set("dateFilter", params.dateFilter);
-    if (params.sort) p.set("sort", params.sort);
-    if (page > 1) p.set("page", String(page));
-    const query = p.toString();
-    return `/actions${query ? `?${query}` : ""}`;
-  }
-
   return (
     <div className="animate-fade-in-up">
       <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "アクション一覧" }]} />
@@ -118,11 +105,7 @@ export default async function ActionsPage({ searchParams }: Props) {
         <ActionFilters members={memberList} tags={tagList} />
       </Suspense>
       <ActionListFull actionItems={actionItemsWithTags} statusFilter={filters.status} />
-      <ActionPagination
-        currentPage={currentPage}
-        totalPages={totalPages}
-        buildPageUrl={buildPageUrl}
-      />
+      <ActionPagination currentPage={currentPage} totalPages={totalPages} searchParams={params} />
     </div>
   );
 }

--- a/src/components/action/__tests__/action-pagination.test.tsx
+++ b/src/components/action/__tests__/action-pagination.test.tsx
@@ -7,67 +7,80 @@ afterEach(() => {
   cleanup();
 });
 
-const buildPageUrl = (page: number) => `/actions?page=${page}`;
-
 describe("ActionPagination", () => {
   it("totalPages が 1 のとき何も表示しない", () => {
     const { container } = render(
-      <ActionPagination currentPage={1} totalPages={1} buildPageUrl={buildPageUrl} />,
+      <ActionPagination currentPage={1} totalPages={1} searchParams={{}} />,
     );
     expect(container.firstChild).toBeNull();
   });
 
   it("totalPages が 0 のとき何も表示しない", () => {
     const { container } = render(
-      <ActionPagination currentPage={1} totalPages={0} buildPageUrl={buildPageUrl} />,
+      <ActionPagination currentPage={1} totalPages={0} searchParams={{}} />,
     );
     expect(container.firstChild).toBeNull();
   });
 
   it("複数ページのとき前へ・次へボタンが表示される", () => {
-    render(<ActionPagination currentPage={2} totalPages={3} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={2} totalPages={3} searchParams={{}} />);
     expect(screen.getByRole("link", { name: "前のページ" })).toBeDefined();
     expect(screen.getByRole("link", { name: "次のページ" })).toBeDefined();
   });
 
   it("1ページ目のとき前へボタンが無効", () => {
-    render(<ActionPagination currentPage={1} totalPages={3} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={1} totalPages={3} searchParams={{}} />);
     expect(screen.queryByRole("link", { name: "前のページ" })).toBeNull();
   });
 
   it("最終ページのとき次へボタンが無効", () => {
-    render(<ActionPagination currentPage={3} totalPages={3} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={3} totalPages={3} searchParams={{}} />);
     expect(screen.queryByRole("link", { name: "次のページ" })).toBeNull();
   });
 
   it("7ページ以下のとき全ページ番号が表示される", () => {
-    render(<ActionPagination currentPage={1} totalPages={5} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={1} totalPages={5} searchParams={{}} />);
     expect(screen.getByRole("link", { name: "2ページ目" })).toBeDefined();
     expect(screen.getByRole("link", { name: "5ページ目" })).toBeDefined();
   });
 
   it("現在のページ番号はリンクでなくボタン表示", () => {
-    render(<ActionPagination currentPage={2} totalPages={5} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={2} totalPages={5} searchParams={{}} />);
     // 現在ページ (2) はリンクではなくボタン表示
     const currentPageBtn = screen.getByText("2");
     expect(currentPageBtn.closest("a")).toBeNull();
   });
 
   it("8ページ以上のとき省略記号が表示される", () => {
-    render(<ActionPagination currentPage={5} totalPages={10} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={5} totalPages={10} searchParams={{}} />);
     const ellipses = screen.getAllByText("…");
     expect(ellipses.length).toBeGreaterThanOrEqual(1);
   });
 
   it("前へリンクが正しいURLを持つ", () => {
-    render(<ActionPagination currentPage={3} totalPages={5} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={3} totalPages={5} searchParams={{}} />);
     const prevLink = screen.getByRole("link", { name: "前のページ" });
     expect(prevLink.getAttribute("href")).toBe("/actions?page=2");
   });
 
   it("次へリンクが正しいURLを持つ", () => {
-    render(<ActionPagination currentPage={2} totalPages={5} buildPageUrl={buildPageUrl} />);
+    render(<ActionPagination currentPage={2} totalPages={5} searchParams={{}} />);
     const nextLink = screen.getByRole("link", { name: "次のページ" });
     expect(nextLink.getAttribute("href")).toBe("/actions?page=3");
+  });
+
+  it("フィルターパラメータがURLに引き継がれる", () => {
+    render(
+      <ActionPagination
+        currentPage={1}
+        totalPages={3}
+        searchParams={{ status: "TODO", sort: "dueDate" }}
+      />,
+    );
+    const nextLink = screen.getByRole("link", { name: "次のページ" });
+    const href = nextLink.getAttribute("href") ?? "";
+    expect(href).toContain("status=TODO");
+    expect(href).toContain("sort=dueDate");
+    expect(href).toContain("page=2");
   });
 });

--- a/src/components/action/action-pagination.tsx
+++ b/src/components/action/action-pagination.tsx
@@ -5,13 +5,35 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 
+type ActionSearchParams = {
+  status?: string;
+  memberId?: string;
+  tag?: string;
+  q?: string;
+  dateFilter?: string;
+  sort?: string;
+};
+
 type Props = {
   currentPage: number;
   totalPages: number;
-  buildPageUrl: (page: number) => string;
+  searchParams: ActionSearchParams;
 };
 
-export function ActionPagination({ currentPage, totalPages, buildPageUrl }: Props) {
+function buildPageUrl(searchParams: ActionSearchParams, page: number): string {
+  const p = new URLSearchParams();
+  if (searchParams.status) p.set("status", searchParams.status);
+  if (searchParams.memberId) p.set("memberId", searchParams.memberId);
+  if (searchParams.tag) p.set("tag", searchParams.tag);
+  if (searchParams.q) p.set("q", searchParams.q);
+  if (searchParams.dateFilter) p.set("dateFilter", searchParams.dateFilter);
+  if (searchParams.sort) p.set("sort", searchParams.sort);
+  if (page > 1) p.set("page", String(page));
+  const query = p.toString();
+  return `/actions${query ? `?${query}` : ""}`;
+}
+
+export function ActionPagination({ currentPage, totalPages, searchParams }: Props) {
   if (totalPages <= 1) return null;
 
   const pages = buildPageNumbers(currentPage, totalPages);
@@ -24,7 +46,7 @@ export function ActionPagination({ currentPage, totalPages, buildPageUrl }: Prop
             <ChevronLeft className="h-4 w-4" />
           </span>
         ) : (
-          <Link href={buildPageUrl(currentPage - 1)} aria-label="前のページ">
+          <Link href={buildPageUrl(searchParams, currentPage - 1)} aria-label="前のページ">
             <ChevronLeft className="h-4 w-4" />
           </Link>
         )}
@@ -45,7 +67,7 @@ export function ActionPagination({ currentPage, totalPages, buildPageUrl }: Prop
             {p === currentPage ? (
               <span>{p}</span>
             ) : (
-              <Link href={buildPageUrl(p as number)} aria-label={`${p}ページ目`}>
+              <Link href={buildPageUrl(searchParams, p as number)} aria-label={`${p}ページ目`}>
                 {p}
               </Link>
             )}
@@ -59,7 +81,7 @@ export function ActionPagination({ currentPage, totalPages, buildPageUrl }: Prop
             <ChevronRight className="h-4 w-4" />
           </span>
         ) : (
-          <Link href={buildPageUrl(currentPage + 1)} aria-label="次のページ">
+          <Link href={buildPageUrl(searchParams, currentPage + 1)} aria-label="次のページ">
             <ChevronRight className="h-4 w-4" />
           </Link>
         )}


### PR DESCRIPTION
## 概要

issue #147 の対応。アクション一覧ページ (`/actions`) でサーバーコンポーネントからクライアントコンポーネントに `buildPageUrl` 関数を props として渡していたことで発生するページクラッシュを修正する。

## 変更内容

### 変更ファイル
- `src/components/action/action-pagination.tsx` — `buildPageUrl` prop を削除し、`searchParams` prop に変更。URL 構築ロジックをコンポーネント内に移動
- `src/app/actions/page.tsx` — `buildPageUrl` 関数定義を削除し、`<ActionPagination>` に `searchParams={params}` を渡すよう変更
- `src/components/action/__tests__/action-pagination.test.tsx` — 新しい props インターフェースに合わせてテストを更新。フィルターパラメータが URL に引き継がれることを確認するテストを追加

## 原因と修正方針

React/Next.js はサーバーコンポーネントからクライアントコンポーネントへ関数を直接渡せない。`ActionPagination` は `"use client"` のクライアントコンポーネントであるため、`buildPageUrl` 関数を props として受け取ることができなかった。

修正として、関数の代わりにフィルター条件を表すシリアライズ可能なデータ（`searchParams` オブジェクト）を渡し、URL 構築ロジックをクライアントコンポーネント内に移動した。

## テスト計画

- [x] `npm test` — 1 ファイル 11 テスト全パス（フィルターパラメータ引き継ぎのテストを新規追加）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] `/actions` にアクセスしてページが正常に表示されることを確認
- [ ] フィルターを設定した状態でページネーションが正しく動作することを確認

Closes #147