### PR TITLE
test: recharts チャートコンポーネントのユニットテストを追加する (issue #141)

### DIFF
--- a/src/components/analytics/__tests__/action-completion-trend-chart.test.tsx
+++ b/src/components/analytics/__tests__/action-completion-trend-chart.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ActionCompletionTrendChart } from "../action-completion-trend-chart";
+
+vi.mock("recharts", () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => cleanup());
+
+describe("ActionCompletionTrendChart", () => {
+  it("renders empty state when no data", () => {
+    render(<ActionCompletionTrendChart data={[]} />);
+    expect(screen.getByText("データがありません")).toBeDefined();
+  });
+
+  it("renders line chart when data exists", () => {
+    const data = [
+      { month: "2026-01", created: 5, completed: 4 },
+      { month: "2026-02", created: 3, completed: 3 },
+    ];
+    render(<ActionCompletionTrendChart data={data} />);
+    expect(screen.getByTestId("line-chart")).toBeDefined();
+  });
+
+  it("renders card title", () => {
+    render(<ActionCompletionTrendChart data={[]} />);
+    expect(screen.getByText("月次完了トレンド")).toBeDefined();
+  });
+});

--- a/src/components/analytics/__tests__/topic-distribution-chart.test.tsx
+++ b/src/components/analytics/__tests__/topic-distribution-chart.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TopicDistributionChart } from "../topic-distribution-chart";
+
+vi.mock("recharts", () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: () => null,
+  Cell: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => cleanup());
+
+describe("TopicDistributionChart", () => {
+  it("renders empty state when no data", () => {
+    render(<TopicDistributionChart data={[]} />);
+    expect(screen.getByText("データがありません")).toBeDefined();
+  });
+
+  it("renders pie chart when data exists", () => {
+    const data = [
+      { category: "WORK_PROGRESS" as const, count: 5 },
+      { category: "CAREER" as const, count: 3 },
+    ];
+    render(<TopicDistributionChart data={data} />);
+    expect(screen.getByTestId("pie-chart")).toBeDefined();
+  });
+
+  it("renders card title", () => {
+    render(<TopicDistributionChart data={[]} />);
+    expect(screen.getByText("話題カテゴリの分布")).toBeDefined();
+  });
+});

--- a/src/components/analytics/__tests__/topic-trend-chart.test.tsx
+++ b/src/components/analytics/__tests__/topic-trend-chart.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TopicTrendChart } from "../topic-trend-chart";
+
+vi.mock("recharts", () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => cleanup());
+
+describe("TopicTrendChart", () => {
+  it("renders empty state when no data", () => {
+    render(<TopicTrendChart data={[]} />);
+    expect(screen.getByText("データがありません")).toBeDefined();
+  });
+
+  it("renders bar chart when data exists", () => {
+    const data = [{ month: "2026-01", WORK_PROGRESS: 3, CAREER: 1 }];
+    render(<TopicTrendChart data={data} />);
+    expect(screen.getByTestId("bar-chart")).toBeDefined();
+  });
+
+  it("renders card title", () => {
+    render(<TopicTrendChart data={[]} />);
+    expect(screen.getByText("話題の時系列推移")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## 概要

issue #141 の対応。recharts を使用する 3 つのチャートコンポーネント（`TopicDistributionChart`・`TopicTrendChart`・`ActionCompletionTrendChart`）にユニットテストが存在しなかったため追加する。

コードフィックス自体は PR #159 (issue #148) で実施済み。本 PR ではテストカバレッジを補完し issue をクローズする。

## 変更内容

### 新規ファイル

- `src/components/analytics/__tests__/topic-distribution-chart.test.tsx` — 話題カテゴリ分布チャートのテスト
- `src/components/analytics/__tests__/topic-trend-chart.test.tsx` — 話題時系列推移チャートのテスト
- `src/components/analytics/__tests__/action-completion-trend-chart.test.tsx` — アクション完了トレンドチャートのテスト

## テスト計画

- [x] `npm test` — 103 ファイル 1013 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] `/members/[id]` ページでコンソール警告が出ないことを確認
- [ ] `/analytics` ページでコンソール警告が出ないことを確認

Closes #141