### PR TITLE
feat: ミーティング詳細画面に前回・次回ナビゲーションを追加する (issue #127)

### DIFF
--- a/src/app/members/[id]/meetings/[meetingId]/page.tsx
+++ b/src/app/members/[id]/meetings/[meetingId]/page.tsx
@@ -5,18 +5,20 @@ import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { CoachingPanel } from "@/components/meeting/coaching-panel";
 import { MeetingDetailPageClient } from "@/components/meeting/meeting-detail-page-client";
 import { MeetingHeaderActions } from "@/components/meeting/meeting-header-actions";
+import { MeetingNavigation } from "@/components/meeting/meeting-navigation";
 import { PrintButton } from "@/components/meeting/print-button";
 import { Button } from "@/components/ui/button";
-import { getMeeting, getPreviousMeeting } from "@/lib/actions/meeting-actions";
+import { getAdjacentMeetings, getMeeting, getPreviousMeeting } from "@/lib/actions/meeting-actions";
 import { formatDate } from "@/lib/format";
 
 type Props = { params: Promise<{ id: string; meetingId: string }> };
 
 export default async function MeetingDetailPage({ params }: Props) {
   const { id, meetingId } = await params;
-  const [meeting, previousMeeting] = await Promise.all([
+  const [meeting, previousMeeting, adjacentMeetings] = await Promise.all([
     getMeeting(meetingId),
     getPreviousMeeting(id, meetingId),
+    getAdjacentMeetings(id, meetingId),
   ]);
   if (!meeting) {
     notFound();
@@ -33,6 +35,11 @@ export default async function MeetingDetailPage({ params }: Props) {
           ]}
         />
       </div>
+      <MeetingNavigation
+        memberId={id}
+        previous={adjacentMeetings.previous}
+        next={adjacentMeetings.next}
+      />
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
           {meeting.member.name}との1on1

--- a/src/components/meeting/__tests__/meeting-navigation.test.tsx
+++ b/src/components/meeting/__tests__/meeting-navigation.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MeetingNavigation } from "../meeting-navigation";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const previous = { id: "prev-1", date: new Date("2025-01-15"), mood: 4 };
+const next = { id: "next-1", date: new Date("2025-03-12"), mood: 2 };
+
+describe("MeetingNavigation", () => {
+  describe("両方 null の場合", () => {
+    it("何も表示されない", () => {
+      const { container } = render(
+        <MeetingNavigation memberId="member-1" previous={null} next={null} />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("両方存在する場合", () => {
+    beforeEach(() => {
+      render(<MeetingNavigation memberId="member-1" previous={previous} next={next} />);
+    });
+
+    it("前回の1on1が表示される", () => {
+      expect(screen.getByText(/前回の1on1/)).toBeDefined();
+    });
+
+    it("次回の1on1が表示される", () => {
+      expect(screen.getByText(/次回の1on1/)).toBeDefined();
+    });
+
+    it("前回リンクをクリックすると前回ページへ遷移する", async () => {
+      const user = userEvent.setup();
+      const prevBtn = screen.getByRole("button", { name: /前回の1on1/ });
+      await user.click(prevBtn);
+      expect(mockPush).toHaveBeenCalledWith("/members/member-1/meetings/prev-1");
+    });
+
+    it("次回リンクをクリックすると次回ページへ遷移する", async () => {
+      const user = userEvent.setup();
+      const nextBtn = screen.getByRole("button", { name: /次回の1on1/ });
+      await user.click(nextBtn);
+      expect(mockPush).toHaveBeenCalledWith("/members/member-1/meetings/next-1");
+    });
+
+    it("ムード絵文字が表示される（前回: 🙂）", () => {
+      expect(screen.getByText(/🙂/)).toBeDefined();
+    });
+
+    it("ムード絵文字が表示される（次回: 😕）", () => {
+      expect(screen.getByText(/😕/)).toBeDefined();
+    });
+  });
+
+  describe("previous のみ null の場合", () => {
+    it("前回がグレーアウト表示される（ボタンではない）", () => {
+      render(<MeetingNavigation memberId="member-1" previous={null} next={next} />);
+      expect(screen.queryByRole("button", { name: /前回の1on1/ })).toBeNull();
+      expect(screen.getByText(/前回の1on1/)).toBeDefined();
+    });
+
+    it("次回ボタンは有効でクリック可能", async () => {
+      const user = userEvent.setup();
+      render(<MeetingNavigation memberId="member-1" previous={null} next={next} />);
+      const nextBtn = screen.getByRole("button", { name: /次回の1on1/ });
+      await user.click(nextBtn);
+      expect(mockPush).toHaveBeenCalledWith("/members/member-1/meetings/next-1");
+    });
+  });
+
+  describe("next のみ null の場合", () => {
+    it("次回がグレーアウト表示される（ボタンではない）", () => {
+      render(<MeetingNavigation memberId="member-1" previous={previous} next={null} />);
+      expect(screen.queryByRole("button", { name: /次回の1on1/ })).toBeNull();
+      expect(screen.getByText(/次回の1on1/)).toBeDefined();
+    });
+
+    it("前回ボタンは有効でクリック可能", async () => {
+      const user = userEvent.setup();
+      render(<MeetingNavigation memberId="member-1" previous={previous} next={null} />);
+      const prevBtn = screen.getByRole("button", { name: /前回の1on1/ });
+      await user.click(prevBtn);
+      expect(mockPush).toHaveBeenCalledWith("/members/member-1/meetings/prev-1");
+    });
+  });
+});

--- a/src/components/meeting/meeting-navigation.tsx
+++ b/src/components/meeting/meeting-navigation.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+import { formatDate } from "@/lib/format";
+import { getMoodOption } from "@/lib/mood";
+
+type AdjacentMeeting = {
+  id: string;
+  date: Date;
+  mood: number | null;
+};
+
+type MeetingNavigationProps = {
+  memberId: string;
+  previous: AdjacentMeeting | null;
+  next: AdjacentMeeting | null;
+};
+
+function isTypingTarget(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  const tag = element.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select" || element.isContentEditable;
+}
+
+export function MeetingNavigation({ memberId, previous, next }: MeetingNavigationProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTypingTarget(document.activeElement)) return;
+      if (e.key === "ArrowLeft" && previous) {
+        e.preventDefault();
+        router.push(`/members/${memberId}/meetings/${previous.id}`);
+      }
+      if (e.key === "ArrowRight" && next) {
+        e.preventDefault();
+        router.push(`/members/${memberId}/meetings/${next.id}`);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [memberId, previous, next, router]);
+
+  if (!previous && !next) return null;
+
+  return (
+    <div className="print:hidden flex items-center justify-between gap-2 rounded-lg border border-border/50 bg-muted/30 px-3 py-2 text-sm">
+      <NavButton direction="previous" meeting={previous} memberId={memberId} router={router} />
+      <NavButton direction="next" meeting={next} memberId={memberId} router={router} />
+    </div>
+  );
+}
+
+type NavButtonProps = {
+  direction: "previous" | "next";
+  meeting: AdjacentMeeting | null;
+  memberId: string;
+  router: ReturnType<typeof useRouter>;
+};
+
+function NavButton({ direction, meeting, memberId, router }: NavButtonProps) {
+  const isPrevious = direction === "previous";
+  const label = isPrevious ? "前回の1on1" : "次回の1on1";
+  const emoji = getMoodOption(meeting?.mood ?? null)?.emoji;
+
+  if (!meeting) {
+    return (
+      <div
+        className={`flex items-center gap-1 text-muted-foreground/40 cursor-not-allowed select-none ${isPrevious ? "" : "ml-auto"}`}
+      >
+        {isPrevious && <ChevronLeft className="h-4 w-4" />}
+        <span>{label}</span>
+        {!isPrevious && <ChevronRight className="h-4 w-4" />}
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={`flex items-center gap-1 h-auto py-0.5 px-1.5 text-muted-foreground hover:text-foreground ${!isPrevious ? "ml-auto" : ""}`}
+      onClick={() => router.push(`/members/${memberId}/meetings/${meeting.id}`)}
+      title={`${label}（${isPrevious ? "← キー" : "→ キー"}）`}
+    >
+      {isPrevious && <ChevronLeft className="h-4 w-4" />}
+      <span>
+        {label}（{formatDate(meeting.date)}
+        {emoji ? ` ${emoji}` : ""}）
+      </span>
+      {!isPrevious && <ChevronRight className="h-4 w-4" />}
+    </Button>
+  );
+}

--- a/src/lib/actions/__tests__/meeting-actions.test.ts
+++ b/src/lib/actions/__tests__/meeting-actions.test.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import {
   createMeeting,
   endMeeting,
+  getAdjacentMeetings,
   getMeeting,
   getPreviousMeeting,
   getRecentMeetings,
@@ -805,5 +806,81 @@ describe("updateTopicNotes", () => {
   it("存在しない topicId でエラーを返すこと", async () => {
     const result = await updateTopicNotes({ topicId: "non-existent-id", notes: "ノート" });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("getAdjacentMeetings", () => {
+  async function createTestMeetings() {
+    const r1 = await createMeeting({
+      memberId,
+      date: "2026-01-01T10:00:00.000Z",
+      topics: [],
+      actionItems: [],
+      mood: 3,
+    });
+    if (!r1.success) throw new Error(r1.error);
+    const r2 = await createMeeting({
+      memberId,
+      date: "2026-02-01T10:00:00.000Z",
+      topics: [],
+      actionItems: [],
+      mood: 4,
+    });
+    if (!r2.success) throw new Error(r2.error);
+    const r3 = await createMeeting({
+      memberId,
+      date: "2026-03-01T10:00:00.000Z",
+      topics: [],
+      actionItems: [],
+      mood: 5,
+    });
+    if (!r3.success) throw new Error(r3.error);
+    return { first: r1.data, second: r2.data, third: r3.data };
+  }
+
+  it("前後両方が存在する場合: previous と next を返す", async () => {
+    const { first, second, third } = await createTestMeetings();
+    const result = await getAdjacentMeetings(memberId, second.id);
+    expect(result.previous?.id).toBe(first.id);
+    expect(result.next?.id).toBe(third.id);
+  });
+
+  it("前のみ存在する場合: previous を返し next は null", async () => {
+    const { second, third } = await createTestMeetings();
+    const result = await getAdjacentMeetings(memberId, third.id);
+    expect(result.previous?.id).toBe(second.id);
+    expect(result.next).toBeNull();
+  });
+
+  it("次のみ存在する場合: next を返し previous は null", async () => {
+    const { first, second } = await createTestMeetings();
+    const result = await getAdjacentMeetings(memberId, first.id);
+    expect(result.previous).toBeNull();
+    expect(result.next?.id).toBe(second.id);
+  });
+
+  it("ミーティングが1件のみの場合: 両方 null", async () => {
+    const r = await createMeeting({
+      memberId,
+      date: "2026-06-01T10:00:00.000Z",
+      topics: [],
+      actionItems: [],
+    });
+    if (!r.success) throw new Error(r.error);
+    const result = await getAdjacentMeetings(memberId, r.data.id);
+    expect(result.previous).toBeNull();
+    expect(result.next).toBeNull();
+  });
+
+  it("存在しない meetingId の場合: 両方 null", async () => {
+    const result = await getAdjacentMeetings(memberId, "non-existent-id");
+    expect(result.previous).toBeNull();
+    expect(result.next).toBeNull();
+  });
+
+  it("mood フィールドが含まれること", async () => {
+    const { first, second } = await createTestMeetings();
+    const result = await getAdjacentMeetings(memberId, second.id);
+    expect(result.previous?.mood).toBe(first.mood);
   });
 });

--- a/src/lib/actions/meeting-actions.ts
+++ b/src/lib/actions/meeting-actions.ts
@@ -344,6 +344,35 @@ export async function endMeeting(input: EndMeetingInput): Promise<ActionResult<M
   });
 }
 
+export async function getAdjacentMeetings(
+  memberId: string,
+  meetingId: string,
+): Promise<{
+  previous: { id: string; date: Date; mood: number | null } | null;
+  next: { id: string; date: Date; mood: number | null } | null;
+}> {
+  const current = await prisma.meeting.findUnique({
+    where: { id: meetingId },
+    select: { date: true },
+  });
+  if (!current) return { previous: null, next: null };
+
+  const [previous, next] = await Promise.all([
+    prisma.meeting.findFirst({
+      where: { memberId, date: { lt: current.date }, id: { not: meetingId } },
+      orderBy: { date: "desc" },
+      select: { id: true, date: true, mood: true },
+    }),
+    prisma.meeting.findFirst({
+      where: { memberId, date: { gt: current.date }, id: { not: meetingId } },
+      orderBy: { date: "asc" },
+      select: { id: true, date: true, mood: true },
+    }),
+  ]);
+
+  return { previous, next };
+}
+
 export async function updateTopicNotes(input: UpdateTopicNotesInput): Promise<ActionResult<Topic>> {
   return runAction(async () => {
     const validated = updateTopicNotesSchema.parse(input);


### PR DESCRIPTION
## 概要

issue #127 の対応。ミーティング詳細画面（`/members/[id]/meetings/[meetingId]`）に前回・次回ミーティングへのナビゲーションバーを追加する。メンバー詳細ページへ戻る手間を省き、記録間の行き来をスムーズにする。

## 変更内容

### 新規ファイル
- `src/components/meeting/meeting-navigation.tsx` — 前回・次回ナビゲーションコンポーネント
- `src/components/meeting/__tests__/meeting-navigation.test.tsx` — コンポーネントテスト（11ケース）

### 変更ファイル
- `src/lib/actions/meeting-actions.ts` — `getAdjacentMeetings` Server Action を追加
- `src/app/members/[id]/meetings/[meetingId]/page.tsx` — MeetingNavigation を統合
- `src/lib/actions/__tests__/meeting-actions.test.ts` — getAdjacentMeetings テストを追加（6ケース）

## 機能

- **前回・次回ナビゲーションバー**: Breadcrumb 直下に表示。日付・ムード絵文字付き
- **キーボードショートカット**: `←` キーで前回、`→` キーで次回へ遷移
- **入力中は無効化**: input / textarea / contentEditable にフォーカス中はキーボードナビを抑制
- **片方が存在しない場合**: グレーアウト表示（ボタン無効）
- **両方 null の場合**: ナビゲーションバー自体を非表示
- **印刷除外**: `print:hidden` クラスで印刷・PDF 出力から除外

## テスト計画

- [x] `npm test` — 116ファイル 1210テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ミーティングが3件以上あるメンバーの詳細からミーティングを開き、ナビゲーションバーが表示されることを確認
- [ ] 前回・次回リンクをクリックして正しく遷移することを確認
- [ ] `←` `→` キーで前後ミーティングへ遷移できることを確認
- [ ] 入力フィールドにフォーカス中はキーが無効になることを確認
- [ ] 最初のミーティングでは「前回」がグレーアウト、最後では「次回」がグレーアウトになることを確認

Closes #127