### PR TITLE
feat: チェックイン入力後に前回との比較差分を表示する (issue #136)

### DIFF
--- a/src/app/members/[id]/meetings/[meetingId]/page.tsx
+++ b/src/app/members/[id]/meetings/[meetingId]/page.tsx
@@ -7,14 +7,17 @@ import { MeetingDetailPageClient } from "@/components/meeting/meeting-detail-pag
 import { MeetingHeaderActions } from "@/components/meeting/meeting-header-actions";
 import { PrintButton } from "@/components/meeting/print-button";
 import { Button } from "@/components/ui/button";
-import { getMeeting } from "@/lib/actions/meeting-actions";
+import { getMeeting, getPreviousMeeting } from "@/lib/actions/meeting-actions";
 import { formatDate } from "@/lib/format";
 
 type Props = { params: Promise<{ id: string; meetingId: string }> };
 
 export default async function MeetingDetailPage({ params }: Props) {
   const { id, meetingId } = await params;
-  const meeting = await getMeeting(meetingId);
+  const [meeting, previousMeeting] = await Promise.all([
+    getMeeting(meetingId),
+    getPreviousMeeting(id, meetingId),
+  ]);
   if (!meeting) {
     notFound();
   }
@@ -59,6 +62,15 @@ export default async function MeetingDetailPage({ params }: Props) {
             checkinNote={meeting.checkinNote}
             startedAt={meeting.startedAt}
             endedAt={meeting.endedAt}
+            previousConditions={
+              previousMeeting
+                ? {
+                    health: previousMeeting.conditionHealth,
+                    mood: previousMeeting.conditionMood,
+                    workload: previousMeeting.conditionWorkload,
+                  }
+                : undefined
+            }
             topics={meeting.topics.map((t) => ({
               id: t.id,
               category: t.category,

--- a/src/app/members/[id]/meetings/new/page.tsx
+++ b/src/app/members/[id]/meetings/new/page.tsx
@@ -63,7 +63,19 @@ export default async function NewMeetingPage({ params, searchParams }: Props) {
       </h1>
       <div className="flex flex-col lg:flex-row gap-8">
         <div className="flex-1">
-          <MeetingForm memberId={id} initialTopics={initialTopics} />
+          <MeetingForm
+            memberId={id}
+            initialTopics={initialTopics}
+            previousConditions={
+              previousMeeting
+                ? {
+                    health: previousMeeting.conditionHealth,
+                    mood: previousMeeting.conditionMood,
+                    workload: previousMeeting.conditionWorkload,
+                  }
+                : undefined
+            }
+          />
         </div>
         <div className="w-full lg:w-80 shrink-0">
           <PreviousMeetingSidebar

--- a/src/components/meeting/__tests__/condition-selector.test.tsx
+++ b/src/components/meeting/__tests__/condition-selector.test.tsx
@@ -126,4 +126,69 @@ describe("ConditionSelector", () => {
     expect(minEmojis).toHaveLength(3);
     expect(maxEmojis).toHaveLength(3);
   });
+
+  describe("前回との差分表示", () => {
+    it("前回データがない場合は差分が表示されないこと", () => {
+      render(<ConditionSelector {...defaultProps} conditionHealth={3} />);
+      expect(screen.queryByText(/前回より/)).toBeNull();
+      expect(screen.queryByText(/前回と同じ/)).toBeNull();
+    });
+
+    it("現在値がない場合は差分が表示されないこと", () => {
+      render(
+        <ConditionSelector {...defaultProps} conditionHealth={null} previousConditionHealth={3} />,
+      );
+      expect(screen.queryByText(/前回より/)).toBeNull();
+    });
+
+    it("体調が前回より上がった場合に'↑ 前回より+1'が表示されること", () => {
+      render(
+        <ConditionSelector {...defaultProps} conditionHealth={4} previousConditionHealth={3} />,
+      );
+      expect(screen.getByText("↑ 前回より+1")).toBeInTheDocument();
+    });
+
+    it("体調が前回と同じ場合に'─ 前回と同じ'が表示されること", () => {
+      render(
+        <ConditionSelector {...defaultProps} conditionHealth={3} previousConditionHealth={3} />,
+      );
+      expect(screen.getByText("─ 前回と同じ")).toBeInTheDocument();
+    });
+
+    it("体調が前回より下がった場合に'↓ 前回より-2'が表示されること", () => {
+      render(
+        <ConditionSelector {...defaultProps} conditionHealth={1} previousConditionHealth={3} />,
+      );
+      expect(screen.getByText("↓ 前回より-2")).toBeInTheDocument();
+    });
+
+    it("気分の差分が表示されること", () => {
+      render(<ConditionSelector {...defaultProps} conditionMood={5} previousConditionMood={3} />);
+      expect(screen.getByText("↑ 前回より+2")).toBeInTheDocument();
+    });
+
+    it("業務量の差分が表示されること", () => {
+      render(
+        <ConditionSelector {...defaultProps} conditionWorkload={2} previousConditionWorkload={4} />,
+      );
+      expect(screen.getByText("↓ 前回より-2")).toBeInTheDocument();
+    });
+
+    it("複数軸に差分がある場合に各々表示されること", () => {
+      render(
+        <ConditionSelector
+          {...defaultProps}
+          conditionHealth={4}
+          previousConditionHealth={3}
+          conditionMood={2}
+          previousConditionMood={2}
+          conditionWorkload={3}
+          previousConditionWorkload={5}
+        />,
+      );
+      expect(screen.getByText("↑ 前回より+1")).toBeInTheDocument();
+      expect(screen.getByText("─ 前回と同じ")).toBeInTheDocument();
+      expect(screen.getByText("↓ 前回より-2")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/meeting/__tests__/meeting-summary.test.tsx
+++ b/src/components/meeting/__tests__/meeting-summary.test.tsx
@@ -131,4 +131,44 @@ describe("MeetingSummary", () => {
       expect(screen.queryByText(/アクションアイテムが設定されていません/)).toBeNull();
     });
   });
+
+  describe("前回との差分表示", () => {
+    it("前回データがない場合は差分が表示されないこと", () => {
+      render(<MeetingSummary {...baseProps} conditionHealth={3} />);
+      expect(screen.queryByText(/前回より/)).toBeNull();
+      expect(screen.queryByText(/前回と同じ/)).toBeNull();
+    });
+
+    it("体調が前回より上がった場合に差分が表示されること", () => {
+      render(<MeetingSummary {...baseProps} conditionHealth={4} previousConditionHealth={3} />);
+      expect(screen.getByText("↑ 前回より+1")).toBeInTheDocument();
+    });
+
+    it("体調が前回と同じ場合に差分が表示されること", () => {
+      render(<MeetingSummary {...baseProps} conditionHealth={3} previousConditionHealth={3} />);
+      expect(screen.getByText("─ 前回と同じ")).toBeInTheDocument();
+    });
+
+    it("体調が前回より下がった場合に差分が表示されること", () => {
+      render(<MeetingSummary {...baseProps} conditionHealth={1} previousConditionHealth={3} />);
+      expect(screen.getByText("↓ 前回より-2")).toBeInTheDocument();
+    });
+
+    it("気分・業務量の差分も表示されること", () => {
+      render(
+        <MeetingSummary
+          {...baseProps}
+          conditionHealth={4}
+          previousConditionHealth={3}
+          conditionMood={3}
+          previousConditionMood={3}
+          conditionWorkload={2}
+          previousConditionWorkload={4}
+        />,
+      );
+      expect(screen.getByText("↑ 前回より+1")).toBeInTheDocument();
+      expect(screen.getByText("─ 前回と同じ")).toBeInTheDocument();
+      expect(screen.getByText("↓ 前回より-2")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/meeting/checkin-section.tsx
+++ b/src/components/meeting/checkin-section.tsx
@@ -14,6 +14,9 @@ interface CheckinSectionProps {
   conditionMood: number | null;
   conditionWorkload: number | null;
   checkinNote: string;
+  previousConditionHealth?: number | null;
+  previousConditionMood?: number | null;
+  previousConditionWorkload?: number | null;
   onConditionChange: (field: ConditionField, value: number | null) => void;
   onCheckinNoteChange: (note: string) => void;
 }
@@ -23,6 +26,9 @@ export function CheckinSection({
   conditionMood,
   conditionWorkload,
   checkinNote,
+  previousConditionHealth,
+  previousConditionMood,
+  previousConditionWorkload,
   onConditionChange,
   onCheckinNoteChange,
 }: CheckinSectionProps) {
@@ -45,6 +51,9 @@ export function CheckinSection({
             conditionHealth={conditionHealth}
             conditionMood={conditionMood}
             conditionWorkload={conditionWorkload}
+            previousConditionHealth={previousConditionHealth}
+            previousConditionMood={previousConditionMood}
+            previousConditionWorkload={previousConditionWorkload}
             onConditionChange={onConditionChange}
           />
         </div>

--- a/src/components/meeting/condition-selector.tsx
+++ b/src/components/meeting/condition-selector.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { calculateConditionDiff, formatConditionDiff } from "@/lib/condition-diff";
+
 export type ConditionField = "conditionHealth" | "conditionMood" | "conditionWorkload";
 
 interface ConditionAxis {
@@ -64,10 +66,19 @@ const CONDITION_AXES: ConditionAxis[] = [
   },
 ];
 
+const DIFF_STYLE: Record<"up" | "same" | "down", string> = {
+  up: "text-emerald-600",
+  same: "text-slate-500",
+  down: "text-rose-600",
+};
+
 interface ConditionSelectorProps {
   conditionHealth: number | null;
   conditionMood: number | null;
   conditionWorkload: number | null;
+  previousConditionHealth?: number | null;
+  previousConditionMood?: number | null;
+  previousConditionWorkload?: number | null;
   onConditionChange: (field: ConditionField, value: number | null) => void;
 }
 
@@ -75,12 +86,21 @@ export function ConditionSelector({
   conditionHealth,
   conditionMood,
   conditionWorkload,
+  previousConditionHealth,
+  previousConditionMood,
+  previousConditionWorkload,
   onConditionChange,
 }: ConditionSelectorProps) {
   const currentValues: Record<ConditionField, number | null> = {
     conditionHealth,
     conditionMood,
     conditionWorkload,
+  };
+
+  const previousValues: Record<ConditionField, number | null | undefined> = {
+    conditionHealth: previousConditionHealth,
+    conditionMood: previousConditionMood,
+    conditionWorkload: previousConditionWorkload,
   };
 
   const handleSelect = (field: ConditionField, optionValue: number) => {
@@ -92,6 +112,9 @@ export function ConditionSelector({
     <div className="space-y-3">
       {CONDITION_AXES.map((axis) => {
         const currentValue = currentValues[axis.field];
+        const previousValue = previousValues[axis.field] ?? null;
+        const diffResult = calculateConditionDiff(currentValue, previousValue);
+        const diffText = formatConditionDiff(diffResult);
         return (
           <div key={axis.field} className="flex items-center gap-3">
             <div className="flex w-20 shrink-0 items-center gap-1">
@@ -129,6 +152,11 @@ export function ConditionSelector({
                 </span>
                 <span className="text-xs text-slate-400">{axis.maxLabel}</span>
               </div>
+              {diffText && diffResult && (
+                <span className={`text-xs font-medium ${DIFF_STYLE[diffResult.direction]}`}>
+                  {diffText}
+                </span>
+              )}
             </div>
           </div>
         );

--- a/src/components/meeting/meeting-detail-page-client.tsx
+++ b/src/components/meeting/meeting-detail-page-client.tsx
@@ -40,6 +40,12 @@ type ActionItem = {
   readonly tags?: ReadonlyArray<TagData>;
 };
 
+type PreviousConditions = {
+  readonly health: number | null;
+  readonly mood: number | null;
+  readonly workload: number | null;
+};
+
 type Props = {
   readonly meetingId: string;
   readonly memberId: string;
@@ -53,6 +59,7 @@ type Props = {
   readonly actionItems: ReadonlyArray<ActionItem>;
   readonly startedAt?: Date | null;
   readonly endedAt?: Date | null;
+  readonly previousConditions?: PreviousConditions;
 };
 
 export function MeetingDetailPageClient({
@@ -68,6 +75,7 @@ export function MeetingDetailPageClient({
   actionItems,
   startedAt,
   endedAt,
+  previousConditions,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [isRecording, setIsRecording] = useState(startedAt != null && endedAt == null);
@@ -157,6 +165,7 @@ export function MeetingDetailPageClient({
               tags: a.tags ? [...a.tags] : [],
             })),
           }}
+          previousConditions={previousConditions}
           onSuccess={handleEditSuccess}
         />
         <CoachingSheet />

--- a/src/components/meeting/meeting-form.tsx
+++ b/src/components/meeting/meeting-form.tsx
@@ -76,10 +76,17 @@ type MeetingInitialData = {
   }>;
 };
 
+type PreviousConditions = {
+  readonly health: number | null;
+  readonly mood: number | null;
+  readonly workload: number | null;
+};
+
 type Props = {
   memberId: string;
   initialTopics?: Array<{ category: string; title: string; notes: string; sortOrder: number }>;
   initialData?: MeetingInitialData;
+  previousConditions?: PreviousConditions;
   onSuccess?: () => void;
 };
 
@@ -97,7 +104,13 @@ function buildTagParams(tags: TagData[]) {
   return { tagIds, newTagNames };
 }
 
-export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }: Props) {
+export function MeetingForm({
+  memberId,
+  initialTopics,
+  initialData,
+  previousConditions,
+  onSuccess,
+}: Props) {
   const router = useRouter();
   const isEditing = !!initialData;
 
@@ -388,6 +401,9 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
           conditionMood={conditionMood}
           conditionWorkload={conditionWorkload}
           checkinNote={checkinNote}
+          previousConditionHealth={previousConditions?.health}
+          previousConditionMood={previousConditions?.mood}
+          previousConditionWorkload={previousConditions?.workload}
           onConditionChange={handleConditionChange}
           onCheckinNoteChange={setCheckinNote}
         />
@@ -517,6 +533,9 @@ export function MeetingForm({ memberId, initialTopics, initialData, onSuccess }:
           conditionMood,
           conditionWorkload,
           checkinNote,
+          previousConditionHealth: previousConditions?.health,
+          previousConditionMood: previousConditions?.mood,
+          previousConditionWorkload: previousConditions?.workload,
           topicCount: validTopicCount,
           actionItemCount: validActionCount,
           topicTitles,

--- a/src/components/meeting/meeting-summary.tsx
+++ b/src/components/meeting/meeting-summary.tsx
@@ -1,3 +1,4 @@
+import { calculateConditionDiff, formatConditionDiff } from "@/lib/condition-diff";
 import { formatDateLong } from "@/lib/format";
 
 import { ConditionBar } from "./condition-bar";
@@ -13,6 +14,30 @@ export interface MeetingSummaryProps {
   topicTitles?: string[];
   actionItemTitles?: string[];
   showWarnings?: boolean;
+  previousConditionHealth?: number | null;
+  previousConditionMood?: number | null;
+  previousConditionWorkload?: number | null;
+}
+
+const DIFF_STYLE: Record<"up" | "same" | "down", string> = {
+  up: "text-emerald-600",
+  same: "text-slate-500",
+  down: "text-rose-600",
+};
+
+function ConditionDiffBadge({
+  current,
+  previous,
+}: {
+  current: number | null;
+  previous: number | null | undefined;
+}) {
+  const diffResult = calculateConditionDiff(current, previous ?? null);
+  const diffText = formatConditionDiff(diffResult);
+  if (!diffText || !diffResult) return null;
+  return (
+    <span className={`text-xs font-medium ${DIFF_STYLE[diffResult.direction]}`}>{diffText}</span>
+  );
 }
 
 export function MeetingSummary({
@@ -26,6 +51,9 @@ export function MeetingSummary({
   topicTitles,
   actionItemTitles,
   showWarnings = true,
+  previousConditionHealth,
+  previousConditionMood,
+  previousConditionWorkload,
 }: MeetingSummaryProps) {
   const hasAnyCondition =
     conditionHealth !== null || conditionMood !== null || conditionWorkload !== null;
@@ -45,18 +73,24 @@ export function MeetingSummary({
               <div className="flex items-center gap-2">
                 <span>体調🏥:</span>
                 <ConditionBar value={conditionHealth} />
+                <ConditionDiffBadge current={conditionHealth} previous={previousConditionHealth} />
               </div>
             )}
             {conditionMood !== null && (
               <div className="flex items-center gap-2">
                 <span>気分💭:</span>
                 <ConditionBar value={conditionMood} />
+                <ConditionDiffBadge current={conditionMood} previous={previousConditionMood} />
               </div>
             )}
             {conditionWorkload !== null && (
               <div className="flex items-center gap-2">
                 <span>業務量📊:</span>
                 <ConditionBar value={conditionWorkload} />
+                <ConditionDiffBadge
+                  current={conditionWorkload}
+                  previous={previousConditionWorkload}
+                />
               </div>
             )}
           </div>

--- a/src/lib/__tests__/condition-diff.test.ts
+++ b/src/lib/__tests__/condition-diff.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateConditionDiff, formatConditionDiff } from "../condition-diff";
+
+describe("calculateConditionDiff", () => {
+  it("currentがnullのときnullを返す", () => {
+    expect(calculateConditionDiff(null, 3)).toBeNull();
+  });
+
+  it("previousがnullのときnullを返す", () => {
+    expect(calculateConditionDiff(3, null)).toBeNull();
+  });
+
+  it("両方nullのときnullを返す", () => {
+    expect(calculateConditionDiff(null, null)).toBeNull();
+  });
+
+  it("currentがpreviousより大きいとき正のdiffとdirection=upを返す", () => {
+    expect(calculateConditionDiff(4, 3)).toEqual({ diff: 1, direction: "up" });
+  });
+
+  it("current===previousのときdiff=0とdirection=sameを返す", () => {
+    expect(calculateConditionDiff(3, 3)).toEqual({ diff: 0, direction: "same" });
+  });
+
+  it("currentがpreviousより小さいとき負のdiffとdirection=downを返す", () => {
+    expect(calculateConditionDiff(1, 3)).toEqual({ diff: -2, direction: "down" });
+  });
+
+  it("最大差分(5-1=+4)を正しく計算する", () => {
+    expect(calculateConditionDiff(5, 1)).toEqual({ diff: 4, direction: "up" });
+  });
+});
+
+describe("formatConditionDiff", () => {
+  it("nullのときnullを返す", () => {
+    expect(formatConditionDiff(null)).toBeNull();
+  });
+
+  it("direction=upのとき'↑ 前回より+N'を返す", () => {
+    expect(formatConditionDiff({ diff: 1, direction: "up" })).toBe("↑ 前回より+1");
+  });
+
+  it("direction=upで差分2のとき'↑ 前回より+2'を返す", () => {
+    expect(formatConditionDiff({ diff: 2, direction: "up" })).toBe("↑ 前回より+2");
+  });
+
+  it("direction=sameのとき'─ 前回と同じ'を返す", () => {
+    expect(formatConditionDiff({ diff: 0, direction: "same" })).toBe("─ 前回と同じ");
+  });
+
+  it("direction=downのとき'↓ 前回より-N'を返す", () => {
+    expect(formatConditionDiff({ diff: -2, direction: "down" })).toBe("↓ 前回より-2");
+  });
+
+  it("direction=downで差分-1のとき'↓ 前回より-1'を返す", () => {
+    expect(formatConditionDiff({ diff: -1, direction: "down" })).toBe("↓ 前回より-1");
+  });
+});

--- a/src/lib/condition-diff.ts
+++ b/src/lib/condition-diff.ts
@@ -1,0 +1,21 @@
+export type ConditionDiffResult = {
+  diff: number;
+  direction: "up" | "same" | "down";
+} | null;
+
+export function calculateConditionDiff(
+  current: number | null,
+  previous: number | null,
+): ConditionDiffResult {
+  if (current === null || previous === null) return null;
+  const diff = current - previous;
+  const direction = diff > 0 ? "up" : diff < 0 ? "down" : "same";
+  return { diff, direction };
+}
+
+export function formatConditionDiff(result: ConditionDiffResult): string | null {
+  if (result === null) return null;
+  if (result.direction === "up") return `↑ 前回より+${result.diff}`;
+  if (result.direction === "down") return `↓ 前回より${result.diff}`;
+  return "─ 前回と同じ";
+}


### PR DESCRIPTION
## 概要

issue #136 の対応。チェックイン（体調・気分・業務量）入力時に、前回ミーティングとの差分をインラインで表示する。1on1のベストプラクティスとして「継続的なメンバーの状態観察」を自然にサポートする。

## 変更内容

### 新規ファイル
- `src/lib/condition-diff.ts` — 差分計算・表示ユーティリティ（calculateConditionDiff / formatConditionDiff）
- `src/lib/__tests__/condition-diff.test.ts` — ユーティリティのユニットテスト（13テスト）

### 変更ファイル
- `src/components/meeting/condition-selector.tsx` — 前回値 props を追加し、選択値がある場合に差分バッジをインライン表示（色分け: 改善=緑 / 変化なし=グレー / 悪化=赤）
- `src/components/meeting/checkin-section.tsx` — previousConditionHealth/Mood/Workload props を追加して ConditionSelector に伝播
- `src/components/meeting/meeting-form.tsx` — previousConditions prop を追加して CheckinSection と ClosingDialog（MeetingSummary）に渡す
- `src/components/meeting/meeting-detail-page-client.tsx` — previousConditions prop を追加して MeetingForm に渡す
- `src/components/meeting/meeting-summary.tsx` — ClosingDialog 確認画面にも差分インジケーターを表示（previousConditionHealth/Mood/Workload props 追加）
- `src/app/members/[id]/meetings/[meetingId]/page.tsx` — getPreviousMeeting を並列取得して MeetingDetailPageClient に渡す
- `src/app/members/[id]/meetings/new/page.tsx` — 既存の previousMeeting を MeetingForm に渡す
- `src/components/meeting/__tests__/condition-selector.test.tsx` — 差分表示テストを追加（9テスト）
- `src/components/meeting/__tests__/meeting-summary.test.tsx` — 差分表示テストを追加（5テスト）

## 機能

- **インライン差分バッジ**: スコア選択後、各軸の右に `↑ 前回より+1` / `─ 前回と同じ` / `↓ 前回より-2` を色付きで表示
- **ClosingDialog 差分サマリー**: ミーティング保存前の確認ダイアログにも差分を表示
- **前回データがない場合は非表示**: 初回ミーティングや前回にチェックインがない場合は差分を表示しない

## テスト計画

- [x] `npm test` — 107ファイル 1071テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ブラウザで新規ミーティング作成: 前回チェックインデータがある場合に差分が表示される
- [ ] ブラウザで既存ミーティング編集: 1つ前のミーティングとの差分が表示される
- [ ] 初回ミーティングの場合: 差分が表示されない（非表示）
- [ ] ClosingDialog: 保存確認ダイアログに差分インジケーターが表示される

Closes #136