### PR TITLE
ux: グローバル検索結果にキーワードのハイライト表示を追加する (issue #134)

### DIFF
--- a/src/components/layout/__tests__/global-search.test.tsx
+++ b/src/components/layout/__tests__/global-search.test.tsx
@@ -87,7 +87,8 @@ describe("GlobalSearch", () => {
 
       await user.type(input, "田中");
       await waitFor(() => {
-        expect(screen.getByText("田中太郎")).toBeDefined();
+        const listbox = screen.getByRole("listbox");
+        expect(listbox.textContent).toContain("田中太郎");
       });
     });
 
@@ -118,7 +119,8 @@ describe("GlobalSearch", () => {
 
       await user.type(input, "キャリア");
       await waitFor(() => {
-        expect(screen.getByText("キャリア相談")).toBeDefined();
+        const listbox = screen.getByRole("listbox");
+        expect(listbox.textContent).toContain("キャリア相談");
       });
     });
 
@@ -149,7 +151,8 @@ describe("GlobalSearch", () => {
 
       await user.type(input, "プレゼン");
       await waitFor(() => {
-        expect(screen.getByText("プレゼン資料作成")).toBeDefined();
+        const listbox = screen.getByRole("listbox");
+        expect(listbox.textContent).toContain("プレゼン資料作成");
       });
     });
 
@@ -230,11 +233,14 @@ describe("GlobalSearch", () => {
       const input = screen.getByPlaceholderText("検索...");
 
       await user.type(input, "田中");
-      await waitFor(() => expect(screen.getByText("田中太郎")).toBeDefined());
+      await waitFor(() => {
+        const listbox = screen.getByRole("listbox");
+        expect(listbox.textContent).toContain("田中太郎");
+      });
 
       await user.keyboard("{Escape}");
       await waitFor(() => {
-        expect(screen.queryByText("田中太郎")).toBeNull();
+        expect(screen.queryByRole("listbox")).toBeNull();
       });
     });
   });
@@ -244,6 +250,120 @@ describe("GlobalSearch", () => {
       render(<GlobalSearch />);
       const input = screen.getByLabelText("グローバル検索");
       expect(input).toBeDefined();
+    });
+  });
+
+  describe("キーワードハイライト", () => {
+    it("メンバー名の一致部分が mark タグでハイライトされる", async () => {
+      mockSearchAll.mockResolvedValue({
+        success: true,
+        data: {
+          members: [{ id: "m1", name: "田中太郎", department: null, position: null }],
+          topics: [],
+          actionItems: [],
+          tags: [],
+        },
+      });
+
+      const user = userEvent.setup({ delay: null });
+      render(<GlobalSearch />);
+      const input = screen.getByPlaceholderText("検索...");
+
+      await user.type(input, "田中");
+      await waitFor(() => {
+        const marks = document.querySelectorAll("mark");
+        expect(marks.length).toBeGreaterThan(0);
+        expect(marks[0].textContent).toBe("田中");
+      });
+    });
+
+    it("話題タイトルの一致部分がハイライトされる", async () => {
+      mockSearchAll.mockResolvedValue({
+        success: true,
+        data: {
+          members: [],
+          topics: [
+            {
+              id: "t1",
+              title: "キャリア相談",
+              notes: null,
+              category: "CAREER",
+              meetingId: "meeting-1",
+              memberId: "m1",
+              memberName: "田中太郎",
+            },
+          ],
+          actionItems: [],
+          tags: [],
+        },
+      });
+
+      const user = userEvent.setup({ delay: null });
+      render(<GlobalSearch />);
+      const input = screen.getByPlaceholderText("検索...");
+
+      await user.type(input, "キャリア");
+      await waitFor(() => {
+        const marks = document.querySelectorAll("mark");
+        expect(marks.length).toBeGreaterThan(0);
+        expect(marks[0].textContent).toBe("キャリア");
+      });
+    });
+
+    it("アクションアイテムタイトルの一致部分がハイライトされる", async () => {
+      mockSearchAll.mockResolvedValue({
+        success: true,
+        data: {
+          members: [],
+          topics: [],
+          actionItems: [
+            {
+              id: "a1",
+              title: "プレゼン資料作成",
+              description: null,
+              status: "TODO",
+              memberId: "m1",
+              memberName: "田中太郎",
+              meetingId: null,
+            },
+          ],
+          tags: [],
+        },
+      });
+
+      const user = userEvent.setup({ delay: null });
+      render(<GlobalSearch />);
+      const input = screen.getByPlaceholderText("検索...");
+
+      await user.type(input, "プレゼン");
+      await waitFor(() => {
+        const marks = document.querySelectorAll("mark");
+        expect(marks.length).toBeGreaterThan(0);
+        expect(marks[0].textContent).toBe("プレゼン");
+      });
+    });
+
+    it("タグ名の一致部分がハイライトされる", async () => {
+      mockSearchAll.mockResolvedValue({
+        success: true,
+        data: {
+          members: [],
+          topics: [],
+          actionItems: [],
+          tags: [{ id: "tag1", name: "重要タスク", color: "#ef4444" }],
+        },
+      });
+
+      const user = userEvent.setup({ delay: null });
+      render(<GlobalSearch />);
+      const input = screen.getByPlaceholderText("検索...");
+
+      await user.type(input, "重要");
+      await waitFor(() => {
+        const marks = document.querySelectorAll("mark");
+        expect(marks.length).toBeGreaterThan(0);
+        expect(marks[0].textContent).toBe("重要");
+      });
     });
   });
 });

