### PR TITLE
ux: ミーティング詳細に印刷/PDF保存機能を追加する (issue #140)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -208,6 +208,43 @@
   animation: pulse-attention 2s ease-in-out infinite;
 }
 
+@media print {
+  @page {
+    size: A4;
+    margin: 20mm;
+  }
+
+  /* ダークモードを白背景・黒文字に上書き */
+  :root,
+  .dark {
+    --background: oklch(1 0 0);
+    --foreground: oklch(0 0 0);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0 0 0);
+    --muted: oklch(0.96 0 0);
+    --muted-foreground: oklch(0.45 0 0);
+    --border: oklch(0.8 0 0);
+    --primary: oklch(0.3 0.1 270);
+    --primary-foreground: oklch(1 0 0);
+  }
+
+  * {
+    animation: none !important;
+    transition: none !important;
+    box-shadow: none !important;
+  }
+
+  body {
+    background: white !important;
+    color: black !important;
+  }
+
+  main {
+    overflow: visible !important;
+    padding: 0 !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-fade-in-up,
   .animate-slide-in,

--- a/src/app/members/[id]/meetings/[meetingId]/page.tsx
+++ b/src/app/members/[id]/meetings/[meetingId]/page.tsx
@@ -5,6 +5,7 @@ import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { CoachingPanel } from "@/components/meeting/coaching-panel";
 import { MeetingDetailPageClient } from "@/components/meeting/meeting-detail-page-client";
 import { MeetingHeaderActions } from "@/components/meeting/meeting-header-actions";
+import { PrintButton } from "@/components/meeting/print-button";
 import { Button } from "@/components/ui/button";
 import { getMeeting } from "@/lib/actions/meeting-actions";
 import { formatDate } from "@/lib/format";
@@ -20,18 +21,21 @@ export default async function MeetingDetailPage({ params }: Props) {
 
   return (
     <div className="animate-fade-in-up">
-      <Breadcrumb
-        items={[
-          { label: "ダッシュボード", href: "/" },
-          { label: meeting.member.name, href: `/members/${id}` },
-          { label: formatDate(meeting.date) },
-        ]}
-      />
+      <div className="print:hidden">
+        <Breadcrumb
+          items={[
+            { label: "ダッシュボード", href: "/" },
+            { label: meeting.member.name, href: `/members/${id}` },
+            { label: formatDate(meeting.date) },
+          ]}
+        />
+      </div>
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
           {meeting.member.name}との1on1
         </h1>
-        <div className="flex gap-2">
+        <div className="flex gap-2 print:hidden">
+          <PrintButton />
           <MeetingHeaderActions
             meetingId={meetingId}
             memberId={id}
@@ -83,7 +87,7 @@ export default async function MeetingDetailPage({ params }: Props) {
             }))}
           />
         </div>
-        <aside className="hidden lg:block">
+        <aside className="hidden lg:block print:hidden">
           <div className="sticky top-6">
             <CoachingPanel />
           </div>

