### PR TITLE
feat: キーボードショートカット一覧ヘルプパネルを追加する (issue #122)

### DIFF
--- a/src/components/layout/__tests__/keyboard-shortcut-provider.test.tsx
+++ b/src/components/layout/__tests__/keyboard-shortcut-provider.test.tsx
@@ -5,14 +5,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { KeyboardShortcutProvider } from "../keyboard-shortcut-provider";
 
 const mockPush = vi.fn();
+let mockPathname = "/";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname,
 }));
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  mockPathname = "/";
 });
 
 const members = [
@@ -48,6 +51,31 @@ describe("KeyboardShortcutProvider", () => {
       fireEvent.keyDown(document, { key: "?" });
 
       expect(screen.getByText("キーボードショートカット")).toBeDefined();
+    });
+  });
+
+  describe("コンテキスト検出", () => {
+    it("グローバルページでは global context の ShortcutHelpDialog が開く", () => {
+      mockPathname = "/";
+      render(<KeyboardShortcutProvider members={members} />);
+
+      fireEvent.keyDown(document, { key: "?" });
+
+      // グローバルセクションが表示されている
+      expect(screen.getByText("グローバル")).toBeDefined();
+      // global context では記録中セクションは非表示
+      expect(screen.queryByText("記録中")).toBeNull();
+    });
+
+    it("ミーティング詳細ページでは recording context の ShortcutHelpDialog が開く", () => {
+      mockPathname = "/members/m1/meetings/meet1";
+      render(<KeyboardShortcutProvider members={members} />);
+
+      fireEvent.keyDown(document, { key: "?" });
+
+      // recording context では記録中セクションが表示される
+      expect(screen.getByText("記録中")).toBeDefined();
+      expect(screen.getByText("タイマー開始/一時停止")).toBeDefined();
     });
   });
 });

