### PR TITLE
feat: ミーティング終了後にサマリーテキストを自動生成してコピーできるようにする (issue #117)

### DIFF
--- a/src/app/members/[id]/meetings/[meetingId]/page.tsx
+++ b/src/app/members/[id]/meetings/[meetingId]/page.tsx
@@ -54,6 +54,7 @@ export default async function MeetingDetailPage({ params }: Props) {
           <MeetingDetailPageClient
             meetingId={meetingId}
             memberId={id}
+            memberName={meeting.member.name}
             date={meeting.date}
             mood={meeting.mood}
             conditionHealth={meeting.conditionHealth}

--- a/src/components/meeting/__tests__/meeting-detail-page-client.test.tsx
+++ b/src/components/meeting/__tests__/meeting-detail-page-client.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -56,6 +56,10 @@ vi.mock("@dnd-kit/core", () => ({
   useSensors: vi.fn(() => []),
 }));
 
+vi.mock("@/lib/meeting-summary", () => ({
+  generateMeetingSummaryText: vi.fn().mockReturnValue("テストサマリーテキスト"),
+}));
+
 vi.mock("@dnd-kit/sortable", () => ({
   SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   verticalListSortingStrategy: {},
@@ -73,6 +77,7 @@ vi.mock("@dnd-kit/sortable", () => ({
 const defaultProps = {
   meetingId: "meeting-1",
   memberId: "member-1",
+  memberName: "田中太郎",
   date: new Date("2026-02-20T10:00:00.000Z"),
   topics: [
     {
@@ -111,6 +116,26 @@ describe("MeetingDetailPageClient", () => {
   it("shows edit button in view mode", () => {
     render(<MeetingDetailPageClient {...defaultProps} />);
     expect(screen.getByRole("button", { name: /編集/ })).toBeTruthy();
+  });
+
+  it("shows copy summary button in view mode", () => {
+    render(<MeetingDetailPageClient {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /サマリーをコピー/ })).toBeTruthy();
+  });
+
+  it("calls generateMeetingSummaryText with memberName when copy button is clicked", async () => {
+    const { generateMeetingSummaryText } = await import("@/lib/meeting-summary");
+    const mockGenerate = vi.mocked(generateMeetingSummaryText);
+
+    const user = userEvent.setup();
+    render(<MeetingDetailPageClient {...defaultProps} />);
+    await user.click(screen.getByRole("button", { name: /サマリーをコピー/ }));
+
+    await waitFor(() => {
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({ memberName: "田中太郎" }),
+      );
+    });
   });
 
   it("switches to edit mode when edit button is clicked", async () => {

--- a/src/components/meeting/meeting-detail-page-client.tsx
+++ b/src/components/meeting/meeting-detail-page-client.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Pencil, Play } from "lucide-react";
+import { Copy, Pencil, Play } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { startMeeting } from "@/lib/actions/meeting-actions";
+import { generateMeetingSummaryText } from "@/lib/meeting-summary";
 import { TOAST_MESSAGES } from "@/lib/toast-messages";
 
 import { CoachingSheet } from "./coaching-sheet";
@@ -49,6 +50,7 @@ type PreviousConditions = {
 type Props = {
   readonly meetingId: string;
   readonly memberId: string;
+  readonly memberName: string;
   readonly date: Date;
   readonly mood?: number | null;
   readonly conditionHealth?: number | null;
@@ -65,6 +67,7 @@ type Props = {
 export function MeetingDetailPageClient({
   meetingId,
   memberId,
+  memberName,
   date,
   mood,
   conditionHealth,
@@ -106,6 +109,23 @@ export function MeetingDetailPageClient({
       toast.error(TOAST_MESSAGES.meeting.recordingStartError);
     } finally {
       setIsStarting(false);
+    }
+  }
+
+  async function handleCopySummary() {
+    const summaryText = generateMeetingSummaryText({
+      memberName,
+      date,
+      topics: topics.map((t) => ({ category: t.category, title: t.title, notes: t.notes })),
+      actionItems: actionItems.map((a) => ({ title: a.title, dueDate: a.dueDate })),
+      startedAt: startedAt ?? null,
+      endedAt: endedAt ?? null,
+    });
+    try {
+      await navigator.clipboard.writeText(summaryText);
+      toast.success(TOAST_MESSAGES.meeting.summaryCopied);
+    } catch {
+      toast.error(TOAST_MESSAGES.meeting.summaryCopyError);
     }
   }
 
@@ -182,6 +202,10 @@ export function MeetingDetailPageClient({
             {isStarting ? "記録開始中..." : "記録を開始"}
           </Button>
         )}
+        <Button variant="outline" size="sm" onClick={handleCopySummary}>
+          <Copy className="w-4 h-4 mr-1.5" />
+          サマリーをコピー
+        </Button>
         <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
           <Pencil className="w-4 h-4 mr-1.5" />
           編集

--- a/src/lib/__tests__/meeting-summary.test.ts
+++ b/src/lib/__tests__/meeting-summary.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { generateMeetingSummaryText } from "../meeting-summary";
+
+const baseData = {
+  memberName: "田中太郎",
+  date: new Date("2026-02-20T10:00:00.000Z"),
+  topics: [
+    {
+      category: "WORK_PROGRESS",
+      title: "スプリントレビュー",
+      notes: "進捗は良好です",
+    },
+    {
+      category: "CAREER",
+      title: "キャリア相談",
+      notes: "",
+    },
+  ],
+  actionItems: [
+    {
+      title: "バグ修正",
+      dueDate: new Date("2026-03-01"),
+    },
+    {
+      title: "レポート提出",
+      dueDate: null,
+    },
+  ],
+  startedAt: new Date("2026-02-20T10:00:00.000Z"),
+  endedAt: new Date("2026-02-20T10:45:00.000Z"),
+};
+
+describe("generateMeetingSummaryText", () => {
+  it("サマリーヘッダーにメンバー名と日付が含まれる", () => {
+    const text = generateMeetingSummaryText(baseData);
+    expect(text).toContain("【1on1サマリー】田中太郎");
+  });
+
+  it("トピックセクションが含まれる", () => {
+    const text = generateMeetingSummaryText(baseData);
+    expect(text).toContain("■ 話したトピック");
+    expect(text).toContain("スプリントレビュー");
+    expect(text).toContain("キャリア相談");
+  });
+
+  it("アクションアイテムセクションが含まれる", () => {
+    const text = generateMeetingSummaryText(baseData);
+    expect(text).toContain("■ 次のアクション");
+    expect(text).toContain("バグ修正");
+    expect(text).toContain("レポート提出");
+  });
+
+  it("期日ありのアクションアイテムに期日が表示される", () => {
+    const text = generateMeetingSummaryText(baseData);
+    expect(text).toContain("期日:");
+  });
+
+  it("期日なしのアクションアイテムに期日なしが表示される", () => {
+    const text = generateMeetingSummaryText(baseData);
+    expect(text).toContain("期日: なし");
+  });
+
+  it("所要時間が表示される", () => {
+    const text = generateMeetingSummaryText(baseData);
+    expect(text).toContain("所要時間:");
+    expect(text).toContain("45分");
+  });
+
+  it("トピックが0件でもエラーなく動作する", () => {
+    const data = { ...baseData, topics: [] };
+    const text = generateMeetingSummaryText(data);
+    expect(text).toContain("■ 話したトピック");
+    expect(text).toContain("なし");
+  });
+
+  it("アクションアイテムが0件でもエラーなく動作する", () => {
+    const data = { ...baseData, actionItems: [] };
+    const text = generateMeetingSummaryText(data);
+    expect(text).toContain("■ 次のアクション");
+    expect(text).toContain("なし");
+  });
+
+  it("トピックもアクションも0件でもエラーなく動作する", () => {
+    const data = { ...baseData, topics: [], actionItems: [] };
+    expect(() => generateMeetingSummaryText(data)).not.toThrow();
+  });
+
+  it("メモが100文字を超える場合は切り詰める", () => {
+    const longNotes = "あ".repeat(150);
+    const data = {
+      ...baseData,
+      topics: [{ category: "WORK_PROGRESS", title: "長いメモ", notes: longNotes }],
+    };
+    const text = generateMeetingSummaryText(data);
+    expect(text).toContain("あ".repeat(100));
+    expect(text).not.toContain("あ".repeat(101));
+  });
+
+  it("startedAt・endedAtがない場合は所要時間を表示しない", () => {
+    const data = { ...baseData, startedAt: null, endedAt: null };
+    const text = generateMeetingSummaryText(data);
+    expect(text).not.toContain("所要時間:");
+  });
+
+  it("startedAtのみある場合は所要時間を表示しない", () => {
+    const data = { ...baseData, startedAt: new Date(), endedAt: null };
+    const text = generateMeetingSummaryText(data);
+    expect(text).not.toContain("所要時間:");
+  });
+
+  it("トピックのカテゴリラベルが日本語で表示される", () => {
+    const text = generateMeetingSummaryText(baseData);
+    // WORK_PROGRESS の日本語ラベルが含まれることを確認
+    expect(text).toMatch(/業務進捗|仕事の進捗|WORK_PROGRESS/);
+  });
+
+  it("トピックにメモがない場合はメモ行を省略する", () => {
+    const data = {
+      ...baseData,
+      topics: [{ category: "CAREER", title: "キャリア", notes: "" }],
+    };
+    const text = generateMeetingSummaryText(data);
+    expect(text).toContain("キャリア");
+  });
+});

--- a/src/lib/meeting-summary.ts
+++ b/src/lib/meeting-summary.ts
@@ -1,0 +1,81 @@
+import { CATEGORY_LABELS } from "@/lib/constants";
+import { formatDate, formatDuration } from "@/lib/format";
+
+type TopicSummaryData = {
+  readonly category: string;
+  readonly title: string;
+  readonly notes: string;
+};
+
+type ActionItemSummaryData = {
+  readonly title: string;
+  readonly dueDate: Date | null;
+};
+
+export type MeetingSummaryData = {
+  readonly memberName: string;
+  readonly date: Date;
+  readonly topics: ReadonlyArray<TopicSummaryData>;
+  readonly actionItems: ReadonlyArray<ActionItemSummaryData>;
+  readonly startedAt: Date | null;
+  readonly endedAt: Date | null;
+};
+
+const NOTES_MAX_LENGTH = 100;
+
+function formatTopicsSection(topics: ReadonlyArray<TopicSummaryData>): string {
+  if (topics.length === 0) {
+    return "■ 話したトピック\nなし";
+  }
+
+  const lines = ["■ 話したトピック"];
+  for (const topic of topics) {
+    const categoryLabel = CATEGORY_LABELS[topic.category] ?? topic.category;
+    lines.push(`- ${topic.title}（${categoryLabel}）`);
+    if (topic.notes) {
+      const truncated =
+        topic.notes.length > NOTES_MAX_LENGTH
+          ? topic.notes.slice(0, NOTES_MAX_LENGTH)
+          : topic.notes;
+      lines.push(`  ${truncated}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatActionItemsSection(actionItems: ReadonlyArray<ActionItemSummaryData>): string {
+  if (actionItems.length === 0) {
+    return "■ 次のアクション\nなし";
+  }
+
+  const lines = ["■ 次のアクション"];
+  for (const item of actionItems) {
+    const due = item.dueDate ? `期日: ${formatDate(item.dueDate)}` : "期日: なし";
+    lines.push(`- [ ] ${item.title}（${due}）`);
+  }
+  return lines.join("\n");
+}
+
+function formatDurationSection(startedAt: Date | null, endedAt: Date | null): string | null {
+  if (!startedAt || !endedAt) return null;
+  const start = startedAt.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
+  const end = endedAt.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
+  const duration = formatDuration(startedAt, endedAt);
+  return `所要時間: ${start}〜${end}（${duration}）`;
+}
+
+export function generateMeetingSummaryText(data: MeetingSummaryData): string {
+  const { memberName, date, topics, actionItems, startedAt, endedAt } = data;
+
+  const header = `【1on1サマリー】${memberName} - ${formatDate(date)}`;
+  const topicsSection = formatTopicsSection(topics);
+  const actionsSection = formatActionItemsSection(actionItems);
+  const durationSection = formatDurationSection(startedAt, endedAt);
+
+  const parts = [header, "", topicsSection, "", actionsSection];
+  if (durationSection) {
+    parts.push("", durationSection);
+  }
+
+  return parts.join("\n");
+}

--- a/src/lib/toast-messages.ts
+++ b/src/lib/toast-messages.ts
@@ -18,6 +18,8 @@ export const TOAST_MESSAGES = {
     recordingEnd: "ミーティングを終了しました",
     recordingEndError: "ミーティングの終了に失敗しました",
     autoSaveError: "自動保存に失敗しました",
+    summaryCopied: "サマリーをクリップボードにコピーしました",
+    summaryCopyError: "コピーに失敗しました",
   },
   actionItem: {
     statusChangeSuccess: "ステータスを更新しました",


### PR DESCRIPTION
## 概要

issue #117 の対応。1on1ミーティング終了後、話したトピック・決まったアクションアイテムをもとにサマリーテキストを自動生成し、ワンクリックでクリップボードにコピーできる機能を追加する。

## 変更内容

### 新規ファイル
- `src/lib/meeting-summary.ts` — サマリーテキスト生成ユーティリティ関数 (`generateMeetingSummaryText`)
- `src/lib/__tests__/meeting-summary.test.ts` — ユーティリティ関数のユニットテスト（14件）

### 変更ファイル
- `src/components/meeting/meeting-detail-page-client.tsx` — `memberName` prop 追加・「サマリーをコピー」ボタン実装
- `src/app/members/[id]/meetings/[meetingId]/page.tsx` — `memberName` を `MeetingDetailPageClient` に渡す
- `src/lib/toast-messages.ts` — `summaryCopied` / `summaryCopyError` トーストメッセージ追加
- `src/components/meeting/__tests__/meeting-detail-page-client.test.tsx` — `memberName` prop 追加・コピーボタンテスト追加（2件）

## 機能

- **サマリーフォーマット**:
  ```
  【1on1サマリー】{メンバー名} - {日付}

  ■ 話したトピック
  - {トピックタイトル}（{カテゴリ}）
    {メモの先頭100文字}

  ■ 次のアクション
  - [ ] {アクションタイトル}（期日: {dueDate}）

  所要時間: {startedAt}〜{endedAt}（{経過時間}）
  ```
- **メモの切り詰め**: 100文字を超えるメモは先頭100文字に切り詰め
- **0件対応**: トピック・アクションが0件でも「なし」と表示してエラーなく動作
- **ローカル処理のみ**: 外部AIサービス不要のシンプルなプレーンテキスト生成

## テスト計画

- [x] `npm test` — 111ファイル / 1132テスト通過（1件は既存DB状態の問題、今回の変更と無関係）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ミーティング詳細画面で「サマリーをコピー」ボタンが表示されることを確認
- [ ] ボタンクリックでサマリーテキストがクリップボードにコピーされることを確認
- [ ] トースト通知が表示されることを確認
- [ ] トピック0件・アクション0件のミーティングでも正常動作することを確認

Closes #117