--- a/src/components/action/action-list-compact.tsx
+++ b/src/components/action/action-list-compact.tsx
@@ -219,6 +219,7 @@ export function ActionListCompact({ actionItems, meetingId, memberId }: Props) {
                 size="icon-xs"
                 aria-label="編集"
                 onClick={() => handleEdit(item)}
+                className="print:hidden"
               >
                 <Pencil />
               </Button>
@@ -252,7 +253,7 @@ export function ActionListCompact({ actionItems, meetingId, memberId }: Props) {
         </div>
       )}
       {canAdd && !showAddForm && (
-        <div className="flex justify-end mt-1">
+        <div className="flex justify-end mt-1 print:hidden">
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -151,7 +151,7 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
   return (
     <>
       {/* モバイルトップバー */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 z-40 h-14 bg-sidebar border-b flex items-center px-4">
+      <div className="lg:hidden print:hidden fixed top-0 left-0 right-0 z-40 h-14 bg-sidebar border-b flex items-center px-4">
         <button
           onClick={() => setIsOpen(true)}
           className="p-3 rounded-lg hover:bg-accent transition-colors duration-150"
@@ -203,7 +203,7 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
       )}
 
       {/* デスクトップサイドバー */}
-      <aside className="hidden lg:flex w-56 border-r bg-sidebar p-4 flex-col gap-6 shrink-0">
+      <aside className="hidden lg:flex print:hidden w-56 border-r bg-sidebar p-4 flex-col gap-6 shrink-0">
         <Link href="/" className="text-lg font-semibold tracking-tight text-foreground">
           Nudge
         </Link>

--- a/src/components/meeting/__tests__/print-button.test.tsx
+++ b/src/components/meeting/__tests__/print-button.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PrintButton } from "../print-button";
+
+describe("PrintButton", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("「印刷 / PDFで保存」ボタンが表示される", () => {
+    render(<PrintButton />);
+    expect(screen.getByRole("button", { name: /印刷 \/ PDFで保存/ })).toBeInTheDocument();
+  });
+
+  it("クリック時に window.print() が呼ばれる", async () => {
+    const printMock = vi.spyOn(window, "print").mockImplementation(() => undefined);
+
+    const user = userEvent.setup();
+    const { getByRole } = render(<PrintButton />);
+
+    await user.click(getByRole("button", { name: /印刷 \/ PDFで保存/ }));
+
+    expect(printMock).toHaveBeenCalledOnce();
+
+    printMock.mockRestore();
+  });
+});

--- a/src/components/meeting/meeting-detail-page-client.tsx
+++ b/src/components/meeting/meeting-detail-page-client.tsx
@@ -166,7 +166,7 @@ export function MeetingDetailPageClient({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex justify-end gap-2">
+      <div className="flex justify-end gap-2 print:hidden">
         {!startedAt && !endedAt && (
           <Button variant="default" size="sm" onClick={handleStartMeeting} disabled={isStarting}>
             <Play className="w-4 h-4 mr-1.5" />

--- a/src/components/meeting/print-button.tsx
+++ b/src/components/meeting/print-button.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { Printer } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export function PrintButton() {
+  return (
+    <Button variant="outline" size="sm" onClick={() => window.print()}>
+      <Printer className="w-4 h-4 mr-1.5" />
+      印刷 / PDFで保存
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

- ミーティング詳細ページ（`/members/[id]/meetings/[meetingId]`）に「印刷 / PDFで保存」ボタンを追加し、`window.print()` でブラウザ印刷ダイアログを起動できるようにした
- `@media print` CSS を追加し、印刷時にサイドバー・ヘッダー・UIボタン類を非表示にしてクリーンなレイアウトで出力できるようにした
- ダークモードでも印刷時は白背景・黒文字になるよう CSS 変数を上書きした

## Changes

- `src/components/meeting/print-button.tsx`（新規）: `window.print()` を呼び出すクライアントコンポーネント
- `src/app/globals.css`: `@media print` ブロックを追加（`@page` A4 設定、ダークモード変数上書き、レイアウトリセット）
- `src/components/layout/sidebar.tsx`: モバイルトップバー・デスクトップサイドバーに `print:hidden` を追加
- `src/app/members/[id]/meetings/[meetingId]/page.tsx`: Breadcrumb・ボタン群・CoachingPanel に `print:hidden` を追加、PrintButton を組み込み
- `src/components/meeting/meeting-detail-page-client.tsx`: 編集・記録開始ボタン群に `print:hidden` を追加
- `src/components/action/action-list-compact.tsx`: アクション編集・追加ボタンに `print:hidden` を追加

## Test Plan

- [ ] ミーティング詳細ページで「印刷 / PDFで保存」ボタンが表示される
- [ ] ボタンをクリックするとブラウザの印刷ダイアログが開く
- [ ] 印刷プレビューでサイドバー・ヘッダー・ボタン類が非表示になっている
- [ ] 印刷プレビューでメンバー名・日時・チェックイン・トピック・アクションアイテムが表示されている
- [ ] ダークモード時でも印刷プレビューが白背景・黒文字になる
- [ ] A4 サイズで適切に収まるレイアウトになっている
- [ ] `npm test` 1006件すべてパス

Closes #140