--- a/src/components/layout/__tests__/shortcut-help-dialog.test.tsx
+++ b/src/components/layout/__tests__/shortcut-help-dialog.test.tsx
@@ -11,7 +11,7 @@ afterEach(() => {
 
 describe("ShortcutHelpDialog", () => {
   describe("表示", () => {
-    it("open=true のとき全ショートカットが表示される", () => {
+    it("open=true のときグローバルショートカットが表示される", () => {
       render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
 
       expect(screen.getByText("新規メンバーを追加")).toBeDefined();
@@ -37,6 +37,35 @@ describe("ShortcutHelpDialog", () => {
       render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
 
       expect(screen.getByText("キーボードショートカット")).toBeDefined();
+    });
+
+    it("context 未指定のとき記録中セクションも表示される", () => {
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      expect(screen.getByText("記録中")).toBeDefined();
+      expect(screen.getByText("タイマー開始/一時停止")).toBeDefined();
+      expect(screen.getByText("新しいトピックを追加")).toBeDefined();
+      expect(screen.getByText("アクションアイテムを追加")).toBeDefined();
+    });
+
+    it("context='global' のとき記録中セクションは表示されない", () => {
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} context="global" />);
+
+      expect(screen.queryByText("記録中")).toBeNull();
+      expect(screen.queryByText("タイマー開始/一時停止")).toBeNull();
+    });
+
+    it("context='recording' のとき記録中セクションが表示される", () => {
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} context="recording" />);
+
+      expect(screen.getByText("記録中")).toBeDefined();
+      expect(screen.getByText("タイマー開始/一時停止")).toBeDefined();
+    });
+
+    it("グローバルセクションラベルが表示される", () => {
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      expect(screen.getByText("グローバル")).toBeDefined();
     });
   });
 

--- a/src/components/layout/__tests__/sidebar.test.tsx
+++ b/src/components/layout/__tests__/sidebar.test.tsx
@@ -130,6 +130,14 @@ describe("Sidebar - メンバーリスト", () => {
   });
 });
 
+describe("Sidebar - ショートカットヒント", () => {
+  it("デスクトップサイドバーにショートカットヒントが表示される", () => {
+    render(<Sidebar />);
+    const hints = screen.getAllByText(/ショートカット一覧/);
+    expect(hints.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
 describe("Sidebar - モバイル", () => {
   it("モバイルトップバーに Nudge ロゴを表示する", () => {
     render(<Sidebar />);

--- a/src/components/layout/keyboard-shortcut-provider.tsx
+++ b/src/components/layout/keyboard-shortcut-provider.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 
 import { ShortcutHelpDialog } from "@/components/layout/shortcut-help-dialog";
 import { NewMeetingDialog } from "@/components/meeting/new-meeting-dialog";
-import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { type ShortcutContext, useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 
 type MemberItem = {
   readonly id: string;
@@ -16,8 +16,16 @@ type Props = {
   readonly members: ReadonlyArray<MemberItem>;
 };
 
+// /members/[id]/meetings/[meetingId] パスかつ記録中（startedAt あり）と見なす
+function useShortcutContext(): ShortcutContext {
+  const pathname = usePathname();
+  const isRecordingPage = /^\/members\/[^/]+\/meetings\/[^/]+$/.test(pathname);
+  return isRecordingPage ? "recording" : "global";
+}
+
 export function KeyboardShortcutProvider({ members }: Props) {
   const router = useRouter();
+  const context = useShortcutContext();
   const [isMeetingDialogOpen, setIsMeetingDialogOpen] = useState(false);
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
 
@@ -46,7 +54,11 @@ export function KeyboardShortcutProvider({ members }: Props) {
         onClose={() => setIsMeetingDialogOpen(false)}
         members={members}
       />
-      <ShortcutHelpDialog open={isHelpDialogOpen} onClose={() => setIsHelpDialogOpen(false)} />
+      <ShortcutHelpDialog
+        open={isHelpDialogOpen}
+        onClose={() => setIsHelpDialogOpen(false)}
+        context={context}
+      />
     </>
   );
 }

--- a/src/components/layout/shortcut-help-dialog.tsx
+++ b/src/components/layout/shortcut-help-dialog.tsx
@@ -7,25 +7,34 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-
-type ShortcutEntry = {
-  readonly key: string;
-  readonly description: string;
-};
-
-const SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
-  { key: "n", description: "新規メンバーを追加" },
-  { key: "m", description: "新規ミーティングを作成" },
-  { key: "⌘ K", description: "検索" },
-  { key: "?", description: "ショートカット一覧を表示" },
-];
+import { KEYBOARD_SHORTCUTS, type ShortcutContext } from "@/hooks/use-keyboard-shortcuts";
 
 type Props = {
   readonly open: boolean;
   readonly onClose: () => void;
+  readonly context?: ShortcutContext;
 };
 
-export function ShortcutHelpDialog({ open, onClose }: Props) {
+function ShortcutRow({ keyLabel, description }: { keyLabel: string; description: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <dt>
+        <kbd
+          role="term"
+          className="inline-flex items-center rounded border border-border bg-muted px-2 py-0.5 font-mono text-sm font-medium text-muted-foreground"
+        >
+          {keyLabel}
+        </kbd>
+      </dt>
+      <dd className="text-sm text-foreground">{description}</dd>
+    </div>
+  );
+}
+
+export function ShortcutHelpDialog({ open, onClose, context }: Props) {
+  const globalShortcuts = KEYBOARD_SHORTCUTS.filter((s) => s.context === "global");
+  const recordingShortcuts = KEYBOARD_SHORTCUTS.filter((s) => s.context === "recording");
+
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="sm:max-w-sm">
@@ -35,21 +44,36 @@ export function ShortcutHelpDialog({ open, onClose }: Props) {
           </DialogTitle>
           <DialogDescription>利用可能なキーボードショートカット一覧</DialogDescription>
         </DialogHeader>
-        <dl className="space-y-3">
-          {SHORTCUTS.map(({ key, description }) => (
-            <div key={key} className="flex items-center justify-between">
-              <dt>
-                <kbd
-                  role="term"
-                  className="inline-flex items-center rounded border border-border bg-muted px-2 py-0.5 font-mono text-sm font-medium text-muted-foreground"
-                >
-                  {key}
-                </kbd>
-              </dt>
-              <dd className="text-sm text-foreground">{description}</dd>
-            </div>
-          ))}
-        </dl>
+
+        <div className="space-y-5">
+          <section>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              グローバル
+            </p>
+            <dl className="space-y-3">
+              {globalShortcuts.map(({ key, description }) => (
+                <ShortcutRow key={key} keyLabel={key} description={description} />
+              ))}
+            </dl>
+          </section>
+
+          {(context === "recording" || context === undefined) && (
+            <section>
+              <p
+                className={`mb-2 text-xs font-medium uppercase tracking-wider ${
+                  context === "recording" ? "text-primary" : "text-muted-foreground"
+                }`}
+              >
+                記録中
+              </p>
+              <dl className="space-y-3">
+                {recordingShortcuts.map(({ key, description }) => (
+                  <ShortcutRow key={key} keyLabel={key} description={description} />
+                ))}
+              </dl>
+            </section>
+          )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -205,7 +205,10 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
               onNavigate={() => setIsOpen(false)}
             />
             <MemberQuickList members={members} onNavigate={() => setIsOpen(false)} />
-            <div className="mt-auto pt-4 border-t border-border">
+            <div className="mt-auto pt-4 border-t border-border space-y-2">
+              <p className="px-3 py-1 text-xs text-muted-foreground">
+                <kbd className="font-mono font-medium">?</kbd> ショートカット一覧
+              </p>
               <ThemeToggle />
             </div>
           </aside>
@@ -220,7 +223,10 @@ export function Sidebar({ members = [], actionCount }: SidebarProps) {
         <GlobalSearch />
         <NavLinks pathname={pathname} actionCount={actionCount} />
         <MemberQuickList members={members} />
-        <div className="mt-auto pt-4 border-t border-border">
+        <div className="mt-auto pt-4 border-t border-border space-y-2">
+          <p className="px-3 py-1 text-xs text-muted-foreground">
+            <kbd className="font-mono font-medium">?</kbd> ショートカット一覧
+          </p>
           <ThemeToggle />
         </div>
       </aside>

--- a/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
+++ b/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
@@ -2,7 +2,7 @@ import { fireEvent } from "@testing-library/dom";
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useKeyboardShortcuts } from "../use-keyboard-shortcuts";
+import { KEYBOARD_SHORTCUTS, useKeyboardShortcuts } from "../use-keyboard-shortcuts";
 
 const defaultCallbacks = () => ({
   onNewMember: vi.fn(),
@@ -12,6 +12,38 @@ const defaultCallbacks = () => ({
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe("KEYBOARD_SHORTCUTS 定数", () => {
+  it("global コンテキストのショートカットが含まれる", () => {
+    const globalShortcuts = KEYBOARD_SHORTCUTS.filter((s) => s.context === "global");
+    expect(globalShortcuts.length).toBeGreaterThan(0);
+  });
+
+  it("recording コンテキストのショートカットが含まれる", () => {
+    const recordingShortcuts = KEYBOARD_SHORTCUTS.filter((s) => s.context === "recording");
+    expect(recordingShortcuts.length).toBeGreaterThan(0);
+  });
+
+  it("'?' キーのグローバルショートカットが定義されている", () => {
+    const helpShortcut = KEYBOARD_SHORTCUTS.find((s) => s.key === "?");
+    expect(helpShortcut).toBeDefined();
+    expect(helpShortcut?.context).toBe("global");
+  });
+
+  it("'Space' キーの記録中ショートカットが定義されている", () => {
+    const spaceShortcut = KEYBOARD_SHORTCUTS.find((s) => s.key === "Space");
+    expect(spaceShortcut).toBeDefined();
+    expect(spaceShortcut?.context).toBe("recording");
+  });
+
+  it("各エントリに key, description, context が含まれる", () => {
+    for (const entry of KEYBOARD_SHORTCUTS) {
+      expect(entry.key).toBeTruthy();
+      expect(entry.description).toBeTruthy();
+      expect(["global", "recording"]).toContain(entry.context);
+    }
+  });
 });
 
 describe("useKeyboardShortcuts", () => {

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -2,6 +2,25 @@
 
 import { useEffect, useRef } from "react";
 
+export type ShortcutContext = "global" | "recording";
+
+export type ShortcutEntry = {
+  readonly key: string;
+  readonly description: string;
+  readonly context: ShortcutContext;
+};
+
+export const KEYBOARD_SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
+  { key: "n", description: "新規メンバーを追加", context: "global" },
+  { key: "m", description: "新規ミーティングを作成", context: "global" },
+  { key: "⌘ K", description: "検索", context: "global" },
+  { key: "?", description: "ショートカット一覧を表示", context: "global" },
+  { key: "Space", description: "タイマー開始/一時停止", context: "recording" },
+  { key: "T", description: "新しいトピックを追加", context: "recording" },
+  { key: "A", description: "アクションアイテムを追加", context: "recording" },
+  { key: "Esc", description: "ダイアログを閉じる", context: "global" },
+];
+
 type ShortcutCallbacks = {
   readonly onNewMember: () => void;
   readonly onNewMeeting: () => void;


### PR DESCRIPTION
## 概要

issue #122 の対応。`?` キーで開くキーボードショートカット一覧モーダルをコンテキスト対応・動的生成に改善し、サイドバーにヒントを追加する。

## 変更内容

### 変更ファイル
- `src/hooks/use-keyboard-shortcuts.ts` — `KEYBOARD_SHORTCUTS` 定数・`ShortcutContext` 型・`ShortcutEntry` 型をエクスポート追加
- `src/components/layout/shortcut-help-dialog.tsx` — ハードコードから `KEYBOARD_SHORTCUTS` 定数を参照した動的生成に刷新。`context` prop でグローバル/記録中セクションを制御
- `src/components/layout/keyboard-shortcut-provider.tsx` — `usePathname()` でミーティング記録ページを検出し、`context` を `ShortcutHelpDialog` に渡す
- `src/components/layout/sidebar.tsx` — デスクトップ・モバイル両サイドバーフッターに「? ショートカット一覧」ヒントを追加
- `src/hooks/__tests__/use-keyboard-shortcuts.test.ts` — `KEYBOARD_SHORTCUTS` 定数の構造テストを追加
- `src/components/layout/__tests__/shortcut-help-dialog.test.tsx` — context prop によるセクション制御テストを追加
- `src/components/layout/__tests__/keyboard-shortcut-provider.test.tsx` — usePathname を用いたコンテキスト検出テストを追加
- `src/components/layout/__tests__/sidebar.test.tsx` — ショートカットヒント表示テストを追加

## 機能

- **ショートカット定義の一元管理**: `KEYBOARD_SHORTCUTS` 定数でキー・説明・コンテキストを管理
- **コンテキスト対応表示**: グローバルページでは「グローバル」セクションのみ、ミーティング記録ページでは「記録中」セクション（Space/T/A）も表示
- **サイドバーヒント**: デスクトップ・モバイル両サイドバーのフッターに `?` キーのショートカットヒントを表示

## テスト計画

- [x] `npm test` — 113ファイル 1180テスト全パス（既存バグ1件を除く）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] `?` キーでモーダルが開閉できることをブラウザで確認
- [ ] グローバルページでは「グローバル」セクションのみ表示されること
- [ ] ミーティング詳細ページでは「記録中」セクションも表示されること
- [ ] サイドバーフッターの「? ショートカット一覧」ヒントが表示されること

Closes #122