### PR TITLE
ux: 空状態（Empty State）のデザインを改善して初回利用時・データなし時の誘導を強化する (issue #133)

### DIFF
--- a/src/components/action/__tests__/action-list-grouped.test.tsx
+++ b/src/components/action/__tests__/action-list-grouped.test.tsx
@@ -108,9 +108,16 @@ describe("ActionListGrouped", () => {
   });
 
   describe("エッジケース", () => {
-    it("空のアイテムリストで何も表示しない", () => {
-      const { container } = render(<ActionListGrouped actionItems={[]} groupBy="member" />);
-      expect(container.firstChild).toBeNull();
+    it("空のアイテムリストでEmptyStateを表示する", () => {
+      render(<ActionListGrouped actionItems={[]} groupBy="member" />);
+      expect(screen.getByText("アクションアイテムはありません")).toBeDefined();
+    });
+
+    it("空のアイテムリストのEmptyStateに説明文を表示する", () => {
+      render(<ActionListGrouped actionItems={[]} groupBy="member" />);
+      expect(
+        screen.getByText("1on1でアクションアイテムを作成すると、ここに表示されます"),
+      ).toBeDefined();
     });
 
     it("groupBy が none のとき何も表示しない", () => {

--- a/src/components/action/action-list-grouped.tsx
+++ b/src/components/action/action-list-grouped.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, SquareCheck } from "lucide-react";
 import { useState } from "react";
 
 import { ActionListFull } from "@/components/action/action-list-full";
 import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { GroupByType } from "@/lib/group-actions";
 import { groupActionItems } from "@/lib/group-actions";
 
@@ -35,7 +36,16 @@ export function ActionListGrouped({ actionItems, groupBy, statusFilter }: Props)
   const groups = groupActionItems(actionItems, groupBy);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
-  if (groups.length === 0) return null;
+  if (groupBy === "none") return null;
+  if (groups.length === 0) {
+    return (
+      <EmptyState
+        icon={SquareCheck}
+        title="アクションアイテムはありません"
+        description="1on1でアクションアイテムを作成すると、ここに表示されます"
+      />
+    );
+  }
 
   function toggleGroup(key: string) {
     setCollapsedGroups((prev) => {

--- a/src/components/analytics/__tests__/meeting-frequency-chart.test.tsx
+++ b/src/components/analytics/__tests__/meeting-frequency-chart.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MeetingFrequencyChart } from "../meeting-frequency-chart";
 
@@ -15,10 +15,19 @@ vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("MeetingFrequencyChart", () => {
   it("renders empty state when no data", () => {
     render(<MeetingFrequencyChart data={[]} />);
-    expect(screen.getByText("データがありません")).toBeDefined();
+    expect(screen.getByText("まだデータがありません")).toBeDefined();
+  });
+
+  it("renders guidance message in empty state", () => {
+    render(<MeetingFrequencyChart data={[]} />);
+    expect(screen.getByText("1on1を実施すると、月次実施回数グラフが表示されます")).toBeDefined();
   });
 
   it("renders bar chart when data exists", () => {

--- a/src/components/analytics/__tests__/meeting-heatmap.test.tsx
+++ b/src/components/analytics/__tests__/meeting-heatmap.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { HeatmapData } from "@/lib/actions/analytics-actions";
 
@@ -80,10 +80,21 @@ const sampleData: HeatmapData = {
   ],
 };
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("MeetingHeatmap", () => {
-  it("メンバーがいない場合は空状態メッセージを表示する", () => {
+  it("メンバーがいない場合は空状態コンポーネントを表示する", () => {
     render(<MeetingHeatmap data={emptyData} />);
-    expect(screen.getByText("データがありません")).toBeDefined();
+    expect(screen.getByText("まだデータがありません")).toBeDefined();
+  });
+
+  it("メンバーがいない場合は説明文を表示する", () => {
+    render(<MeetingHeatmap data={emptyData} />);
+    expect(
+      screen.getByText("1on1を実施すると、メンバー別の頻度マップが表示されます"),
+    ).toBeDefined();
   });
 
   it("メンバー名を表示する", () => {

--- a/src/components/analytics/__tests__/meeting-interval-table.test.tsx
+++ b/src/components/analytics/__tests__/meeting-interval-table.test.tsx
@@ -74,7 +74,15 @@ describe("MeetingIntervalTable", () => {
 
   it("renders empty state when no data", () => {
     render(<MeetingIntervalTable data={[]} />);
-    expect(screen.getByText("データがありません")).toBeDefined();
+    expect(screen.getByText("メンバーが登録されていません")).toBeDefined();
+  });
+
+  it("renders guidance and action in empty state", () => {
+    render(<MeetingIntervalTable data={[]} />);
+    expect(
+      screen.getByText("メンバーを追加すると、最終1on1の経過日数が表示されます"),
+    ).toBeDefined();
+    expect(screen.getByRole("link", { name: "メンバーを追加する" })).toBeDefined();
   });
 
   it("全員が実施済みの場合トグルボタンは表示しない", () => {

--- a/src/components/analytics/meeting-frequency-chart.tsx
+++ b/src/components/analytics/meeting-frequency-chart.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { BarChart2 } from "lucide-react";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import { useChartMounted } from "@/hooks/use-chart-mounted";
 import type { MeetingFrequencyMonth } from "@/lib/actions/analytics-actions";
 
@@ -18,9 +20,12 @@ export function MeetingFrequencyChart({ data }: { data: MeetingFrequencyMonth[] 
       </CardHeader>
       <CardContent className="h-[250px] w-full pt-4">
         {data.length === 0 ? (
-          <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
-            データがありません
-          </div>
+          <EmptyState
+            icon={BarChart2}
+            title="まだデータがありません"
+            description="1on1を実施すると、月次実施回数グラフが表示されます"
+            size="compact"
+          />
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={data} margin={{ top: 5, right: 10, left: -20, bottom: 0 }}>

--- a/src/components/analytics/meeting-heatmap.tsx
+++ b/src/components/analytics/meeting-heatmap.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { Calendar } from "lucide-react";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { HeatmapData } from "@/lib/actions/analytics-actions";
 
 type Props = {
@@ -41,9 +44,12 @@ export function MeetingHeatmap({ data }: Props) {
       </CardHeader>
       <CardContent>
         {members.length === 0 ? (
-          <div className="flex items-center justify-center py-8 text-muted-foreground text-sm">
-            データがありません
-          </div>
+          <EmptyState
+            icon={Calendar}
+            title="まだデータがありません"
+            description="1on1を実施すると、メンバー別の頻度マップが表示されます"
+            size="compact"
+          />
         ) : (
           <div className="overflow-x-auto">
             <table

--- a/src/components/analytics/meeting-interval-table.tsx
+++ b/src/components/analytics/meeting-interval-table.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { Users } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { RecommendedMeeting } from "@/lib/actions/analytics-actions";
 
 function DaysBadge({ member }: { member: RecommendedMeeting }) {
@@ -66,7 +68,13 @@ export function MeetingIntervalTable({ data }: { data: RecommendedMeeting[] }) {
       </CardHeader>
       <CardContent>
         {data.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-4">データがありません</p>
+          <EmptyState
+            icon={Users}
+            title="メンバーが登録されていません"
+            description="メンバーを追加すると、最終1on1の経過日数が表示されます"
+            action={{ label: "メンバーを追加する", href: "/members/new" }}
+            size="compact"
+          />
         ) : (
           <>
             <div className="divide-y divide-border">

--- a/src/components/meeting/__tests__/meeting-history.test.tsx
+++ b/src/components/meeting/__tests__/meeting-history.test.tsx
@@ -34,6 +34,21 @@ describe("MeetingHistory", () => {
     expect(screen.getByText("まだ1on1の記録がありません")).toBeDefined();
   });
 
+  it("空状態に「最初の1on1を準備する」ボタンを表示する", () => {
+    render(
+      <MeetingHistory meetings={[]} memberId="mem1" pagination={{ ...basePagination, total: 0 }} />,
+    );
+    expect(screen.getByText("最初の1on1を準備する")).toBeDefined();
+  });
+
+  it("空状態のCTAがprepareページへリンクする", () => {
+    render(
+      <MeetingHistory meetings={[]} memberId="mem1" pagination={{ ...basePagination, total: 0 }} />,
+    );
+    const link = screen.getByRole("link", { name: "最初の1on1を準備する" });
+    expect(link.getAttribute("href")).toBe("/members/mem1/meetings/prepare");
+  });
+
   it("ミーティング一覧を表示する", () => {
     render(
       <MeetingHistory

--- a/src/components/meeting/meeting-history.tsx
+++ b/src/components/meeting/meeting-history.tsx
@@ -36,7 +36,7 @@ export function MeetingHistory({ meetings, memberId, pagination }: Props) {
         icon={MessageSquare}
         title="まだ1on1の記録がありません"
         description="最初の1on1を記録して、継続的なフォローアップを始めましょう"
-        action={{ label: "1on1を記録する", href: `/members/${memberId}/meetings/new` }}
+        action={{ label: "最初の1on1を準備する", href: `/members/${memberId}/meetings/prepare` }}
       />
     );
   }


### PR DESCRIPTION
## 概要

issue #133 の対応。各画面でデータが存在しない場合の空状態表示を改善し、ユーザーを次のアクションへ自然に誘導する UX を強化する。テキストのみの空状態を `EmptyState` コンポーネントに統一し、アイコン・説明文・CTAボタンを追加した。

## 変更内容

### 変更ファイル

- `src/components/meeting/meeting-history.tsx` — 空状態CTAを「1on1を記録する」から「最初の1on1を準備する」に変更し、prepareページへリンク
- `src/components/action/action-list-grouped.tsx` — グループ表示が空の場合に `null` ではなく `EmptyState` コンポーネントを表示
- `src/components/analytics/meeting-frequency-chart.tsx` — テキストのみの空状態を `EmptyState`（BarChart2アイコン・ガイダンス文）に変更
- `src/components/analytics/meeting-heatmap.tsx` — テキストのみの空状態を `EmptyState`（Calendarアイコン・ガイダンス文）に変更
- `src/components/analytics/meeting-interval-table.tsx` — テキストのみの空状態を `EmptyState`（Usersアイコン・「メンバーを追加する」CTAボタン）に変更

### テストファイル

- `src/components/meeting/__tests__/meeting-history.test.tsx` — 新CTAテキスト・prepareページへのリンクを確認するテストを追加
- `src/components/action/__tests__/action-list-grouped.test.tsx` — 空配列時の `EmptyState` 表示・説明文テストに更新
- `src/components/analytics/__tests__/meeting-frequency-chart.test.tsx` — 新EmptyStateタイトル・ガイダンスメッセージテストに更新
- `src/components/analytics/__tests__/meeting-heatmap.test.tsx` — 新EmptyStateタイトル・ガイダンスメッセージテストに更新
- `src/components/analytics/__tests__/meeting-interval-table.test.tsx` — 新EmptyStateタイトル・説明文・CTAボタンテストに更新

## 改善詳細

| 画面・コンポーネント | 変更前 | 変更後 |
|---|---|---|
| MeetingHistory（空状態CTA） | 「1on1を記録する」→ newページ | 「最初の1on1を準備する」→ prepareページ |
| ActionListGrouped（空状態） | `null`（何も表示しない） | EmptyState（アイコン・タイトル・説明文） |
| MeetingFrequencyChart（空状態） | テキスト「データがありません」 | EmptyState + ガイダンス文 |
| MeetingHeatmap（空状態） | テキスト「データがありません」 | EmptyState + ガイダンス文 |
| MeetingIntervalTable（空状態） | テキスト「データがありません」 | EmptyState + 「メンバーを追加する」CTA |

## テスト計画

- [x] `npm test` — 109ファイル 1108テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ブラウザで各画面の空状態表示を目視確認
- [ ] ダークモードで各空状態が適切に表示されることを確認
- [ ] 「最初の1on1を準備する」CTAクリック後に準備画面へ遷移することを確認
- [ ] 「メンバーを追加する」CTAクリック後にメンバー追加ページへ遷移することを確認

Closes #133