--- a/src/components/layout/global-search.tsx
+++ b/src/components/layout/global-search.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 
 import { searchAll, type SearchResults } from "@/lib/actions/search-actions";
+import { highlightText } from "@/lib/highlight";
 import { cn } from "@/lib/utils";
 
 const DEBOUNCE_MS = 300;
@@ -150,6 +151,7 @@ export function GlobalSearch() {
                       icon={<User size={12} />}
                       primary={member.name}
                       secondary={[member.department, member.position].filter(Boolean).join(" · ")}
+                      query={query}
                       onClick={() => handleNavigate(`/members/${member.id}`)}
                     />
                   ))}
@@ -163,6 +165,7 @@ export function GlobalSearch() {
                       icon={<MessageSquare size={12} />}
                       primary={topic.title}
                       secondary={topic.memberName}
+                      query={query}
                       onClick={() =>
                         handleNavigate(`/members/${topic.memberId}/meetings/${topic.meetingId}`)
                       }
@@ -178,6 +181,7 @@ export function GlobalSearch() {
                       icon={<CheckSquare size={12} />}
                       primary={item.title}
                       secondary={item.memberName}
+                      query={query}
                       onClick={() =>
                         item.meetingId
                           ? handleNavigate(`/members/${item.memberId}/meetings/${item.meetingId}`)
@@ -194,6 +198,7 @@ export function GlobalSearch() {
                       key={tag.id}
                       icon={<Tag size={12} />}
                       primary={tag.name}
+                      query={query}
                       onClick={() => handleNavigate(`/actions?tag=${tag.id}`)}
                     />
                   ))}
@@ -224,11 +229,13 @@ function SearchItem({
   icon,
   primary,
   secondary,
+  query,
   onClick,
 }: {
   icon: React.ReactNode;
   primary: string;
   secondary?: string;
+  query: string;
   onClick: () => void;
 }) {
   return (
@@ -245,7 +252,7 @@ function SearchItem({
     >
       <span className="mt-0.5 shrink-0 text-muted-foreground">{icon}</span>
       <div className="min-w-0">
-        <div className="truncate font-medium">{primary}</div>
+        <div className="truncate font-medium">{highlightText(primary, query)}</div>
         {secondary && <div className="truncate text-xs text-muted-foreground">{secondary}</div>}
       </div>
     </button>

--- a/src/lib/__tests__/highlight.test.ts
+++ b/src/lib/__tests__/highlight.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { highlightText } from "../highlight";
+
+describe("highlightText", () => {
+  describe("基本動作", () => {
+    it("クエリが空の場合はそのまま文字列を返す", () => {
+      const result = highlightText("田中太郎", "");
+      expect(result).toBe("田中太郎");
+    });
+
+    it("一致がない場合はそのまま文字列を返す", () => {
+      const result = highlightText("田中太郎", "佐藤");
+      expect(result).toBe("田中太郎");
+    });
+
+    it("一致する部分を mark タグで包む", () => {
+      const result = highlightText("田中太郎", "田中");
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("テキスト全体が一致する場合も mark タグで包む", () => {
+      const result = highlightText("田中", "田中");
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe("大文字小文字の扱い", () => {
+    it("大文字で検索すると小文字の一致もハイライトする", () => {
+      const result = highlightText("hello world", "HELLO");
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("小文字で検索すると大文字の一致もハイライトする", () => {
+      const result = highlightText("Hello World", "hello");
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe("複数一致", () => {
+    it("複数箇所が一致する場合、すべてをハイライトする", () => {
+      const result = highlightText("田中 と 田中", "田中");
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe("特殊文字のエスケープ", () => {
+    it("正規表現の特殊文字を含むクエリでもクラッシュしない", () => {
+      expect(() => highlightText("テスト(括弧)", "(")).not.toThrow();
+      expect(() => highlightText("テスト.ドット", ".")).not.toThrow();
+      expect(() => highlightText("テスト*アスタ", "*")).not.toThrow();
+      expect(() => highlightText("テスト+プラス", "+")).not.toThrow();
+      expect(() => highlightText("テスト?クエスチョン", "?")).not.toThrow();
+    });
+
+    it("特殊文字をリテラルとしてマッチする", () => {
+      const result = highlightText("テスト(括弧)あり", "(括弧)");
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("テキストが空の場合は空文字を返す", () => {
+      const result = highlightText("", "テスト");
+      expect(result).toBe("");
+    });
+  });
+});

--- a/src/lib/highlight.tsx
+++ b/src/lib/highlight.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+/**
+ * 正規表現の特殊文字をエスケープする
+ */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * テキスト内のクエリに一致する部分を <mark> タグでハイライトする。
+ * クエリが空の場合、または一致がない場合はそのまま文字列を返す。
+ * 大文字・小文字を区別しない。
+ */
+export function highlightText(text: string, query: string): React.ReactNode {
+  if (!query || !text) return text;
+
+  const escaped = escapeRegExp(query);
+  const parts = text.split(new RegExp(`(${escaped})`, "gi"));
+
+  if (parts.length <= 1) return text;
+
+  return parts.map((part, i) =>
+    part.toLowerCase() === query.toLowerCase() ? (
+      <mark
+        key={i}
+        className="rounded-sm bg-yellow-200 text-yellow-900 dark:bg-yellow-800 dark:text-yellow-100"
+      >
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  );
+}


### PR DESCRIPTION
## 概要

issue #134 の対応。グローバル検索結果の各アイテムで、入力したキーワードに一致する文字列を強調表示（ハイライト）する。ライトモード・ダークモード両対応。

## 変更内容

### 新規ファイル
- `src/lib/highlight.tsx` — `highlightText` ユーティリティ関数。正規表現特殊文字エスケープ済み、大文字小文字区別なし
- `src/lib/__tests__/highlight.test.ts` — `highlightText` のユニットテスト（10テスト）

### 変更ファイル
- `src/components/layout/global-search.tsx` — `SearchItem` に `query` prop を追加し `highlightText` でタイトルをハイライト表示
- `src/components/layout/__tests__/global-search.test.tsx` — ハイライト表示テスト4件を追加、既存テストをハイライト対応に修正

## 機能

- **キーワードハイライト**: メンバー名・話題タイトル・アクションアイテムタイトル・タグ名の一致部分を `<mark>` タグで包む
  - ライトモード: `bg-yellow-200 text-yellow-900`
  - ダークモード: `dark:bg-yellow-800 dark:text-yellow-100`
- **安全なマッチング**: `(`, `)`, `.`, `*` など正規表現特殊文字を含むクエリでもクラッシュしない
- **クエリ空の場合はハイライトなし**: テキストをそのまま返す

## テスト計画

- [x] `npm test` — 107ファイル 1059テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] 実際に検索ボックスにキーワードを入力して各カテゴリの結果でハイライトが表示されることを確認
- [ ] ダークモードでハイライトの視認性を確認
- [ ] 正規表現特殊文字（`(`, `.`, `*` など）を含むキーワードで検索してクラッシュしないことを確認

Closes #134