### PR TITLE
feat: カスタムミーティングテンプレートの作成・管理機能を追加する (issue #137)

### DIFF
--- a/prisma/migrations/20260224031210_add_meeting_template/migration.sql
+++ b/prisma/migrations/20260224031210_add_meeting_template/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "MeetingTemplate" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "topics" JSONB NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MeetingTemplate_name_key" ON "MeetingTemplate"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,3 +129,13 @@ model ActionItemTag {
   @@id([actionItemId, tagId])
   @@index([tagId])
 }
+
+model MeetingTemplate {
+  id          String   @id @default(uuid())
+  name        String   @unique
+  description String   @default("")
+  topics      Json
+  isDefault   Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/src/app/members/[id]/meetings/prepare/page.tsx
+++ b/src/app/members/[id]/meetings/prepare/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/actions/action-item-actions";
 import { getRecentMeetings } from "@/lib/actions/meeting-actions";
 import { getMember } from "@/lib/actions/member-actions";
+import { getCustomTemplates } from "@/lib/actions/template-actions";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -18,10 +19,11 @@ export default async function PrepareMeetingPage({ params }: Props) {
     notFound();
   }
 
-  const [recentMeetings, pendingActions, carryoverData] = await Promise.all([
+  const [recentMeetings, pendingActions, carryoverData, customTemplates] = await Promise.all([
     getRecentMeetings(id, 5),
     getPendingActionItems(id),
     getLastMeetingPendingActions(id),
+    getCustomTemplates(),
   ]);
 
   return (
@@ -41,6 +43,7 @@ export default async function PrepareMeetingPage({ params }: Props) {
         recentMeetings={recentMeetings}
         pendingActions={pendingActions}
         carryoverData={carryoverData}
+        customTemplates={customTemplates}
       />
     </div>
   );

--- a/src/app/settings/templates/page.tsx
+++ b/src/app/settings/templates/page.tsx
@@ -1,0 +1,17 @@
+import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { TemplateManagement } from "@/components/meeting/template-management";
+import { getCustomTemplates } from "@/lib/actions/template-actions";
+
+export default async function TemplatesSettingsPage() {
+  const templates = await getCustomTemplates();
+
+  return (
+    <div className="animate-fade-in-up">
+      <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "テンプレート管理" }]} />
+      <h1 className="text-2xl font-semibold tracking-tight mb-6 text-foreground">
+        テンプレート管理
+      </h1>
+      <TemplateManagement templates={templates} />
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { BarChart2, LayoutDashboard, ListChecks, Menu, UserPlus, Users, X } from "lucide-react";
+import {
+  BarChart2,
+  LayoutDashboard,
+  ListChecks,
+  Menu,
+  Settings,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -27,6 +36,7 @@ const navItems = [
   { href: "/members/new", label: "メンバー追加", icon: UserPlus },
   { href: "/actions", label: "アクション一覧", icon: ListChecks },
   { href: "/analytics", label: "ミーティング分析", icon: BarChart2 },
+  { href: "/settings/templates", label: "テンプレート管理", icon: Settings },
 ];
 
 function NavLinks({

--- a/src/components/meeting/__tests__/template-management.test.tsx
+++ b/src/components/meeting/__tests__/template-management.test.tsx
@@ -1,0 +1,135 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TemplateManagement } from "../template-management";
+
+vi.mock("@/lib/actions/template-actions", () => ({
+  deleteTemplate: vi.fn().mockResolvedValue({ success: true }),
+  createTemplate: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  updateTemplate: vi.fn().mockResolvedValue({ success: true, data: {} }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("radix-ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("radix-ui")>();
+  return {
+    ...actual,
+    Dialog: {
+      Root: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Trigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Portal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Overlay: () => null,
+      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Title: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Description: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Close: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    },
+    AlertDialog: {
+      Root: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Trigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Portal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Overlay: () => null,
+      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Title: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Description: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Cancel: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button {...props}>{children}</button>
+      ),
+      Action: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button {...props}>{children}</button>
+      ),
+    },
+  };
+});
+
+const mockTemplates = [
+  {
+    id: "t1",
+    name: "週次レビュー",
+    description: "毎週の振り返り",
+    topics: [{ category: "WORK_PROGRESS", title: "今週の進捗" }],
+    isDefault: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "t2",
+    name: "キャリア面談",
+    description: "",
+    topics: [],
+    isDefault: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TemplateManagement", () => {
+  it("テンプレートがない場合は空状態メッセージを表示する", () => {
+    render(<TemplateManagement templates={[]} />);
+    expect(screen.getByText("カスタムテンプレートがまだありません")).toBeDefined();
+  });
+
+  it("テンプレート一覧を表示する", () => {
+    render(<TemplateManagement templates={mockTemplates} />);
+    expect(screen.getByText("週次レビュー")).toBeDefined();
+    expect(screen.getByText("キャリア面談")).toBeDefined();
+  });
+
+  it("テンプレートの説明を表示する", () => {
+    render(<TemplateManagement templates={mockTemplates} />);
+    // モックでダイアログコンテンツも常に表示されるため getAllByText を使用
+    const descriptionElements = screen.getAllByText("毎週の振り返り");
+    expect(descriptionElements.length).toBeGreaterThan(0);
+  });
+
+  it("トピックをバッジで表示する", () => {
+    render(<TemplateManagement templates={mockTemplates} />);
+    expect(screen.getByText(/今週の進捗/)).toBeDefined();
+  });
+
+  it("トピックなしのテンプレートに「トピックなし」を表示する", () => {
+    render(<TemplateManagement templates={mockTemplates} />);
+    expect(screen.getByText("トピックなし")).toBeDefined();
+  });
+
+  it("「新規作成」ボタンを表示する", () => {
+    render(<TemplateManagement templates={[]} />);
+    expect(screen.getByRole("button", { name: /新規作成/ })).toBeDefined();
+  });
+
+  it("各テンプレートに編集ボタンと削除ボタンを表示する", () => {
+    render(<TemplateManagement templates={mockTemplates} />);
+    // aria-label="編集" のボタンはテンプレートごとに1つ
+    const editButtons = screen.getAllByRole("button", { name: "編集" });
+    expect(editButtons).toHaveLength(2);
+    // モックでは AlertDialog コンテンツが常にレンダリングされるため、
+    // 各テンプレートにトリガーボタン + アクションボタンの計2つが表示される
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    expect(deleteButtons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("削除ボタンをクリックすると確認ダイアログが表示される", async () => {
+    const user = userEvent.setup();
+    render(<TemplateManagement templates={mockTemplates} />);
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    await user.click(deleteButtons[0]);
+    const confirmMessages = screen.getAllByText("テンプレートを削除しますか？");
+    expect(confirmMessages.length).toBeGreaterThan(0);
+  });
+
+  it("ヘッダーに説明テキストを表示する", () => {
+    render(<TemplateManagement templates={[]} />);
+    expect(screen.getByText("カスタムテンプレート")).toBeDefined();
+    expect(
+      screen.getByText("1on1 準備画面で使えるオリジナルテンプレートを作成できます"),
+    ).toBeDefined();
+  });
+});

--- a/src/components/meeting/__tests__/template-selector.test.tsx
+++ b/src/components/meeting/__tests__/template-selector.test.tsx
@@ -6,6 +6,16 @@ import { MEETING_TEMPLATES } from "@/lib/meeting-templates";
 
 import { TemplateSelector } from "../template-selector";
 
+const mockCustomTemplate = {
+  id: "custom-1",
+  name: "マイテンプレート",
+  description: "カスタム説明",
+  topics: [{ category: "WORK_PROGRESS", title: "カスタムトピック" }],
+  isDefault: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
 afterEach(() => {
   cleanup();
 });
@@ -69,5 +79,55 @@ describe("TemplateSelector", () => {
 
     await user.click(screen.getByRole("button", { name: /定期チェックイン/ }));
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "regular-checkin" }));
+  });
+
+  describe("カスタムテンプレート対応", () => {
+    it("カスタムテンプレートを表示する", () => {
+      render(<TemplateSelector onSelect={vi.fn()} customTemplates={[mockCustomTemplate]} />);
+      expect(screen.getByRole("button", { name: /マイテンプレート/ })).toBeDefined();
+    });
+
+    it("カスタムテンプレートに「カスタム」バッジを表示する", () => {
+      render(<TemplateSelector onSelect={vi.fn()} customTemplates={[mockCustomTemplate]} />);
+      expect(screen.getByText("カスタム")).toBeDefined();
+    });
+
+    it("ビルトインテンプレートには「カスタム」バッジを表示しない", () => {
+      render(<TemplateSelector onSelect={vi.fn()} customTemplates={[mockCustomTemplate]} />);
+      const badges = screen.getAllByText("カスタム");
+      expect(badges).toHaveLength(1);
+    });
+
+    it("カスタムテンプレートをクリックすると onSelect が呼ばれる", async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+      render(<TemplateSelector onSelect={onSelect} customTemplates={[mockCustomTemplate]} />);
+      await user.click(screen.getByRole("button", { name: /マイテンプレート/ }));
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "custom-1",
+          name: "マイテンプレート",
+        }),
+      );
+    });
+
+    it("カスタムテンプレートが選択されたときチェックアイコンを表示する", () => {
+      render(
+        <TemplateSelector
+          onSelect={vi.fn()}
+          selectedId="custom-1"
+          customTemplates={[mockCustomTemplate]}
+        />,
+      );
+      const checkIcons = document.querySelectorAll("[data-testid='template-check-icon']");
+      expect(checkIcons).toHaveLength(1);
+    });
+
+    it("customTemplates が空でもビルトインテンプレートを表示する", () => {
+      render(<TemplateSelector onSelect={vi.fn()} customTemplates={[]} />);
+      for (const template of MEETING_TEMPLATES) {
+        expect(screen.getByRole("button", { name: new RegExp(template.name) })).toBeDefined();
+      }
+    });
   });
 });

--- a/src/components/meeting/meeting-prepare.tsx
+++ b/src/components/meeting/meeting-prepare.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import type { MeetingTemplate as DbMeetingTemplate } from "@/generated/prisma/client";
 import type { MeetingTemplate, TopicCategory } from "@/lib/meeting-templates";
 import { TOAST_MESSAGES } from "@/lib/toast-messages";
 
@@ -59,6 +60,7 @@ type Props = {
   recentMeetings: MeetingData[];
   pendingActions: PendingAction[];
   carryoverData: CarryoverData;
+  customTemplates?: DbMeetingTemplate[];
 };
 
 const categoryOptions = [
@@ -73,7 +75,13 @@ function createEmptyTopic(sortOrder: number): TopicDraft {
   return { category: "WORK_PROGRESS", title: "", notes: "", sortOrder };
 }
 
-export function MeetingPrepare({ memberId, recentMeetings, pendingActions, carryoverData }: Props) {
+export function MeetingPrepare({
+  memberId,
+  recentMeetings,
+  pendingActions,
+  carryoverData,
+  customTemplates = [],
+}: Props) {
   const [topics, setTopics] = useState<TopicDraft[]>([createEmptyTopic(0)]);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>();
   const agendaRef = useRef<HTMLDivElement>(null);
@@ -189,7 +197,11 @@ export function MeetingPrepare({ memberId, recentMeetings, pendingActions, carry
       <div className="flex flex-col gap-4">
         <div>
           <h3 className="text-sm font-medium mb-3">テンプレート</h3>
-          <TemplateSelector onSelect={handleTemplateSelect} selectedId={selectedTemplateId} />
+          <TemplateSelector
+            onSelect={handleTemplateSelect}
+            selectedId={selectedTemplateId}
+            customTemplates={customTemplates}
+          />
         </div>
 
         <div ref={agendaRef}>

--- a/src/components/meeting/template-form-dialog.tsx
+++ b/src/components/meeting/template-form-dialog.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { MeetingTemplate } from "@/generated/prisma/client";
+import { createTemplate, updateTemplate } from "@/lib/actions/template-actions";
+import type { TemplateTopicInput } from "@/lib/validations/template-schema";
+
+const categoryOptions = [
+  { value: "WORK_PROGRESS", label: "業務進捗" },
+  { value: "CAREER", label: "キャリア" },
+  { value: "ISSUES", label: "課題・相談" },
+  { value: "FEEDBACK", label: "フィードバック" },
+  { value: "OTHER", label: "その他" },
+] as const;
+
+type TemplateTopic = TemplateTopicInput;
+
+function parseTopics(raw: unknown): TemplateTopic[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((t) => ({
+    category: t.category ?? "WORK_PROGRESS",
+    title: t.title ?? "",
+  }));
+}
+
+type Props = {
+  template?: MeetingTemplate;
+  trigger: React.ReactNode;
+};
+
+export function TemplateFormDialog({ template, trigger }: Props) {
+  const isEdit = Boolean(template);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(template?.name ?? "");
+  const [description, setDescription] = useState(template?.description ?? "");
+  const [topics, setTopics] = useState<TemplateTopic[]>(
+    template ? parseTopics(template.topics) : [],
+  );
+  const [isPending, startTransition] = useTransition();
+
+  function addTopic() {
+    setTopics((prev) => [...prev, { category: "WORK_PROGRESS", title: "" }]);
+  }
+
+  function removeTopic(index: number) {
+    setTopics((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function updateTopicField(index: number, field: keyof TemplateTopic, value: string) {
+    setTopics((prev) => prev.map((t, i) => (i === index ? { ...t, [field]: value } : t)));
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) {
+      setName(template?.name ?? "");
+      setDescription(template?.description ?? "");
+      setTopics(template ? parseTopics(template.topics) : []);
+    }
+  }
+
+  function handleSubmit() {
+    const validTopics = topics.filter((t) => t.title.trim() !== "");
+    startTransition(async () => {
+      const input = { name: name.trim(), description: description.trim(), topics: validTopics };
+      const result = isEdit
+        ? await updateTemplate(template!.id, input)
+        : await createTemplate(input);
+      if (result.success) {
+        toast.success(isEdit ? "テンプレートを更新しました" : "テンプレートを作成しました");
+        setOpen(false);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "テンプレートを編集" : "テンプレートを作成"}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div>
+            <Label htmlFor="template-name">テンプレート名 *</Label>
+            <Input
+              id="template-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="例: 週次チェックイン"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="template-description">説明</Label>
+            <Textarea
+              id="template-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="このテンプレートの用途や特徴（任意）"
+              rows={2}
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <Label>トピック</Label>
+              <Button type="button" variant="outline" size="sm" onClick={addTopic}>
+                <Plus className="w-3 h-3 mr-1" />
+                追加
+              </Button>
+            </div>
+            {topics.length === 0 && (
+              <p className="text-sm text-muted-foreground py-2">
+                トピックなし（フリーテンプレート）
+              </p>
+            )}
+            <div className="flex flex-col gap-2">
+              {topics.map((topic, index) => (
+                <div key={index} className="flex gap-2 items-start border rounded p-2">
+                  <div className="w-32 shrink-0">
+                    <Select
+                      value={topic.category}
+                      onValueChange={(val) => updateTopicField(index, "category", val)}
+                    >
+                      <SelectTrigger className="h-8 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {categoryOptions.map((opt) => (
+                          <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                            {opt.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Input
+                    value={topic.title}
+                    onChange={(e) => updateTopicField(index, "title", e.target.value)}
+                    placeholder="トピックのタイトル"
+                    className="h-8 text-sm flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0"
+                    onClick={() => removeTopic(index)}
+                    aria-label="トピックを削除"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <DialogFooter showCloseButton>
+          <Button onClick={handleSubmit} disabled={isPending || name.trim() === ""}>
+            {isPending ? "保存中..." : isEdit ? "更新" : "作成"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/meeting/template-management.tsx
+++ b/src/components/meeting/template-management.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { Edit2, Plus, Trash2 } from "lucide-react";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { MeetingTemplate } from "@/generated/prisma/client";
+import { deleteTemplate } from "@/lib/actions/template-actions";
+
+import { TemplateFormDialog } from "./template-form-dialog";
+
+const categoryLabels: Record<string, string> = {
+  WORK_PROGRESS: "業務進捗",
+  CAREER: "キャリア",
+  ISSUES: "課題・相談",
+  FEEDBACK: "フィードバック",
+  OTHER: "その他",
+};
+
+function parseTopics(raw: unknown): Array<{ category: string; title: string }> {
+  if (!Array.isArray(raw)) return [];
+  return raw as Array<{ category: string; title: string }>;
+}
+
+type TemplateCardProps = {
+  template: MeetingTemplate;
+};
+
+function TemplateCard({ template }: TemplateCardProps) {
+  const [isPending, startTransition] = useTransition();
+  const topics = parseTopics(template.topics);
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await deleteTemplate(template.id);
+      if (result.success) {
+        toast.success("テンプレートを削除しました");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <CardTitle className="text-sm font-medium truncate">{template.name}</CardTitle>
+            {template.description && (
+              <p className="text-xs text-muted-foreground mt-0.5">{template.description}</p>
+            )}
+          </div>
+          <div className="flex gap-1 shrink-0">
+            <TemplateFormDialog
+              template={template}
+              trigger={
+                <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="編集">
+                  <Edit2 className="w-3 h-3" />
+                </Button>
+              }
+            />
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-destructive hover:text-destructive"
+                  aria-label="削除"
+                >
+                  <Trash2 className="w-3 h-3" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>テンプレートを削除しますか？</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    「{template.name}」を削除します。この操作は取り消せません。
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDelete}
+                    disabled={isPending}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    削除
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {topics.length === 0 ? (
+          <p className="text-xs text-muted-foreground">トピックなし</p>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {topics.map((topic, i) => (
+              <Badge key={i} variant="secondary" className="text-xs font-normal">
+                {categoryLabels[topic.category] ?? topic.category}: {topic.title}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+type Props = {
+  templates: MeetingTemplate[];
+};
+
+export function TemplateManagement({ templates }: Props) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">カスタムテンプレート</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            1on1 準備画面で使えるオリジナルテンプレートを作成できます
+          </p>
+        </div>
+        <TemplateFormDialog
+          trigger={
+            <Button size="sm">
+              <Plus className="w-4 h-4 mr-1" />
+              新規作成
+            </Button>
+          }
+        />
+      </div>
+
+      {templates.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">カスタムテンプレートがまだありません</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            「新規作成」ボタンから作成してください
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {templates.map((template) => (
+            <TemplateCard key={template.id} template={template} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/meeting/template-selector.tsx
+++ b/src/components/meeting/template-selector.tsx
@@ -2,20 +2,47 @@
 
 import { Check } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import type { MeetingTemplate as DbMeetingTemplate } from "@/generated/prisma/client";
 import { MEETING_TEMPLATES, type MeetingTemplate } from "@/lib/meeting-templates";
 import { cn } from "@/lib/utils";
+
+type DbTemplateTopic = { category: string; title: string };
+
+function parseDbTopics(raw: unknown): Array<DbTemplateTopic> {
+  if (!Array.isArray(raw)) return [];
+  return raw as Array<DbTemplateTopic>;
+}
+
+function toMeetingTemplate(db: DbMeetingTemplate): MeetingTemplate {
+  return {
+    id: db.id,
+    name: db.name,
+    description: db.description,
+    topics: parseDbTopics(db.topics).map((t) => ({
+      category: t.category as MeetingTemplate["topics"][number]["category"],
+      title: t.title,
+    })),
+  };
+}
 
 type Props = {
   onSelect: (template: MeetingTemplate) => void;
   selectedId?: string;
+  customTemplates?: DbMeetingTemplate[];
 };
 
-export function TemplateSelector({ onSelect, selectedId }: Props) {
+export function TemplateSelector({ onSelect, selectedId, customTemplates = [] }: Props) {
+  const customConverted = customTemplates.map(toMeetingTemplate);
+  const allTemplates = [...MEETING_TEMPLATES, ...customConverted];
+  const customIds = new Set(customTemplates.map((t) => t.id));
+
   return (
     <div className="grid grid-cols-2 gap-3">
-      {MEETING_TEMPLATES.map((template) => {
+      {allTemplates.map((template) => {
         const isSelected = selectedId === template.id;
+        const isCustom = customIds.has(template.id);
         return (
           <button
             key={template.id}
@@ -41,7 +68,14 @@ export function TemplateSelector({ onSelect, selectedId }: Props) {
                     data-testid="template-check-icon"
                   />
                 )}
-                <p className="font-medium text-sm">{template.name}</p>
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  <p className="font-medium text-sm">{template.name}</p>
+                  {isCustom && (
+                    <Badge variant="secondary" className="text-[10px] px-1 py-0 h-4">
+                      カスタム
+                    </Badge>
+                  )}
+                </div>
                 <p className="text-xs text-muted-foreground mt-1">{template.description}</p>
               </CardContent>
             </Card>

--- a/src/lib/actions/__tests__/template-actions.test.ts
+++ b/src/lib/actions/__tests__/template-actions.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "@/lib/prisma";
+
+import {
+  createTemplate,
+  deleteTemplate,
+  getCustomTemplates,
+  updateTemplate,
+} from "../template-actions";
+
+beforeEach(async () => {
+  await prisma.meetingTemplate.deleteMany();
+});
+
+describe("getCustomTemplates", () => {
+  it("空の場合は空配列を返す", async () => {
+    const result = await getCustomTemplates();
+    expect(result).toEqual([]);
+  });
+
+  it("カスタムテンプレートのみを返す", async () => {
+    await prisma.meetingTemplate.createMany({
+      data: [
+        { name: "カスタムA", topics: [], isDefault: false },
+        { name: "デフォルトB", topics: [], isDefault: true },
+      ],
+    });
+    const result = await getCustomTemplates();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("カスタムA");
+  });
+
+  it("createdAt 昇順で返す", async () => {
+    await prisma.meetingTemplate.create({
+      data: { name: "後から作成", topics: [], isDefault: false },
+    });
+    await prisma.meetingTemplate.create({
+      data: { name: "先に作成", topics: [], isDefault: false },
+    });
+    const result = await getCustomTemplates();
+    expect(result[0].name).toBe("後から作成");
+    expect(result[1].name).toBe("先に作成");
+  });
+});
+
+describe("createTemplate", () => {
+  it("テンプレートを作成できる", async () => {
+    const result = await createTemplate({
+      name: "週次レビュー",
+      description: "週次の振り返り",
+      topics: [{ category: "WORK_PROGRESS", title: "今週の進捗" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("週次レビュー");
+      expect(result.data.isDefault).toBe(false);
+    }
+  });
+
+  it("名前が重複している場合はエラーを返す", async () => {
+    await createTemplate({ name: "重複テンプレート", topics: [] });
+    const result = await createTemplate({ name: "重複テンプレート", topics: [] });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("重複テンプレート");
+    }
+  });
+
+  it("名前が空の場合はバリデーションエラーを返す", async () => {
+    const result = await createTemplate({ name: "", topics: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("名前が100文字を超える場合はバリデーションエラーを返す", async () => {
+    const result = await createTemplate({ name: "a".repeat(101), topics: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("トピックなしで作成できる（フリーテンプレート）", async () => {
+    const result = await createTemplate({ name: "フリー", topics: [] });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.topics).toEqual([]);
+    }
+  });
+});
+
+describe("updateTemplate", () => {
+  it("テンプレートを更新できる", async () => {
+    const created = await createTemplate({ name: "更新前", topics: [] });
+    if (!created.success) throw new Error(created.error);
+    const result = await updateTemplate(created.data.id, {
+      name: "更新後",
+      description: "説明追加",
+      topics: [{ category: "CAREER", title: "キャリア相談" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("更新後");
+      expect(result.data.description).toBe("説明追加");
+    }
+  });
+
+  it("別テンプレートと名前が重複している場合はエラーを返す", async () => {
+    await createTemplate({ name: "テンプレートA", topics: [] });
+    const b = await createTemplate({ name: "テンプレートB", topics: [] });
+    if (!b.success) throw new Error(b.error);
+    const result = await updateTemplate(b.data.id, { name: "テンプレートA", topics: [] });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("テンプレートA");
+    }
+  });
+
+  it("同じ名前で自分自身を更新できる", async () => {
+    const created = await createTemplate({ name: "自己更新", topics: [] });
+    if (!created.success) throw new Error(created.error);
+    const result = await updateTemplate(created.data.id, {
+      name: "自己更新",
+      description: "説明変更",
+      topics: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("IDが空の場合はエラーを返す", async () => {
+    const result = await updateTemplate("", { name: "テスト", topics: [] });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("deleteTemplate", () => {
+  it("カスタムテンプレートを削除できる", async () => {
+    const created = await createTemplate({ name: "削除テスト", topics: [] });
+    if (!created.success) throw new Error(created.error);
+    const result = await deleteTemplate(created.data.id);
+    expect(result.success).toBe(true);
+    const remaining = await getCustomTemplates();
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("デフォルトテンプレートは削除できない", async () => {
+    const template = await prisma.meetingTemplate.create({
+      data: { name: "デフォルト", topics: [], isDefault: true },
+    });
+    const result = await deleteTemplate(template.id);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("デフォルトテンプレートは削除できません");
+    }
+  });
+
+  it("存在しないIDの場合はエラーを返す", async () => {
+    const result = await deleteTemplate("non-existent-id");
+    expect(result.success).toBe(false);
+  });
+
+  it("IDが空の場合はエラーを返す", async () => {
+    const result = await deleteTemplate("");
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/actions/template-actions.ts
+++ b/src/lib/actions/template-actions.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import type { MeetingTemplate } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type { CreateTemplateInput, UpdateTemplateInput } from "@/lib/validations/template-schema";
+import { createTemplateSchema, updateTemplateSchema } from "@/lib/validations/template-schema";
+
+import { type ActionResult, runAction } from "./types";
+
+export async function getCustomTemplates(): Promise<MeetingTemplate[]> {
+  return prisma.meetingTemplate.findMany({
+    where: { isDefault: false },
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+export async function createTemplate(
+  input: CreateTemplateInput,
+): Promise<ActionResult<MeetingTemplate>> {
+  return runAction(async () => {
+    const validated = createTemplateSchema.parse(input);
+    const existing = await prisma.meetingTemplate.findUnique({
+      where: { name: validated.name },
+    });
+    if (existing) {
+      throw new Error(`テンプレート名「${validated.name}」はすでに使用されています`);
+    }
+    const result = await prisma.meetingTemplate.create({ data: validated });
+    revalidatePath("/settings/templates");
+    revalidatePath("/", "layout");
+    return result;
+  });
+}
+
+export async function updateTemplate(
+  id: string,
+  input: UpdateTemplateInput,
+): Promise<ActionResult<MeetingTemplate>> {
+  return runAction(async () => {
+    if (!id) throw new Error("テンプレートIDが指定されていません");
+    const validated = updateTemplateSchema.parse(input);
+    const existing = await prisma.meetingTemplate.findUnique({
+      where: { name: validated.name },
+    });
+    if (existing && existing.id !== id) {
+      throw new Error(`テンプレート名「${validated.name}」はすでに使用されています`);
+    }
+    const result = await prisma.meetingTemplate.update({
+      where: { id },
+      data: validated,
+    });
+    revalidatePath("/settings/templates");
+    revalidatePath("/", "layout");
+    return result;
+  });
+}
+
+export async function deleteTemplate(id: string): Promise<ActionResult<MeetingTemplate>> {
+  return runAction(async () => {
+    if (!id) throw new Error("テンプレートIDが指定されていません");
+    const template = await prisma.meetingTemplate.findUnique({ where: { id } });
+    if (!template) throw new Error("テンプレートが見つかりません");
+    if (template.isDefault) {
+      throw new Error("デフォルトテンプレートは削除できません");
+    }
+    const result = await prisma.meetingTemplate.delete({ where: { id } });
+    revalidatePath("/settings/templates");
+    revalidatePath("/", "layout");
+    return result;
+  });
+}

--- a/src/lib/validations/template-schema.ts
+++ b/src/lib/validations/template-schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+const topicCategory = z.enum(["WORK_PROGRESS", "CAREER", "ISSUES", "FEEDBACK", "OTHER"]);
+
+export const templateTopicSchema = z.object({
+  category: topicCategory,
+  title: z.string().min(1, "話題のタイトルは必須です").max(200, "200文字以内で入力してください"),
+});
+
+export const createTemplateSchema = z.object({
+  name: z
+    .string()
+    .min(1, "テンプレート名は必須です")
+    .max(100, "テンプレート名は100文字以内で入力してください"),
+  description: z.string().max(500, "説明は500文字以内で入力してください").default(""),
+  topics: z.array(templateTopicSchema).default([]),
+});
+
+export const updateTemplateSchema = z.object({
+  name: z
+    .string()
+    .min(1, "テンプレート名は必須です")
+    .max(100, "テンプレート名は100文字以内で入力してください"),
+  description: z.string().max(500, "説明は500文字以内で入力してください").default(""),
+  topics: z.array(templateTopicSchema).default([]),
+});
+
+export type CreateTemplateInput = z.input<typeof createTemplateSchema>;
+export type UpdateTemplateInput = z.input<typeof updateTemplateSchema>;
+export type TemplateTopicInput = z.infer<typeof templateTopicSchema>;


### PR DESCRIPTION
## 概要

issue #137 の対応。ハードコードされたテンプレートに加え、ユーザーが独自のカスタムテンプレートを作成・編集・削除できる管理機能を追加する。

## 変更内容

### 新規ファイル
- `prisma/migrations/20260224031210_add_meeting_template/migration.sql` — MeetingTemplate テーブル追加マイグレーション
- `src/lib/validations/template-schema.ts` — Zod バリデーションスキーマ（CreateTemplateSchema, UpdateTemplateSchema）
- `src/lib/actions/template-actions.ts` — CRUD Server Actions（名前重複チェック・デフォルト削除ガード）
- `src/app/settings/templates/page.tsx` — テンプレート管理設定ページ
- `src/components/meeting/template-management.tsx` — テンプレート一覧・削除UI コンポーネント
- `src/components/meeting/template-form-dialog.tsx` — テンプレート作成・編集ダイアログ
- `src/lib/actions/__tests__/template-actions.test.ts` — Server Actions ユニットテスト
- `src/components/meeting/__tests__/template-management.test.tsx` — 管理UIコンポーネントテスト

### 変更ファイル
- `prisma/schema.prisma` — MeetingTemplate モデル追加（name UNIQUE, topics JSON, isDefault フラグ）
- `src/components/meeting/template-selector.tsx` — カスタムテンプレート対応（「カスタム」バッジ表示）
- `src/components/meeting/meeting-prepare.tsx` — customTemplates props 追加
- `src/app/members/[id]/meetings/prepare/page.tsx` — getCustomTemplates() の呼び出し追加
- `src/components/layout/sidebar.tsx` — 「テンプレート管理」ナビゲーション追加
- `src/components/meeting/__tests__/template-selector.test.tsx` — カスタムテンプレート対応テスト追加

## 機能

- **テンプレート管理画面**: `/settings/templates` でカスタムテンプレートを一覧表示・新規作成・編集・削除
- **カスタムテンプレート作成**: 名前・説明・トピック（カテゴリ + タイトル）を設定
- **名前重複バリデーション**: 同名テンプレートの登録時にエラーを表示
- **デフォルト保護**: `isDefault: true` のテンプレートは削除不可
- **準備画面統合**: ビルトインテンプレートと並んでカスタムテンプレートが選択可能（「カスタム」バッジ付き）
- **サイドバーナビゲーション**: Settings アイコン付きの「テンプレート管理」リンク

## テスト計画

- [x] `npm test` — 108ファイル 1076テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] `/settings/templates` でカスタムテンプレートを新規作成できることを確認
- [ ] 作成したテンプレートを準備画面のテンプレート選択で選べることを確認
- [ ] テンプレートの編集・削除が正常に動作することを確認
- [ ] デフォルトテンプレートが削除できないことを確認（DBで isDefault=true の場合）
- [ ] 同名テンプレートの作成時にエラーメッセージが表示されることを確認

Closes #137