### PR TITLE
feat: ダッシュボードに1on1健全性スコアウィジェットを追加する (issue #118)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { BrowserNotification } from "@/components/dashboard/browser-notification";
 import { DashboardSummary } from "@/components/dashboard/dashboard-summary";
 import { FlashToast } from "@/components/dashboard/flash-toast";
+import { HealthScoreWidget } from "@/components/dashboard/health-score-widget";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { RecentActivityFeed } from "@/components/dashboard/recent-activity-feed";
 import { RecommendedMeetingsSection } from "@/components/dashboard/recommended-meetings-section";
@@ -16,6 +17,7 @@ import {
 } from "@/lib/actions/analytics-actions";
 import {
   getDashboardSummary,
+  getHealthScore,
   getRecentActivity,
   getUpcomingActions,
 } from "@/lib/actions/dashboard-actions";
@@ -28,6 +30,7 @@ export default async function DashboardPage() {
   const [
     members,
     summary,
+    healthScore,
     recentActivity,
     upcomingActions,
     recommendedMeetings,
@@ -36,6 +39,7 @@ export default async function DashboardPage() {
   ] = await Promise.all([
     getMembers(),
     getDashboardSummary(),
+    getHealthScore(),
     getRecentActivity(),
     getUpcomingActions(),
     getRecommendedMeetings(),
@@ -56,6 +60,12 @@ export default async function DashboardPage() {
       {!isFirstTime && <BrowserNotification reminders={overdueReminders} />}
 
       {isFirstTime ? <OnboardingCard /> : <DashboardSummary summary={summary} />}
+
+      {!isFirstTime && (
+        <div className="mb-8">
+          <HealthScoreWidget data={healthScore} />
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
         <div className="lg:col-span-2 rounded-xl border bg-card p-5">

--- a/src/components/dashboard/__tests__/health-score-widget.test.tsx
+++ b/src/components/dashboard/__tests__/health-score-widget.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { HealthScoreData } from "@/lib/actions/dashboard-actions";
+
+import { HealthScoreWidget } from "../health-score-widget";
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseData: HealthScoreData = {
+  score: 100,
+  healthyCount: 0,
+  warningCount: 0,
+  dangerCount: 0,
+  memberStatuses: [],
+};
+
+describe("HealthScoreWidget", () => {
+  it("スコアを表示する", () => {
+    const data: HealthScoreData = {
+      ...baseData,
+      score: 75,
+      healthyCount: 3,
+      warningCount: 1,
+      dangerCount: 0,
+    };
+    render(<HealthScoreWidget data={data} />);
+    expect(screen.getByText("75")).toBeDefined();
+  });
+
+  it("メンバーがいない場合でもエラーなく表示される", () => {
+    render(<HealthScoreWidget data={baseData} />);
+    expect(screen.getByText("100")).toBeDefined();
+  });
+
+  it("各カウント（健全・注意・危険）を表示する", () => {
+    const data: HealthScoreData = {
+      ...baseData,
+      score: 50,
+      healthyCount: 2,
+      warningCount: 1,
+      dangerCount: 3,
+      memberStatuses: [],
+    };
+    render(<HealthScoreWidget data={data} />);
+    expect(screen.getByText("2")).toBeDefined(); // healthyCount
+    expect(screen.getByText("3")).toBeDefined(); // dangerCount
+  });
+
+  it("メンバー名が一覧で表示される", () => {
+    const data: HealthScoreData = {
+      ...baseData,
+      score: 50,
+      healthyCount: 1,
+      warningCount: 0,
+      dangerCount: 1,
+      memberStatuses: [
+        { id: "1", name: "田中 一郎", status: "healthy", overdueDays: 0 },
+        { id: "2", name: "佐藤 花子", status: "danger", overdueDays: 10 },
+      ],
+    };
+    render(<HealthScoreWidget data={data} />);
+    expect(screen.getByText("田中 一郎")).toBeDefined();
+    expect(screen.getByText("佐藤 花子")).toBeDefined();
+  });
+
+  it("healthy ステータスのラベルを表示する", () => {
+    const data: HealthScoreData = {
+      ...baseData,
+      score: 100,
+      healthyCount: 1,
+      memberStatuses: [{ id: "1", name: "A", status: "healthy", overdueDays: 0 }],
+    };
+    render(<HealthScoreWidget data={data} />);
+    // CountBadge + MemberRow の両方に「健全」が表示される
+    expect(screen.getAllByText("健全").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("warning ステータスのラベルを表示する", () => {
+    const data: HealthScoreData = {
+      ...baseData,
+      score: 0,
+      warningCount: 1,
+      memberStatuses: [{ id: "1", name: "B", status: "warning", overdueDays: 5 }],
+    };
+    render(<HealthScoreWidget data={data} />);
+    expect(screen.getAllByText("注意").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("danger ステータスのラベルを表示する", () => {
+    const data: HealthScoreData = {
+      ...baseData,
+      score: 0,
+      dangerCount: 1,
+      memberStatuses: [{ id: "1", name: "C", status: "danger", overdueDays: 0 }],
+    };
+    render(<HealthScoreWidget data={data} />);
+    expect(screen.getAllByText("危険").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("スコアが低いとき警告色（赤系）のクラスが適用される", () => {
+    const data: HealthScoreData = { ...baseData, score: 30, dangerCount: 2 };
+    const { container } = render(<HealthScoreWidget data={data} />);
+    // スコア表示要素に danger 系クラスが含まれること
+    const scoreEl = container.querySelector("[data-testid='health-score-value']");
+    expect(scoreEl?.className).toContain("destructive");
+  });
+
+  it("スコアが高いとき成功色（緑系）のクラスが適用される", () => {
+    const data: HealthScoreData = { ...baseData, score: 90, healthyCount: 3 };
+    const { container } = render(<HealthScoreWidget data={data} />);
+    const scoreEl = container.querySelector("[data-testid='health-score-value']");
+    expect(scoreEl?.className).toContain("success");
+  });
+});

--- a/src/components/dashboard/health-score-widget.tsx
+++ b/src/components/dashboard/health-score-widget.tsx
@@ -1,0 +1,167 @@
+import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
+
+import type { HealthScoreData, MemberHealthStatusItem } from "@/lib/actions/dashboard-actions";
+import type { MemberHealthStatus } from "@/lib/schedule";
+
+type Props = {
+  readonly data: HealthScoreData;
+};
+
+type ScoreVariant = "success" | "warning" | "danger";
+
+function getScoreVariant(score: number): ScoreVariant {
+  if (score >= 80) return "success";
+  if (score >= 50) return "warning";
+  return "danger";
+}
+
+function getScoreColorClass(variant: ScoreVariant): string {
+  switch (variant) {
+    case "success":
+      return "text-success";
+    case "warning":
+      return "text-warning";
+    case "danger":
+      return "text-destructive";
+  }
+}
+
+function getScoreBorderClass(variant: ScoreVariant): string {
+  switch (variant) {
+    case "success":
+      return "border-l-success";
+    case "warning":
+      return "border-l-warning";
+    case "danger":
+      return "border-l-destructive";
+  }
+}
+
+type StatusConfig = {
+  label: string;
+  icon: React.ReactNode;
+  badgeClass: string;
+};
+
+function getStatusConfig(status: MemberHealthStatus): StatusConfig {
+  switch (status) {
+    case "healthy":
+      return {
+        label: "健全",
+        icon: <CheckCircle2 className="w-4 h-4 text-success" />,
+        badgeClass: "bg-success/10 text-success border-success/30",
+      };
+    case "warning":
+      return {
+        label: "注意",
+        icon: <AlertTriangle className="w-4 h-4 text-warning" />,
+        badgeClass: "bg-warning/10 text-warning border-warning/30",
+      };
+    case "danger":
+      return {
+        label: "危険",
+        icon: <XCircle className="w-4 h-4 text-destructive" />,
+        badgeClass: "bg-destructive/10 text-destructive border-destructive/30",
+      };
+  }
+}
+
+type MemberRowProps = {
+  readonly member: MemberHealthStatusItem;
+};
+
+function MemberRow({ member }: MemberRowProps) {
+  const config = getStatusConfig(member.status);
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-border/50 last:border-0">
+      <div className="flex items-center gap-2 min-w-0">
+        {config.icon}
+        <span className="text-sm text-foreground truncate">{member.name}</span>
+      </div>
+      <span
+        className={`text-xs font-medium px-2 py-0.5 rounded-full border shrink-0 ${config.badgeClass}`}
+      >
+        {config.label}
+      </span>
+    </div>
+  );
+}
+
+type CountBadgeProps = {
+  readonly count: number;
+  readonly label: string;
+  readonly colorClass: string;
+  readonly bgClass: string;
+};
+
+function CountBadge({ count, label, colorClass, bgClass }: CountBadgeProps) {
+  return (
+    <div className={`flex flex-col items-center px-3 py-2 rounded-lg ${bgClass}`}>
+      <span className={`text-lg font-bold ${colorClass}`}>{count}</span>
+      <span className={`text-xs ${colorClass} opacity-80`}>{label}</span>
+    </div>
+  );
+}
+
+export function HealthScoreWidget({ data }: Props) {
+  const { score, healthyCount, warningCount, dangerCount, memberStatuses } = data;
+  const variant = getScoreVariant(score);
+  const scoreColor = getScoreColorClass(variant);
+  const borderColor = getScoreBorderClass(variant);
+
+  return (
+    <div
+      className={`animate-fade-in-up stagger-1 rounded-xl border border-l-4 ${borderColor} bg-card p-5`}
+    >
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">
+            1on1 健全性スコア
+          </p>
+          <div className="flex items-baseline gap-1">
+            <span
+              data-testid="health-score-value"
+              className={`text-4xl font-bold tracking-tight ${scoreColor}`}
+            >
+              {score}
+            </span>
+            <span className="text-sm font-normal text-muted-foreground">%</span>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <CountBadge
+            count={healthyCount}
+            label="健全"
+            colorClass="text-success"
+            bgClass="bg-success/10"
+          />
+          <CountBadge
+            count={warningCount}
+            label="注意"
+            colorClass="text-warning"
+            bgClass="bg-warning/10"
+          />
+          <CountBadge
+            count={dangerCount}
+            label="危険"
+            colorClass="text-destructive"
+            bgClass="bg-destructive/10"
+          />
+        </div>
+      </div>
+
+      {memberStatuses.length > 0 && (
+        <div className="mt-2 max-h-48 overflow-y-auto">
+          {memberStatuses.map((member) => (
+            <MemberRow key={member.id} member={member} />
+          ))}
+        </div>
+      )}
+
+      {memberStatuses.length === 0 && (
+        <p className="text-sm text-muted-foreground">メンバーが登録されていません</p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/schedule.test.ts
+++ b/src/lib/__tests__/schedule.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   calcNextRecommendedDate,
   formatNextRecommendedDate,
+  getMemberHealthStatus,
   isOverdue,
   isScheduledThisWeek,
 } from "@/lib/schedule";
@@ -95,6 +96,46 @@ describe("isScheduledThisWeek", () => {
   it("次回推奨日が過去（超過）の場合は false を返す", () => {
     const last = new Date("2026-01-01"); // next = 2026-01-15 = 過去
     expect(isScheduledThisWeek(last, 14, now)).toBe(false);
+  });
+});
+
+describe("getMemberHealthStatus", () => {
+  // now = 2026-02-22, intervalDays = 14
+  // next scheduled date = lastMeetingDate + 14 days
+  const now = new Date("2026-02-22");
+
+  it("lastMeetingDate が null の場合は danger を返す（未実施）", () => {
+    expect(getMemberHealthStatus(null, 14, now)).toBe("danger");
+  });
+
+  it("次回推奨日が未来の場合（超過なし）は healthy を返す", () => {
+    const last = new Date("2026-02-15"); // next=2026-03-01, overdue=0日
+    expect(getMemberHealthStatus(last, 14, now)).toBe("healthy");
+  });
+
+  it("超過日数がちょうど3日の場合は healthy を返す", () => {
+    const last = new Date("2026-02-05"); // next=2026-02-19, overdue=3日
+    expect(getMemberHealthStatus(last, 14, now)).toBe("healthy");
+  });
+
+  it("超過日数が4日の場合は warning を返す", () => {
+    const last = new Date("2026-02-04"); // next=2026-02-18, overdue=4日
+    expect(getMemberHealthStatus(last, 14, now)).toBe("warning");
+  });
+
+  it("超過日数がちょうど7日の場合は warning を返す", () => {
+    const last = new Date("2026-02-01"); // next=2026-02-15, overdue=7日
+    expect(getMemberHealthStatus(last, 14, now)).toBe("warning");
+  });
+
+  it("超過日数が8日以上の場合は danger を返す", () => {
+    const last = new Date("2026-01-31"); // next=2026-02-14, overdue=8日
+    expect(getMemberHealthStatus(last, 14, now)).toBe("danger");
+  });
+
+  it("intervalDays=7 で超過なしの場合は healthy を返す", () => {
+    const last = new Date("2026-02-20"); // next=2026-02-27, overdue=0日
+    expect(getMemberHealthStatus(last, 7, now)).toBe("healthy");
   });
 });
 

--- a/src/lib/actions/__tests__/dashboard-actions.test.ts
+++ b/src/lib/actions/__tests__/dashboard-actions.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { prisma } from "@/lib/prisma";
 
 import { updateActionItemStatus } from "../action-item-actions";
-import { getDashboardSummary } from "../dashboard-actions";
+import { getDashboardSummary, getHealthScore } from "../dashboard-actions";
 import { createMeeting } from "../meeting-actions";
 import { createMember } from "../member-actions";
 
@@ -155,5 +155,106 @@ describe("getDashboardSummary", () => {
 
     const summary = await getDashboardSummary();
     expect(summary.overdueActions).toBe(0);
+  });
+});
+
+describe("getHealthScore", () => {
+  it("メンバーが0人の場合はスコア100・各カウント0を返す", async () => {
+    const result = await getHealthScore();
+    expect(result.score).toBe(100);
+    expect(result.healthyCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+    expect(result.dangerCount).toBe(0);
+    expect(result.memberStatuses).toHaveLength(0);
+  });
+
+  it("全メンバーが健全な場合はスコア100を返す", async () => {
+    const r1 = await createMember({ name: "A" });
+    const r2 = await createMember({ name: "B" });
+    if (!r1.success || !r2.success) throw new Error("member creation failed");
+
+    // 両メンバーとも直近でミーティング済み（超過なし）
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 1);
+    await createMeeting({
+      memberId: r1.data.id,
+      date: recentDate.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+    await createMeeting({
+      memberId: r2.data.id,
+      date: recentDate.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    const result = await getHealthScore();
+    expect(result.score).toBe(100);
+    expect(result.healthyCount).toBe(2);
+    expect(result.warningCount).toBe(0);
+    expect(result.dangerCount).toBe(0);
+  });
+
+  it("ミーティング未実施のメンバーは danger になる", async () => {
+    const r1 = await createMember({ name: "NoMeeting" });
+    if (!r1.success) throw new Error("member creation failed");
+    // ミーティングなし
+
+    const result = await getHealthScore();
+    expect(result.dangerCount).toBe(1);
+    expect(result.score).toBe(0);
+    const status = result.memberStatuses.find((s) => s.name === "NoMeeting");
+    expect(status?.status).toBe("danger");
+  });
+
+  it("危険・注意・健全が混在する場合のスコアを計算する", async () => {
+    const r1 = await createMember({ name: "Healthy" });
+    const r2 = await createMember({ name: "Warning" });
+    const r3 = await createMember({ name: "Danger" });
+    if (!r1.success || !r2.success || !r3.success) throw new Error("member creation failed");
+
+    // Healthy: 直近ミーティング（超過なし）
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 1);
+    await createMeeting({
+      memberId: r1.data.id,
+      date: recentDate.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    // Warning: 4〜7日超過 (interval=14, last=18日前 → next=4日前)
+    const warningDate = new Date();
+    warningDate.setDate(warningDate.getDate() - 18);
+    await createMeeting({
+      memberId: r2.data.id,
+      date: warningDate.toISOString(),
+      topics: [],
+      actionItems: [],
+    });
+
+    // Danger: ミーティングなし
+    // r3 has no meeting
+
+    const result = await getHealthScore();
+    expect(result.healthyCount).toBe(1);
+    expect(result.warningCount).toBe(1);
+    expect(result.dangerCount).toBe(1);
+    // スコア = healthy(1) / total(3) * 100 = 33
+    expect(result.score).toBe(33);
+  });
+
+  it("memberStatuses に id・name・status・overdueDays が含まれる", async () => {
+    const r = await createMember({ name: "Test" });
+    if (!r.success) throw new Error("member creation failed");
+
+    const result = await getHealthScore();
+    expect(result.memberStatuses).toHaveLength(1);
+    const s = result.memberStatuses[0];
+    expect(s).toHaveProperty("id");
+    expect(s).toHaveProperty("name", "Test");
+    expect(s).toHaveProperty("status");
+    expect(s).toHaveProperty("overdueDays");
   });
 });

--- a/src/lib/actions/dashboard-actions.ts
+++ b/src/lib/actions/dashboard-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { isOverdue } from "@/lib/schedule";
+import { getMemberHealthStatus, isOverdue, type MemberHealthStatus } from "@/lib/schedule";
 import type {
   ActionActivityItem,
   ActionItemWithMember,
@@ -120,6 +120,69 @@ export async function getRecentActivity(): Promise<ActivityItem[]> {
   });
 
   return merged.slice(0, 8);
+}
+
+export type MemberHealthStatusItem = {
+  id: string;
+  name: string;
+  status: MemberHealthStatus;
+  overdueDays: number;
+};
+
+export type HealthScoreData = {
+  score: number;
+  healthyCount: number;
+  warningCount: number;
+  dangerCount: number;
+  memberStatuses: MemberHealthStatusItem[];
+};
+
+export async function getHealthScore(): Promise<HealthScoreData> {
+  const now = new Date();
+
+  const members = await prisma.member.findMany({
+    select: {
+      id: true,
+      name: true,
+      meetingIntervalDays: true,
+      meetings: {
+        orderBy: { date: "desc" },
+        take: 1,
+        select: { date: true },
+      },
+    },
+    orderBy: { name: "asc" },
+  });
+
+  if (members.length === 0) {
+    return { score: 100, healthyCount: 0, warningCount: 0, dangerCount: 0, memberStatuses: [] };
+  }
+
+  const memberStatuses: MemberHealthStatusItem[] = members.map((m) => {
+    const lastDate = m.meetings[0]?.date ? new Date(m.meetings[0].date) : null;
+    const status = getMemberHealthStatus(lastDate, m.meetingIntervalDays, now);
+    const overdueDays =
+      lastDate !== null
+        ? Math.max(
+            0,
+            Math.floor(
+              (now.getTime() -
+                new Date(
+                  lastDate.getTime() + m.meetingIntervalDays * 24 * 60 * 60 * 1000,
+                ).getTime()) /
+                (1000 * 60 * 60 * 24),
+            ),
+          )
+        : 0;
+    return { id: m.id, name: m.name, status, overdueDays };
+  });
+
+  const healthyCount = memberStatuses.filter((s) => s.status === "healthy").length;
+  const warningCount = memberStatuses.filter((s) => s.status === "warning").length;
+  const dangerCount = memberStatuses.filter((s) => s.status === "danger").length;
+  const score = Math.round((healthyCount / members.length) * 100);
+
+  return { score, healthyCount, warningCount, dangerCount, memberStatuses };
 }
 
 export async function getUpcomingActions(): Promise<UpcomingActionsData> {

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -55,6 +55,37 @@ export function isScheduledThisWeek(
   return next >= now && next < weekEnd;
 }
 
+export type MemberHealthStatus = "healthy" | "warning" | "danger";
+
+/**
+ * メンバーの1on1健全性ステータスを返す
+ * - healthy: 設定周期から3日以内の超過（±3日の許容範囲内）
+ * - warning: 3日超〜7日以内の超過
+ * - danger: 7日超の超過、または1on1未実施
+ * @param lastMeetingDate 最終ミーティング日（null の場合は danger）
+ * @param intervalDays ミーティング間隔（日数）
+ * @param now 現在日時（省略時は new Date()）
+ */
+export function getMemberHealthStatus(
+  lastMeetingDate: Date | null,
+  intervalDays: number,
+  now: Date = new Date(),
+): MemberHealthStatus {
+  if (!lastMeetingDate) return "danger";
+
+  const next = calcNextRecommendedDate(lastMeetingDate, intervalDays);
+  if (!next) return "danger";
+
+  const overdueDays = Math.max(
+    0,
+    Math.floor((now.getTime() - next.getTime()) / (1000 * 60 * 60 * 24)),
+  );
+
+  if (overdueDays <= 3) return "healthy";
+  if (overdueDays <= 7) return "warning";
+  return "danger";
+}
+
 /**
  * 次回推奨日を人間が読みやすい文字列にフォーマットする
  * @param nextDate 次回推奨日（null の場合は「未設定」）


### PR DESCRIPTION
## 概要

issue #118 の対応。ダッシュボードに「1on1健全性スコア」ウィジェットを追加し、チーム全体の1on1実施状況を俯瞰できるようにする。

## 変更内容

### 新規ファイル
- `src/components/dashboard/health-score-widget.tsx` — 1on1健全性スコアウィジェットコンポーネント
- `src/components/dashboard/__tests__/health-score-widget.test.tsx` — コンポーネントテスト（9テスト）

### 変更ファイル
- `src/lib/schedule.ts` — `getMemberHealthStatus()` 関数・`MemberHealthStatus` 型を追加
- `src/lib/actions/dashboard-actions.ts` — `getHealthScore()` Server Action・関連型を追加
- `src/lib/__tests__/schedule.test.ts` — `getMemberHealthStatus()` のユニットテスト（7テスト）を追加
- `src/lib/actions/__tests__/dashboard-actions.test.ts` — `getHealthScore()` のインテグレーションテスト（5テスト）を追加
- `src/app/page.tsx` — HealthScoreWidget を組み込む

## 機能

- **健全性スコア表示**: 「健全メンバー数 / 全メンバー数 × 100 (%）」をスコアとして大きく表示（スコアに応じて緑/黄/赤で色分け）
- **ステータス判定ロジック**:
  - 健全（緑）: 設定周期から3日以内の超過
  - 注意（黄）: 3〜7日超過
  - 危険（赤）: 7日超過または1on1未実施
- **カウントバッジ**: 健全・注意・危険それぞれのメンバー数を表示
- **メンバー別ステータス一覧**: 各メンバーのステータスをアイコン・色付きバッジで一覧表示

## テスト計画

- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] `npm test` — 111ファイル中110通過（1は既存の未解決テスト）
- [ ] ダッシュボードにウィジェットが表示される
- [ ] 健全・注意・危険のメンバーがそれぞれ正しい色で表示される
- [ ] メンバーが0人の場合にエラーなく表示される

Closes #118