### PR TITLE
feat: メンバー詳細にチェックイン状態の時系列トレンドグラフを追加する (issue #119)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { ActionListCompact } from "@/components/action/action-list-compact";
 import { ActionAnalyticsSection } from "@/components/analytics/action-analytics-section";
+import { CheckinTrendSection } from "@/components/analytics/checkin-trend-section";
 import { TopicAnalyticsSection } from "@/components/analytics/topic-analytics-section";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { MeetingHistory } from "@/components/meeting/meeting-history";
@@ -82,6 +83,7 @@ export default async function MemberDetailPage({ params, searchParams }: Props) 
 
       <TopicAnalyticsSection memberId={id} />
       <ActionAnalyticsSection memberId={id} />
+      <CheckinTrendSection memberId={id} />
 
       {moodTrend.length > 0 && (
         <div className="mt-6">

--- a/src/components/analytics/__tests__/checkin-trend-chart.test.tsx
+++ b/src/components/analytics/__tests__/checkin-trend-chart.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CheckinTrendChart } from "../checkin-trend-chart";
+
+vi.mock("recharts", () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => cleanup());
+
+describe("CheckinTrendChart", () => {
+  it("データが0件の場合にデータ不足メッセージを表示する", () => {
+    render(<CheckinTrendChart data={[]} />);
+    expect(screen.getByText("グラフを表示するには3回以上のチェックインが必要です")).toBeDefined();
+  });
+
+  it("データが2件の場合にデータ不足メッセージを表示する", () => {
+    const data = [
+      { date: "2026/01/01", health: 4, mood: 3, workload: 2 },
+      { date: "2026/01/15", health: 5, mood: 4, workload: 3 },
+    ];
+    render(<CheckinTrendChart data={data} />);
+    expect(screen.getByText("グラフを表示するには3回以上のチェックインが必要です")).toBeDefined();
+  });
+
+  it("データが3件以上の場合はグラフを表示する", () => {
+    const data = [
+      { date: "2026/01/01", health: 4, mood: 3, workload: 2 },
+      { date: "2026/01/15", health: 5, mood: 4, workload: 3 },
+      { date: "2026/02/01", health: 3, mood: 5, workload: 4 },
+    ];
+    render(<CheckinTrendChart data={data} />);
+    expect(screen.getByTestId("line-chart")).toBeDefined();
+  });
+
+  it("カードタイトルを表示する", () => {
+    render(<CheckinTrendChart data={[]} />);
+    expect(screen.getByText("チェックイン状態の推移")).toBeDefined();
+  });
+});

--- a/src/components/analytics/checkin-trend-chart.tsx
+++ b/src/components/analytics/checkin-trend-chart.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useChartMounted } from "@/hooks/use-chart-mounted";
+import type { CheckinTrendEntry } from "@/lib/actions/analytics-actions";
+
+const MIN_DATA_POINTS = 3;
+
+export function CheckinTrendChart({ data }: { data: CheckinTrendEntry[] }) {
+  const mounted = useChartMounted();
+
+  if (!mounted) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">チェックイン状態の推移</CardTitle>
+      </CardHeader>
+      <CardContent className="h-[260px] w-full pt-4">
+        {data.length < MIN_DATA_POINTS ? (
+          <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+            グラフを表示するには3回以上のチェックインが必要です
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 5, right: 30, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
+              <XAxis
+                dataKey="date"
+                fontSize={11}
+                tickLine={false}
+                axisLine={false}
+                stroke="var(--muted-foreground)"
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                domain={[1, 5]}
+                ticks={[1, 2, 3, 4, 5]}
+                fontSize={11}
+                tickLine={false}
+                axisLine={false}
+                stroke="var(--muted-foreground)"
+                allowDecimals={false}
+              />
+              <Tooltip
+                cursor={{ stroke: "var(--muted)", strokeWidth: 2 }}
+                contentStyle={{
+                  backgroundColor: "var(--background)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius)",
+                  fontSize: "12px",
+                }}
+              />
+              <Legend wrapperStyle={{ fontSize: "12px", paddingTop: "10px" }} />
+              <Line
+                name="健康"
+                type="monotone"
+                dataKey="health"
+                stroke="oklch(0.60 0.2 25)"
+                strokeWidth={2}
+                dot={{ r: 4, fill: "var(--background)", strokeWidth: 2 }}
+                activeDot={{ r: 6 }}
+                connectNulls={false}
+              />
+              <Line
+                name="気分"
+                type="monotone"
+                dataKey="mood"
+                stroke="oklch(0.72 0.15 85)"
+                strokeWidth={2}
+                dot={{ r: 4, fill: "var(--background)", strokeWidth: 2 }}
+                activeDot={{ r: 6 }}
+                connectNulls={false}
+              />
+              <Line
+                name="業務負荷"
+                type="monotone"
+                dataKey="workload"
+                stroke="oklch(0.55 0.2 240)"
+                strokeWidth={2}
+                dot={{ r: 4, fill: "var(--background)", strokeWidth: 2 }}
+                activeDot={{ r: 6 }}
+                connectNulls={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analytics/checkin-trend-section.tsx
+++ b/src/components/analytics/checkin-trend-section.tsx
@@ -1,0 +1,24 @@
+import { getCheckinTrend } from "@/lib/actions/analytics-actions";
+
+import { CheckinTrendChart } from "./checkin-trend-chart";
+
+type Props = {
+  memberId: string;
+};
+
+export async function CheckinTrendSection({ memberId }: Props) {
+  const data = await getCheckinTrend(memberId, 12);
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="my-8 animate-fade-in-up stagger-4">
+      <h2 className="text-lg font-semibold tracking-tight mb-3 text-foreground">
+        チェックイン状態の推移
+      </h2>
+      <CheckinTrendChart data={data} />
+    </div>
+  );
+}

--- a/src/lib/actions/__tests__/analytics-actions.test.ts
+++ b/src/lib/actions/__tests__/analytics-actions.test.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 
 import {
   getAllMembersWithInterval,
+  getCheckinTrend,
   getDepartments,
   getMeetingFrequencyByMonth,
   getMemberActionTrends,
@@ -614,5 +615,127 @@ describe("getAllMembersWithInterval with options", () => {
     const indexA = result.findIndex((m) => m.name === "AaaMember");
     const indexB = result.findIndex((m) => m.name === "BbbMember");
     expect(indexA).toBeLessThan(indexB);
+  });
+});
+
+describe("getCheckinTrend", () => {
+  it("チェックインデータがない場合は空配列を返す", async () => {
+    const member = await createMember({
+      name: "Empty",
+      department: undefined,
+      position: undefined,
+    });
+    if (!member.success) throw new Error("Member creation failed");
+
+    await prisma.meeting.create({
+      data: { memberId: member.data.id, date: new Date("2026-01-01T10:00:00Z") },
+    });
+
+    const result = await getCheckinTrend(member.data.id);
+    expect(result).toHaveLength(0);
+  });
+
+  it("チェックインが記録されたミーティングのみ返す", async () => {
+    const member = await createMember({
+      name: "HasCheckin",
+      department: undefined,
+      position: undefined,
+    });
+    if (!member.success) throw new Error("Member creation failed");
+
+    await prisma.meeting.create({
+      data: { memberId: member.data.id, date: new Date("2026-01-01T10:00:00Z") },
+    });
+    await prisma.meeting.create({
+      data: {
+        memberId: member.data.id,
+        date: new Date("2026-01-15T10:00:00Z"),
+        conditionHealth: 4,
+        conditionMood: 3,
+        conditionWorkload: 2,
+      },
+    });
+
+    const result = await getCheckinTrend(member.data.id);
+    expect(result).toHaveLength(1);
+    expect(result[0].health).toBe(4);
+    expect(result[0].mood).toBe(3);
+    expect(result[0].workload).toBe(2);
+  });
+
+  it("日付昇順で返す", async () => {
+    const member = await createMember({
+      name: "OrderTest",
+      department: undefined,
+      position: undefined,
+    });
+    if (!member.success) throw new Error("Member creation failed");
+
+    await prisma.meeting.create({
+      data: {
+        memberId: member.data.id,
+        date: new Date("2026-02-01T10:00:00Z"),
+        conditionHealth: 3,
+      },
+    });
+    await prisma.meeting.create({
+      data: {
+        memberId: member.data.id,
+        date: new Date("2026-01-01T10:00:00Z"),
+        conditionHealth: 5,
+      },
+    });
+
+    const result = await getCheckinTrend(member.data.id);
+    expect(result).toHaveLength(2);
+    expect(result[0].health).toBe(5);
+    expect(result[1].health).toBe(3);
+  });
+
+  it("limitで取得件数を制限する", async () => {
+    const member = await createMember({
+      name: "LimitTest",
+      department: undefined,
+      position: undefined,
+    });
+    if (!member.success) throw new Error("Member creation failed");
+
+    for (let i = 1; i <= 5; i++) {
+      await prisma.meeting.create({
+        data: {
+          memberId: member.data.id,
+          date: new Date(`2026-01-${String(i).padStart(2, "0")}T10:00:00Z`),
+          conditionMood: i,
+        },
+      });
+    }
+
+    const result = await getCheckinTrend(member.data.id, 3);
+    expect(result).toHaveLength(3);
+  });
+
+  it("一部の指標のみ記録されている場合も返す", async () => {
+    const member = await createMember({
+      name: "PartialCheckin",
+      department: undefined,
+      position: undefined,
+    });
+    if (!member.success) throw new Error("Member creation failed");
+
+    await prisma.meeting.create({
+      data: {
+        memberId: member.data.id,
+        date: new Date("2026-01-10T10:00:00Z"),
+        conditionHealth: 4,
+        conditionMood: null,
+        conditionWorkload: null,
+      },
+    });
+
+    const result = await getCheckinTrend(member.data.id);
+    expect(result).toHaveLength(1);
+    expect(result[0].health).toBe(4);
+    expect(result[0].mood).toBeNull();
+    expect(result[0].workload).toBeNull();
   });
 });

--- a/src/lib/actions/analytics-actions.ts
+++ b/src/lib/actions/analytics-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import type { TopicCategory } from "@/generated/prisma/client";
-import { toMonthKey } from "@/lib/format";
+import { formatDate, toMonthKey } from "@/lib/format";
 import { prisma } from "@/lib/prisma";
 import { calcNextRecommendedDate, isOverdue, isScheduledThisWeek } from "@/lib/schedule";
 import type {
@@ -31,6 +31,36 @@ export type {
   RecommendedMeeting,
   ScheduledMeeting,
 };
+
+export type CheckinTrendEntry = {
+  date: string;
+  health: number | null;
+  mood: number | null;
+  workload: number | null;
+};
+
+export async function getCheckinTrend(memberId: string, limit = 12): Promise<CheckinTrendEntry[]> {
+  const meetings = await prisma.meeting.findMany({
+    where: {
+      memberId,
+      OR: [
+        { conditionHealth: { not: null } },
+        { conditionMood: { not: null } },
+        { conditionWorkload: { not: null } },
+      ],
+    },
+    orderBy: { date: "asc" },
+    take: limit,
+    select: { date: true, conditionHealth: true, conditionMood: true, conditionWorkload: true },
+  });
+
+  return meetings.map((m) => ({
+    date: formatDate(m.date),
+    health: m.conditionHealth,
+    mood: m.conditionMood,
+    workload: m.conditionWorkload,
+  }));
+}
 
 export async function getMemberTopicTrends(memberId: string) {
   const topics = await prisma.topic.findMany({


### PR DESCRIPTION
## 概要

issue #119 の対応。メンバー詳細ページのアナリティクスセクションに、チェックイン状態（健康・気分・業務負荷）の時系列折れ線グラフを追加する。

## 変更内容

### 新規ファイル
- `src/components/analytics/checkin-trend-chart.tsx` — recharts LineChart を使用した 3 指標折れ線グラフコンポーネント
- `src/components/analytics/checkin-trend-section.tsx` — データ取得を行う非同期 Server Component
- `src/components/analytics/__tests__/checkin-trend-chart.test.tsx` — チャートコンポーネントのユニットテスト（4 ケース）

### 変更ファイル
- `src/lib/actions/analytics-actions.ts` — `getCheckinTrend()` Server Action を追加
- `src/lib/actions/__tests__/analytics-actions.test.ts` — `getCheckinTrend` のユニットテストを追加（5 ケース）
- `src/app/members/[id]/page.tsx` — `CheckinTrendSection` を組み込み

## 機能

- **チェックイン状態グラフ**: 健康（赤系）・気分（黄系）・業務負荷（青系）の 3 本の折れ線を同一グラフに表示
- **Y 軸固定**: 1〜5 の 5 段階スコアを固定レンジで表示
- **最小データ件数チェック**: 3 件未満の場合は「グラフを表示するには3回以上のチェックインが必要です」を表示
- **データなし時の非表示**: チェックインが 1 件もない場合はセクション自体を非表示（null を返す）
- **null 安全**: 一部の指標のみ記録されている場合も正しく表示（`connectNulls={false}` でデータ断線表示）

## テスト計画

- [x] `npm test` — 111 ファイル 1125 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー詳細ページでチェックイン状態グラフが表示される
- [ ] チェックインが 3 件未満の場合にメッセージが表示される
- [ ] チェックインが 0 件のメンバーはセクション自体が非表示

Closes #119