### PR TITLE
ux: ページ遷移・データ取得中のスケルトンUIを実装して視覚的フィードバックを統一する (issue #138)

### DIFF
--- a/src/app/actions/loading.tsx
+++ b/src/app/actions/loading.tsx
@@ -1,0 +1,5 @@
+import { ActionListSkeleton } from "@/components/action/action-list-skeleton";
+
+export default function ActionsLoading() {
+  return <ActionListSkeleton />;
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
+
+export default function DashboardLoading() {
+  return <DashboardSkeleton />;
+}

--- a/src/app/members/[id]/loading.tsx
+++ b/src/app/members/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { MemberDetailSkeleton } from "@/components/member/member-detail-skeleton";
+
+export default function MemberDetailLoading() {
+  return <MemberDetailSkeleton />;
+}

--- a/src/app/members/loading.tsx
+++ b/src/app/members/loading.tsx
@@ -1,0 +1,5 @@
+import { MemberListSkeleton } from "@/components/member/member-list-skeleton";
+
+export default function MembersLoading() {
+  return <MemberListSkeleton />;
+}

--- a/src/components/action/action-list-skeleton.tsx
+++ b/src/components/action/action-list-skeleton.tsx
@@ -1,0 +1,51 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+function ActionCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-9 w-28 rounded-md shrink-0" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-3.5 w-32" />
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-5 w-20 rounded-full" />
+          <Skeleton className="h-6 w-6 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ActionListSkeleton() {
+  return (
+    <div className="animate-fade-in-up">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <Skeleton className="h-7 w-32" />
+        <Skeleton className="h-5 w-12 rounded-full" />
+      </div>
+
+      {/* Filter bar */}
+      <div className="mb-4 space-y-3">
+        <Skeleton className="h-9 w-full rounded-md" />
+        <div className="flex flex-wrap gap-3">
+          <Skeleton className="h-9 w-36 rounded-md" />
+          <Skeleton className="h-9 w-44 rounded-md" />
+          <Skeleton className="h-9 w-40 rounded-md" />
+          <Skeleton className="h-9 w-40 rounded-md" />
+        </div>
+      </div>
+
+      {/* Action cards */}
+      <div className="space-y-3">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <ActionCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -1,0 +1,136 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+function KPICardSkeleton() {
+  return (
+    <div className="rounded-xl border border-l-4 border-l-muted bg-card p-5">
+      <div className="flex items-center justify-between mb-3">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-5 w-5 rounded" />
+      </div>
+      <Skeleton className="h-10 w-16" />
+    </div>
+  );
+}
+
+function ActivityRowSkeleton() {
+  return (
+    <div className="flex items-start gap-3 py-2">
+      <Skeleton className="w-8 h-8 rounded-full shrink-0" />
+      <div className="flex-1 space-y-1.5">
+        <Skeleton className="h-3.5 w-48" />
+        <Skeleton className="h-3 w-20" />
+      </div>
+    </div>
+  );
+}
+
+function ActionRowSkeleton() {
+  return (
+    <div className="flex items-center gap-2 py-2">
+      <Skeleton className="w-1.5 h-1.5 rounded-full shrink-0" />
+      <div className="flex-1 space-y-1">
+        <Skeleton className="h-3.5 w-full max-w-[200px]" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+    </div>
+  );
+}
+
+function MemberRowSkeleton() {
+  return (
+    <tr className="border-b">
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-8 h-8 rounded-full shrink-0" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-3.5 w-16" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-3.5 w-20" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-3.5 w-8" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-5 w-14 rounded-full" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-7 w-20 rounded-md" />
+      </td>
+    </tr>
+  );
+}
+
+export function DashboardSkeleton() {
+  return (
+    <div>
+      <Skeleton className="h-7 w-40 mb-6" />
+
+      {/* KPI Cards */}
+      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KPICardSkeleton />
+        <KPICardSkeleton />
+        <KPICardSkeleton />
+        <KPICardSkeleton />
+      </div>
+
+      {/* Activity + Tasks */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+        <div className="lg:col-span-2 rounded-xl border bg-card p-5">
+          <Skeleton className="h-4 w-32 mb-4" />
+          <div className="divide-y">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <ActivityRowSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-xl border bg-card p-5">
+          <Skeleton className="h-4 w-24 mb-4" />
+          <div>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <ActionRowSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Member List */}
+      <div className="rounded-xl border bg-card overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-3 text-left">
+                <Skeleton className="h-3 w-16" />
+              </th>
+              <th className="px-4 py-3 text-left">
+                <Skeleton className="h-3 w-12" />
+              </th>
+              <th className="px-4 py-3 text-left">
+                <Skeleton className="h-3 w-16" />
+              </th>
+              <th className="px-4 py-3 text-left">
+                <Skeleton className="h-3 w-14" />
+              </th>
+              <th className="px-4 py-3 text-left">
+                <Skeleton className="h-3 w-16" />
+              </th>
+              <th className="px-4 py-3 text-left" />
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <MemberRowSkeleton key={i} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/member/member-detail-skeleton.tsx
+++ b/src/components/member/member-detail-skeleton.tsx
@@ -1,0 +1,82 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+function StatCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-l-4 border-l-muted bg-card p-5">
+      <div className="flex items-center justify-between mb-3">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-5 w-5 rounded" />
+      </div>
+      <Skeleton className="h-8 w-28" />
+    </div>
+  );
+}
+
+function MeetingCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-28" />
+          <div className="flex gap-2">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </div>
+        </div>
+        <Skeleton className="h-4 w-24" />
+      </div>
+    </div>
+  );
+}
+
+export function MemberDetailSkeleton() {
+  return (
+    <div className="animate-fade-in-up">
+      {/* Header */}
+      <div className="flex justify-between items-start mb-8">
+        <div className="flex items-center gap-4">
+          <Skeleton className="w-12 h-12 rounded-full shrink-0" />
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-32" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-24 rounded-md" />
+          <Skeleton className="h-9 w-24 rounded-md" />
+          <Skeleton className="h-9 w-9 rounded-md" />
+        </div>
+      </div>
+
+      {/* Stats bar */}
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+      </div>
+
+      {/* Meeting history */}
+      <Skeleton className="h-5 w-20 mb-3 mt-8" />
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <MeetingCardSkeleton key={i} />
+        ))}
+      </div>
+
+      {/* Separator */}
+      <div className="my-6 border-t" />
+
+      {/* Action items */}
+      <Skeleton className="h-5 w-36 mb-3" />
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 py-2">
+            <Skeleton className="h-7 w-28 rounded-md" />
+            <Skeleton className="h-3.5 w-48" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/member/member-list-skeleton.tsx
+++ b/src/components/member/member-list-skeleton.tsx
@@ -1,0 +1,83 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+function MemberTableRowSkeleton() {
+  return (
+    <tr className="border-b">
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-8 h-8 rounded-full shrink-0" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-3.5 w-20" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-3.5 w-16" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-3.5 w-8" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-5 w-14 rounded-full" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-7 w-20 rounded-md" />
+      </td>
+    </tr>
+  );
+}
+
+export function MemberListSkeleton() {
+  return (
+    <div className="animate-fade-in-up">
+      {/* Header */}
+      <div className="flex justify-between items-center mb-6">
+        <Skeleton className="h-7 w-28" />
+        <Skeleton className="h-9 w-36 rounded-md" />
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <Skeleton className="h-9 w-48 rounded-md" />
+        <Skeleton className="h-9 w-32 rounded-md" />
+        <Skeleton className="h-9 w-32 rounded-md" />
+        <Skeleton className="h-4 w-10 self-center" />
+      </div>
+
+      {/* Table */}
+      <div className="rounded-xl border bg-card overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                名前
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                部署
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                最終1on1
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                未完了
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                ステータス
+              </th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 8 }).map((_, i) => (
+              <MemberTableRowSkeleton key={i} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+}
+
+export { Skeleton };


### PR DESCRIPTION
## 概要

issue #138 の対応。データ取得中のローディング表示をスケルトンUIで統一し、ページ遷移時のちらつきを減らして知覚速度を改善する。

## 変更内容

### 新規ファイル

**UIコンポーネント**
- `src/components/ui/skeleton.tsx` — shadcn/ui スタイルの Skeleton 基盤コンポーネント（animate-pulse + bg-muted）

**スケルトンコンポーネント**
- `src/components/dashboard/dashboard-skeleton.tsx` — KPIカード×4・アクティビティフィード・タスクリスト・メンバーテーブルのスケルトン
- `src/components/member/member-list-skeleton.tsx` — フィルターバー＋メンバーテーブル行のスケルトン
- `src/components/member/member-detail-skeleton.tsx` — ヘッダー・ステータスバー・ミーティング履歴・アクションリストのスケルトン
- `src/components/action/action-list-skeleton.tsx` — フィルターバー＋アクションカードリストのスケルトン

**Next.js loading.tsx**
- `src/app/loading.tsx` — ダッシュボード用
- `src/app/members/loading.tsx` — メンバー一覧用
- `src/app/members/[id]/loading.tsx` — メンバー詳細用
- `src/app/actions/loading.tsx` — アクション一覧用

## 実装詳細

- `--muted` CSS変数（`:root`/`.dark` 両方定義済み）を利用することでダークモードを自動対応
- Next.js App Router の `loading.tsx` を使用し、各ページの `async` コンポーネントをラップ（既存コード変更不要）
- スケルトンの幅・高さ・角丸は実際のコンテンツレイアウトに合わせて設計

## テスト計画

- [x] `npm test` — 100ファイル 1004テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過（lint-staged で確認済み）
- [ ] ダッシュボード（/）でデータ取得中にスケルトンが表示されること
- [ ] メンバー一覧（/members）でスケルトンが表示されること
- [ ] メンバー詳細（/members/[id]）でスケルトンが表示されること
- [ ] アクション一覧（/actions）でスケルトンが表示されること
- [ ] ダークモードでスケルトンが適切に表示されること（薄暗い背景色）

Closes #138