### PR TITLE
feat: アクション一覧のグループ化表示を追加する (issue #139)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 
 import { ActionFilters } from "@/components/action/action-filters";
 import { ActionListFull } from "@/components/action/action-list-full";
+import { ActionListGrouped } from "@/components/action/action-list-grouped";
 import { ActionPagination } from "@/components/action/action-pagination";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { Badge } from "@/components/ui/badge";
@@ -9,13 +10,16 @@ import type { DateFilterType, SortByType } from "@/lib/actions/action-item-actio
 import { getActionItems } from "@/lib/actions/action-item-actions";
 import { getMembers } from "@/lib/actions/member-actions";
 import { getTags } from "@/lib/actions/tag-actions";
+import type { GroupByType } from "@/lib/group-actions";
 import type { ActionItemStatusType } from "@/lib/validations/action-item";
 
 export const dynamic = "force-dynamic";
 
 const DATE_FILTERS: DateFilterType[] = ["all", "overdue", "this-week", "this-month"];
 const SORT_OPTIONS: SortByType[] = ["dueDate", "createdAt", "memberName"];
+const GROUP_BY_OPTIONS: GroupByType[] = ["none", "member", "dueDate", "tag"];
 const PER_PAGE = 20;
+const PER_PAGE_GROUPED = 1000;
 
 type Props = {
   searchParams: Promise<{
@@ -26,6 +30,7 @@ type Props = {
     dateFilter?: string;
     sort?: string;
     page?: string;
+    groupBy?: string;
   }>;
 };
 
@@ -62,9 +67,15 @@ export default async function ActionsPage({ searchParams }: Props) {
     filters.sortBy = params.sort as SortByType;
   }
 
-  const currentPage = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
+  const groupBy: GroupByType =
+    params.groupBy && GROUP_BY_OPTIONS.includes(params.groupBy as GroupByType)
+      ? (params.groupBy as GroupByType)
+      : "none";
+
+  const isGrouped = groupBy !== "none";
+  const currentPage = isGrouped ? 1 : Math.max(1, parseInt(params.page ?? "1", 10) || 1);
   filters.page = currentPage;
-  filters.perPage = PER_PAGE;
+  filters.perPage = isGrouped ? PER_PAGE_GROUPED : PER_PAGE;
 
   const [{ items: actionItems, total, totalPages }, members, allTags] = await Promise.all([
     getActionItems(filters),
@@ -104,8 +115,22 @@ export default async function ActionsPage({ searchParams }: Props) {
       <Suspense>
         <ActionFilters members={memberList} tags={tagList} />
       </Suspense>
-      <ActionListFull actionItems={actionItemsWithTags} statusFilter={filters.status} />
-      <ActionPagination currentPage={currentPage} totalPages={totalPages} searchParams={params} />
+      {isGrouped ? (
+        <ActionListGrouped
+          actionItems={actionItemsWithTags}
+          groupBy={groupBy}
+          statusFilter={filters.status}
+        />
+      ) : (
+        <>
+          <ActionListFull actionItems={actionItemsWithTags} statusFilter={filters.status} />
+          <ActionPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            searchParams={params}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/action/__tests__/action-filters.test.tsx
+++ b/src/components/action/__tests__/action-filters.test.tsx
@@ -73,19 +73,27 @@ describe("buildFilterUrl", () => {
   it("フィルターが 'all' のときも page パラメータを削除する", () => {
     expect(buildFilterUrl("status=TODO&page=2", "status", "all")).toBe("/actions?");
   });
+
+  it("value が 'none' のとき該当キーを削除する", () => {
+    expect(buildFilterUrl("groupBy=member", "groupBy", "none")).toBe("/actions?");
+  });
+
+  it("groupBy パラメータを設定できる", () => {
+    expect(buildFilterUrl("", "groupBy", "member")).toBe("/actions?groupBy=member");
+  });
 });
 
 describe("ActionFilters", () => {
-  it("4つのフィルターセレクトが表示される（ステータス・メンバー・期限・並び順）", () => {
+  it("5つのフィルターセレクトが表示される（グループ化・ステータス・メンバー・期限・並び順）", () => {
     render(<ActionFilters members={mockMembers} />);
     const triggers = screen.getAllByRole("combobox");
-    expect(triggers.length).toBe(4);
+    expect(triggers.length).toBe(5);
   });
 
   it("空のメンバーリストでもレンダリングされる", () => {
     render(<ActionFilters members={[]} />);
     const triggers = screen.getAllByRole("combobox");
-    expect(triggers.length).toBe(4);
+    expect(triggers.length).toBe(5);
   });
 
   it("キーワード検索のインプットが表示される", () => {

--- a/src/components/action/__tests__/action-list-grouped.test.tsx
+++ b/src/components/action/__tests__/action-list-grouped.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ActionListGrouped } from "../action-list-grouped";
+
+// ActionListFull をモック（グループ化ロジックのテストに集中）
+vi.mock("../action-list-full", () => ({
+  ActionListFull: ({ actionItems }: { actionItems: { id: string; title: string }[] }) => (
+    <ul data-testid="action-list-full">
+      {actionItems.map((item) => (
+        <li key={item.id}>{item.title}</li>
+      ))}
+    </ul>
+  ),
+}));
+
+const mockRouter = { push: vi.fn(), refresh: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeItem(id: string, memberName: string, memberId: string) {
+  return {
+    id,
+    title: `アクション ${id}`,
+    description: "",
+    status: "TODO",
+    dueDate: null,
+    member: { id: memberId, name: memberName },
+    meeting: { id: "meet-1", date: new Date("2024-01-01") },
+    tags: [],
+  };
+}
+
+const sampleItems = [
+  makeItem("1", "田中太郎", "m1"),
+  makeItem("2", "佐藤花子", "m2"),
+  makeItem("3", "田中太郎", "m1"),
+];
+
+describe("ActionListGrouped", () => {
+  describe("メンバー別グループ化", () => {
+    it("メンバー名のグループヘッダーを表示する", () => {
+      render(<ActionListGrouped actionItems={sampleItems} groupBy="member" />);
+      expect(screen.getByText("田中太郎")).toBeDefined();
+      expect(screen.getByText("佐藤花子")).toBeDefined();
+    });
+
+    it("各グループヘッダーに件数バッジを表示する", () => {
+      render(<ActionListGrouped actionItems={sampleItems} groupBy="member" />);
+      // 田中 2件、佐藤 1件
+      expect(screen.getByText("2")).toBeDefined();
+      expect(screen.getByText("1")).toBeDefined();
+    });
+
+    it("グループ内に ActionListFull が表示される", () => {
+      render(<ActionListGrouped actionItems={sampleItems} groupBy="member" />);
+      const lists = screen.getAllByTestId("action-list-full");
+      expect(lists).toHaveLength(2);
+    });
+
+    it("グループはデフォルトで展開されている", () => {
+      render(<ActionListGrouped actionItems={sampleItems} groupBy="member" />);
+      expect(screen.getByText("アクション 1")).toBeDefined();
+      expect(screen.getByText("アクション 2")).toBeDefined();
+    });
+  });
+
+  describe("折りたたみ機能", () => {
+    it("グループヘッダーをクリックすると折りたたまれる", () => {
+      render(<ActionListGrouped actionItems={sampleItems} groupBy="member" />);
+      const tanakaHeader = screen.getByRole("button", { name: /田中太郎/ });
+      fireEvent.click(tanakaHeader);
+      // 田中グループ内のアイテムが非表示になる
+      expect(screen.queryByText("アクション 1")).toBeNull();
+      expect(screen.queryByText("アクション 3")).toBeNull();
+      // 佐藤グループは展開されたまま
+      expect(screen.getByText("アクション 2")).toBeDefined();
+    });
+
+    it("折りたたんだグループを再クリックすると展開される", () => {
+      render(<ActionListGrouped actionItems={sampleItems} groupBy="member" />);
+      const header = screen.getByRole("button", { name: /田中太郎/ });
+      fireEvent.click(header); // 折りたたむ
+      fireEvent.click(header); // 展開する
+      expect(screen.getByText("アクション 1")).toBeDefined();
+    });
+  });
+
+  describe("期限別グループ化", () => {
+    it("期限なしアイテムで '期限なし' グループを表示する", () => {
+      const items = [makeItem("1", "田中", "m1")]; // dueDate: null
+      render(<ActionListGrouped actionItems={items} groupBy="dueDate" />);
+      expect(screen.getByText("期限なし")).toBeDefined();
+    });
+  });
+
+  describe("タグ別グループ化", () => {
+    it("タグなしアイテムで 'タグなし' グループを表示する", () => {
+      render(<ActionListGrouped actionItems={sampleItems} groupBy="tag" />);
+      expect(screen.getByText("タグなし")).toBeDefined();
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("空のアイテムリストで何も表示しない", () => {
+      const { container } = render(<ActionListGrouped actionItems={[]} groupBy="member" />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("groupBy が none のとき何も表示しない", () => {
+      const { container } = render(<ActionListGrouped actionItems={sampleItems} groupBy="none" />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/src/components/action/action-filters.tsx
+++ b/src/components/action/action-filters.tsx
@@ -21,7 +21,7 @@ type Props = { members: Member[]; tags?: Tag[] };
 
 export function buildFilterUrl(currentParams: string, key: string, value: string): string {
   const params = new URLSearchParams(currentParams);
-  if (value === "all" || value === "") {
+  if (value === "all" || value === "" || value === "none") {
     params.delete(key);
   } else {
     params.set(key, value);
@@ -59,6 +59,20 @@ export function ActionFilters({ members, tags = [] }: Props) {
         />
       </div>
       <div className="flex gap-3 flex-wrap">
+        <Select
+          value={searchParams.get("groupBy") ?? "none"}
+          onValueChange={(val) => updateFilter("groupBy", val)}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue placeholder="グループ化" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">グループなし</SelectItem>
+            <SelectItem value="member">メンバー別</SelectItem>
+            <SelectItem value="dueDate">期限別</SelectItem>
+            <SelectItem value="tag">タグ別</SelectItem>
+          </SelectContent>
+        </Select>
         <Select
           value={searchParams.get("status") ?? "all"}
           onValueChange={(val) => updateFilter("status", val)}

--- a/src/components/action/action-list-grouped.tsx
+++ b/src/components/action/action-list-grouped.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import { ActionListFull } from "@/components/action/action-list-full";
+import { Badge } from "@/components/ui/badge";
+import type { GroupByType } from "@/lib/group-actions";
+import { groupActionItems } from "@/lib/group-actions";
+
+type TagData = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+type ActionItemRow = {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  dueDate: Date | null;
+  member: { id: string; name: string };
+  meeting: { id: string; date: Date };
+  tags?: TagData[];
+};
+
+type Props = {
+  actionItems: ActionItemRow[];
+  groupBy: GroupByType;
+  statusFilter?: string;
+};
+
+export function ActionListGrouped({ actionItems, groupBy, statusFilter }: Props) {
+  const groups = groupActionItems(actionItems, groupBy);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+
+  if (groups.length === 0) return null;
+
+  function toggleGroup(key: string) {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {groups.map((group) => {
+        const isCollapsed = collapsedGroups.has(group.key);
+        return (
+          <div key={group.key}>
+            <button
+              type="button"
+              onClick={() => toggleGroup(group.key)}
+              className="flex items-center gap-2 mb-3 text-left hover:opacity-70 transition-opacity w-full"
+              aria-expanded={!isCollapsed}
+            >
+              {isCollapsed ? (
+                <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+              )}
+              <span className="font-semibold tracking-tight">{group.label}</span>
+              <Badge variant="secondary" className="text-xs">
+                {group.items.length}
+              </Badge>
+            </button>
+            {!isCollapsed && (
+              <div className="ml-6">
+                <ActionListFull actionItems={group.items} statusFilter={statusFilter} />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/__tests__/group-actions.test.ts
+++ b/src/lib/__tests__/group-actions.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import type { ActionItemForGrouping } from "../group-actions";
+import { groupActionItems } from "../group-actions";
+
+function makeItem(
+  overrides: Partial<ActionItemForGrouping> & { id: string },
+): ActionItemForGrouping {
+  return {
+    id: overrides.id,
+    dueDate: overrides.dueDate ?? null,
+    member: overrides.member ?? { id: "m1", name: "田中太郎" },
+    tags: overrides.tags ?? [],
+  };
+}
+
+// 固定の「今日」: 2024-06-12 (水曜日, getDay()=3)
+const TODAY = new Date(2024, 5, 12); // 2024-06-12
+
+describe("groupActionItems", () => {
+  describe("groupBy: none", () => {
+    it("空配列を返す", () => {
+      const items = [makeItem({ id: "1" })];
+      expect(groupActionItems(items, "none")).toEqual([]);
+    });
+  });
+
+  describe("groupBy: member", () => {
+    it("メンバーIDでグループ化する", () => {
+      const items = [
+        makeItem({ id: "1", member: { id: "m1", name: "田中太郎" } }),
+        makeItem({ id: "2", member: { id: "m2", name: "佐藤花子" } }),
+        makeItem({ id: "3", member: { id: "m1", name: "田中太郎" } }),
+      ];
+      const groups = groupActionItems(items, "member");
+      expect(groups).toHaveLength(2);
+      expect(groups[0].key).toBe("m1");
+      expect(groups[0].label).toBe("田中太郎");
+      expect(groups[0].items).toHaveLength(2);
+      expect(groups[1].key).toBe("m2");
+      expect(groups[1].label).toBe("佐藤花子");
+      expect(groups[1].items).toHaveLength(1);
+    });
+
+    it("アイテムが1件のメンバーもグループを作成する", () => {
+      const items = [makeItem({ id: "1", member: { id: "m1", name: "田中太郎" } })];
+      const groups = groupActionItems(items, "member");
+      expect(groups).toHaveLength(1);
+      expect(groups[0].items).toHaveLength(1);
+    });
+
+    it("空のアイテムリストで空配列を返す", () => {
+      expect(groupActionItems([], "member")).toEqual([]);
+    });
+
+    it("グループ内でアイテムの順序を保持する", () => {
+      const items = [
+        makeItem({ id: "1", member: { id: "m1", name: "田中" } }),
+        makeItem({ id: "2", member: { id: "m1", name: "田中" } }),
+      ];
+      const groups = groupActionItems(items, "member");
+      expect(groups[0].items[0].id).toBe("1");
+      expect(groups[0].items[1].id).toBe("2");
+    });
+  });
+
+  describe("groupBy: dueDate", () => {
+    it("期限なしアイテムを '期限なし' グループに入れる", () => {
+      const items = [makeItem({ id: "1", dueDate: null })];
+      const groups = groupActionItems(items, "dueDate", TODAY);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].key).toBe("no-date");
+      expect(groups[0].label).toBe("期限なし");
+    });
+
+    it("今日期限のアイテムを '今日' グループに入れる", () => {
+      const items = [makeItem({ id: "1", dueDate: new Date(2024, 5, 12) })];
+      const groups = groupActionItems(items, "dueDate", TODAY);
+      const todayGroup = groups.find((g) => g.key === "today");
+      expect(todayGroup).toBeDefined();
+      expect(todayGroup!.items).toHaveLength(1);
+    });
+
+    it("今日より前のアイテムを '期限超過' グループに入れる", () => {
+      const items = [makeItem({ id: "1", dueDate: new Date(2024, 5, 11) })];
+      const groups = groupActionItems(items, "dueDate", TODAY);
+      const overdueGroup = groups.find((g) => g.key === "overdue");
+      expect(overdueGroup).toBeDefined();
+      expect(overdueGroup!.items).toHaveLength(1);
+      expect(overdueGroup!.label).toBe("期限超過");
+    });
+
+    it("今週のアイテムを '今週' グループに入れる（今日の翌日～日曜）", () => {
+      // TODAY = 2024-06-12 (水曜)。今週 = 2024-06-13 (木) ~ 2024-06-16 (日)
+      const items = [
+        makeItem({ id: "1", dueDate: new Date(2024, 5, 13) }), // 木曜
+        makeItem({ id: "2", dueDate: new Date(2024, 5, 16) }), // 日曜
+      ];
+      const groups = groupActionItems(items, "dueDate", TODAY);
+      const thisWeekGroup = groups.find((g) => g.key === "this-week");
+      expect(thisWeekGroup).toBeDefined();
+      expect(thisWeekGroup!.items).toHaveLength(2);
+      expect(thisWeekGroup!.label).toBe("今週");
+    });
+
+    it("来週以降のアイテムを '来週以降' グループに入れる", () => {
+      // TODAY = 2024-06-12 (水曜)。来週以降 = 2024-06-17 (月) 以降
+      const items = [
+        makeItem({ id: "1", dueDate: new Date(2024, 5, 17) }), // 来週月曜
+        makeItem({ id: "2", dueDate: new Date(2024, 6, 1) }), // 来月
+      ];
+      const groups = groupActionItems(items, "dueDate", TODAY);
+      const laterGroup = groups.find((g) => g.key === "later");
+      expect(laterGroup).toBeDefined();
+      expect(laterGroup!.items).toHaveLength(2);
+      expect(laterGroup!.label).toBe("来週以降");
+    });
+
+    it("アイテムがないグループは除外する", () => {
+      const items = [makeItem({ id: "1", dueDate: null })];
+      const groups = groupActionItems(items, "dueDate", TODAY);
+      expect(groups.every((g) => g.items.length > 0)).toBe(true);
+      // 期限なしのみ
+      expect(groups).toHaveLength(1);
+    });
+
+    it("グループの表示順序: 期限超過 → 今日 → 今週 → 来週以降 → 期限なし", () => {
+      const items = [
+        makeItem({ id: "1", dueDate: null }),
+        makeItem({ id: "2", dueDate: new Date(2024, 5, 17) }), // 来週以降
+        makeItem({ id: "3", dueDate: new Date(2024, 5, 12) }), // 今日
+        makeItem({ id: "4", dueDate: new Date(2024, 5, 11) }), // 期限超過
+        makeItem({ id: "5", dueDate: new Date(2024, 5, 13) }), // 今週
+      ];
+      const groups = groupActionItems(items, "dueDate", TODAY);
+      expect(groups.map((g) => g.key)).toEqual([
+        "overdue",
+        "today",
+        "this-week",
+        "later",
+        "no-date",
+      ]);
+    });
+
+    it("今日が日曜日のとき今週グループが空になる", () => {
+      // 2024-06-16 が日曜日
+      const sunday = new Date(2024, 5, 16);
+      const items = [
+        makeItem({ id: "1", dueDate: new Date(2024, 5, 16) }), // 今日（日曜）
+        makeItem({ id: "2", dueDate: new Date(2024, 5, 23) }), // 来週以降
+      ];
+      const groups = groupActionItems(items, "dueDate", sunday);
+      const keys = groups.map((g) => g.key);
+      expect(keys).not.toContain("this-week");
+      expect(keys).toContain("today");
+      expect(keys).toContain("later");
+    });
+  });
+
+  describe("groupBy: tag", () => {
+    it("タグIDでグループ化する", () => {
+      const items = [
+        makeItem({
+          id: "1",
+          tags: [{ id: "t1", name: "バグ", color: "#ff0000" }],
+        }),
+        makeItem({
+          id: "2",
+          tags: [{ id: "t2", name: "機能", color: "#00ff00" }],
+        }),
+        makeItem({
+          id: "3",
+          tags: [{ id: "t1", name: "バグ", color: "#ff0000" }],
+        }),
+      ];
+      const groups = groupActionItems(items, "tag");
+      expect(groups.length).toBeGreaterThanOrEqual(2);
+      const bugGroup = groups.find((g) => g.key === "t1");
+      expect(bugGroup).toBeDefined();
+      expect(bugGroup!.label).toBe("バグ");
+      expect(bugGroup!.items).toHaveLength(2);
+    });
+
+    it("タグなしアイテムを 'タグなし' グループに入れる", () => {
+      const items = [makeItem({ id: "1", tags: [] }), makeItem({ id: "2", tags: undefined })];
+      const groups = groupActionItems(items, "tag");
+      const noTagGroup = groups.find((g) => g.key === "no-tag");
+      expect(noTagGroup).toBeDefined();
+      expect(noTagGroup!.label).toBe("タグなし");
+      expect(noTagGroup!.items).toHaveLength(2);
+    });
+
+    it("複数タグを持つアイテムは各タグのグループに表示される", () => {
+      const items = [
+        makeItem({
+          id: "1",
+          tags: [
+            { id: "t1", name: "バグ", color: "#ff0000" },
+            { id: "t2", name: "機能", color: "#00ff00" },
+          ],
+        }),
+      ];
+      const groups = groupActionItems(items, "tag");
+      expect(groups.length).toBe(2);
+      expect(groups.find((g) => g.key === "t1")!.items).toHaveLength(1);
+      expect(groups.find((g) => g.key === "t2")!.items).toHaveLength(1);
+    });
+
+    it("'タグなし' グループはリストの最後に表示される", () => {
+      const items = [
+        makeItem({ id: "1", tags: [{ id: "t1", name: "バグ", color: "#f00" }] }),
+        makeItem({ id: "2", tags: [] }),
+      ];
+      const groups = groupActionItems(items, "tag");
+      expect(groups[groups.length - 1].key).toBe("no-tag");
+    });
+
+    it("空のアイテムリストで空配列を返す", () => {
+      expect(groupActionItems([], "tag")).toEqual([]);
+    });
+  });
+});

--- a/src/lib/group-actions.ts
+++ b/src/lib/group-actions.ts
@@ -1,0 +1,108 @@
+export type GroupByType = "none" | "member" | "dueDate" | "tag";
+
+export type ActionItemForGrouping = {
+  id: string;
+  dueDate: Date | null;
+  member: { id: string; name: string };
+  tags?: { id: string; name: string; color: string }[];
+};
+
+export type ActionGroup<T extends ActionItemForGrouping = ActionItemForGrouping> = {
+  key: string;
+  label: string;
+  items: T[];
+};
+
+export function groupActionItems<T extends ActionItemForGrouping>(
+  items: T[],
+  groupBy: GroupByType,
+  now: Date = new Date(),
+): ActionGroup<T>[] {
+  switch (groupBy) {
+    case "member":
+      return groupByMember(items);
+    case "dueDate":
+      return groupByDueDate(items, now);
+    case "tag":
+      return groupByTag(items);
+    default:
+      return [];
+  }
+}
+
+function groupByMember<T extends ActionItemForGrouping>(items: T[]): ActionGroup<T>[] {
+  const map = new Map<string, ActionGroup<T>>();
+  for (const item of items) {
+    const key = item.member.id;
+    if (!map.has(key)) {
+      map.set(key, { key, label: item.member.name, items: [] });
+    }
+    map.get(key)!.items.push(item);
+  }
+  return Array.from(map.values());
+}
+
+function groupByDueDate<T extends ActionItemForGrouping>(items: T[], now: Date): ActionGroup<T>[] {
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrow = new Date(todayStart);
+  tomorrow.setDate(todayStart.getDate() + 1);
+
+  // 今週の日曜日の次の日（月曜日）= 来週以降の境界
+  const dayOfWeek = todayStart.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  const daysUntilNextMonday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
+  const nextMonday = new Date(todayStart);
+  nextMonday.setDate(todayStart.getDate() + daysUntilNextMonday);
+
+  const groups: ActionGroup<T>[] = [
+    { key: "overdue", label: "期限超過", items: [] },
+    { key: "today", label: "今日", items: [] },
+    { key: "this-week", label: "今週", items: [] },
+    { key: "later", label: "来週以降", items: [] },
+    { key: "no-date", label: "期限なし", items: [] },
+  ];
+
+  for (const item of items) {
+    if (!item.dueDate) {
+      groups[4].items.push(item);
+      continue;
+    }
+    const d = new Date(item.dueDate);
+    const dueStart = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+    if (dueStart < todayStart) {
+      groups[0].items.push(item);
+    } else if (dueStart < tomorrow) {
+      groups[1].items.push(item);
+    } else if (dueStart < nextMonday) {
+      groups[2].items.push(item);
+    } else {
+      groups[3].items.push(item);
+    }
+  }
+
+  return groups.filter((g) => g.items.length > 0);
+}
+
+function groupByTag<T extends ActionItemForGrouping>(items: T[]): ActionGroup<T>[] {
+  const map = new Map<string, ActionGroup<T>>();
+  const noTagItems: T[] = [];
+
+  for (const item of items) {
+    if (!item.tags || item.tags.length === 0) {
+      noTagItems.push(item);
+      continue;
+    }
+    for (const tag of item.tags) {
+      if (!map.has(tag.id)) {
+        map.set(tag.id, { key: tag.id, label: tag.name, items: [] });
+      }
+      map.get(tag.id)!.items.push(item);
+    }
+  }
+
+  const groups = Array.from(map.values());
+  if (noTagItems.length > 0) {
+    groups.push({ key: "no-tag", label: "タグなし", items: noTagItems });
+  }
+  return groups;
+}


### PR DESCRIPTION
## 概要

issue #139 の対応。アクション一覧ページにグループ化切り替え機能を追加し、メンバー別・期限別・タグ別でアクションをセクション分けして俯瞰できるようにする。

## 変更内容

### 新規ファイル
- `src/lib/group-actions.ts` — グループ化ロジック（groupByMember / groupByDueDate / groupByTag）
- `src/lib/__tests__/group-actions.test.ts` — グループ化ユーティリティのユニットテスト（18件）
- `src/components/action/action-list-grouped.tsx` — グループ化リストコンポーネント（折りたたみ機能付き）
- `src/components/action/__tests__/action-list-grouped.test.tsx` — コンポーネントテスト（10件）

### 変更ファイル
- `src/components/action/action-filters.tsx` — groupBy セレクターを追加、buildFilterUrl で "none" を削除対象に追加
- `src/components/action/__tests__/action-filters.test.tsx` — セレクター数の更新 + groupBy テスト追加
- `src/app/actions/page.tsx` — groupBy パラメータの読み取り・条件分岐で ActionListGrouped を使用

## 機能

- **グループ化セレクター**: グループなし / メンバー別 / 期限別 / タグ別 の 4 択
- **期限別グループ**: 期限超過 → 今日 → 今週 → 来週以降 → 期限なし の順で表示
- **タグ別グループ**: 複数タグを持つアイテムは各タグのグループに表示、タグなしは最後に表示
- **折りたたみ/展開**: グループヘッダーをクリックで切り替え（デフォルトは展開）
- **グループヘッダー**: グループ名 + 件数バッジ + Chevron アイコン
- **既存フィルターとの組み合わせ**: ステータス・メンバー・期限フィルターとグループ化を同時利用可能
- **グループ化時のページネーション**: グループ化有効時は perPage=1000 で全件取得しページネーションを非表示

## テスト計画

- [x] `npm test` — 102ファイル 1034テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] グループなし → メンバー別に切り替えてグループ分け表示を確認
- [ ] グループヘッダーをクリックして折りたたみ/展開を確認
- [ ] 期限別グループで期限超過・今日・今週・来週以降・期限なしが正しく分類されることを確認
- [ ] タグ別グループで複数タグのアイテムが各グループに表示されることを確認
- [ ] ステータスフィルター + グループ化の組み合わせを確認

Closes #139