### PR TITLE
feat: アクションアイテムの複数選択・一括ステータス変更機能を追加する (issue #123)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -1,9 +1,8 @@
 import { Suspense } from "react";
 
 import { ActionFilters } from "@/components/action/action-filters";
-import { ActionListFull } from "@/components/action/action-list-full";
-import { ActionListGrouped } from "@/components/action/action-list-grouped";
-import { ActionPagination } from "@/components/action/action-pagination";
+import { ActionListSkeleton } from "@/components/action/action-list-skeleton";
+import { ActionsBulkContainer } from "@/components/action/actions-bulk-container";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { Badge } from "@/components/ui/badge";
 import { getActionItems } from "@/lib/actions/action-item-actions";
@@ -115,22 +114,17 @@ export default async function ActionsPage({ searchParams }: Props) {
       <Suspense>
         <ActionFilters members={memberList} tags={tagList} />
       </Suspense>
-      {isGrouped ? (
-        <ActionListGrouped
+      <Suspense fallback={<ActionListSkeleton />}>
+        <ActionsBulkContainer
           actionItems={actionItemsWithTags}
           groupBy={groupBy}
+          isGrouped={isGrouped}
           statusFilter={filters.status}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          searchParams={params}
         />
-      ) : (
-        <>
-          <ActionListFull actionItems={actionItemsWithTags} statusFilter={filters.status} />
-          <ActionPagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            searchParams={params}
-          />
-        </>
-      )}
+      </Suspense>
     </div>
   );
 }

--- a/src/components/action/__tests__/bulk-action-bar.test.tsx
+++ b/src/components/action/__tests__/bulk-action-bar.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TOAST_MESSAGES } from "@/lib/toast-messages";
+
+import { BulkActionBar } from "../bulk-action-bar";
+
+const mockRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockBulkUpdateStatus = vi.fn();
+const mockBulkDelete = vi.fn();
+
+vi.mock("@/lib/actions/action-item-actions", () => ({
+  bulkUpdateActionItemStatus: (...args: unknown[]) => mockBulkUpdateStatus(...args),
+  bulkDeleteActionItems: (...args: unknown[]) => mockBulkDelete(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("BulkActionBar", () => {
+  it("selectedIds が空の場合は何も表示しない", () => {
+    const { container } = render(<BulkActionBar selectedIds={new Set()} onClearAll={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("選択件数を表示する", () => {
+    render(<BulkActionBar selectedIds={new Set(["id-1", "id-2"])} onClearAll={vi.fn()} />);
+    expect(screen.getByText("2件選択中")).toBeDefined();
+  });
+
+  it("ステータス変更ボタンが表示される", () => {
+    render(<BulkActionBar selectedIds={new Set(["id-1"])} onClearAll={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /未着手/ })).toBeDefined();
+    expect(screen.getByRole("button", { name: /進行中/ })).toBeDefined();
+    expect(screen.getByRole("button", { name: /完了/ })).toBeDefined();
+  });
+
+  it("削除ボタンが表示される", () => {
+    render(<BulkActionBar selectedIds={new Set(["id-1"])} onClearAll={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /削除/ })).toBeDefined();
+  });
+
+  it("選択解除ボタンが表示される", () => {
+    render(<BulkActionBar selectedIds={new Set(["id-1"])} onClearAll={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /選択を解除/ })).toBeDefined();
+  });
+
+  it("選択解除ボタンクリックで onClearAll が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onClearAll = vi.fn();
+    render(<BulkActionBar selectedIds={new Set(["id-1"])} onClearAll={onClearAll} />);
+    await user.click(screen.getByRole("button", { name: /選択を解除/ }));
+    expect(onClearAll).toHaveBeenCalledOnce();
+  });
+
+  it("完了ボタンクリックで bulkUpdateActionItemStatus が DONE で呼ばれる", async () => {
+    const user = userEvent.setup();
+    mockBulkUpdateStatus.mockResolvedValue({ success: true, data: { count: 2 } });
+    const onClearAll = vi.fn();
+    render(<BulkActionBar selectedIds={new Set(["id-1", "id-2"])} onClearAll={onClearAll} />);
+    await user.click(screen.getByRole("button", { name: /完了/ }));
+    expect(mockBulkUpdateStatus).toHaveBeenCalledWith(
+      expect.arrayContaining(["id-1", "id-2"]),
+      "DONE",
+    );
+  });
+
+  it("ステータス変更成功時にトーストと clearAll が呼ばれる", async () => {
+    const user = userEvent.setup();
+    mockBulkUpdateStatus.mockResolvedValue({ success: true, data: { count: 1 } });
+    const onClearAll = vi.fn();
+    render(<BulkActionBar selectedIds={new Set(["id-1"])} onClearAll={onClearAll} />);
+    await user.click(screen.getByRole("button", { name: /完了/ }));
+    expect(toast.success).toHaveBeenCalledWith(
+      TOAST_MESSAGES.actionItem.bulkStatusChangeSuccess(1),
+    );
+    expect(onClearAll).toHaveBeenCalledOnce();
+  });
+
+  it("ステータス変更失敗時にエラートーストが表示される", async () => {
+    const user = userEvent.setup();
+    mockBulkUpdateStatus.mockResolvedValue({ success: false, error: "Error" });
+    render(<BulkActionBar selectedIds={new Set(["id-1"])} onClearAll={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /未着手/ }));
+    expect(toast.error).toHaveBeenCalledWith(TOAST_MESSAGES.actionItem.bulkStatusChangeError);
+  });
+
+  it("削除ボタンクリックで確認ダイアログが開く", async () => {
+    const user = userEvent.setup();
+    render(<BulkActionBar selectedIds={new Set(["id-1"])} onClearAll={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    expect(screen.getByText(/この操作は取り消せません/)).toBeDefined();
+  });
+});

--- a/src/components/action/action-list-compact.tsx
+++ b/src/components/action/action-list-compact.tsx
@@ -5,12 +5,15 @@ import { useRouter } from "next/navigation";
 import { useOptimistic, useState, useTransition } from "react";
 import { toast } from "sonner";
 
+import { BulkActionBar } from "@/components/action/bulk-action-bar";
 import { DueDateBadge } from "@/components/action/due-date-badge";
 import { TagBadge } from "@/components/tag/tag-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
+import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import {
   createActionItemForMeeting,
   updateActionItem,
@@ -49,6 +52,7 @@ type Props = {
   actionItems: ActionItemRow[];
   meetingId?: string;
   memberId?: string;
+  enableBulkSelect?: boolean;
 };
 
 const statusLabels: Record<string, string> = {
@@ -66,7 +70,7 @@ function nextStatus(current: string): string {
   return current === "TODO" ? "IN_PROGRESS" : current === "IN_PROGRESS" ? "DONE" : "TODO";
 }
 
-export function ActionListCompact({ actionItems, meetingId, memberId }: Props) {
+export function ActionListCompact({ actionItems, meetingId, memberId, enableBulkSelect }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -82,6 +86,7 @@ export function ActionListCompact({ actionItems, meetingId, memberId }: Props) {
     (currentItems, { id, status }: { id: string; status: string }) =>
       currentItems.map((item) => (item.id === id ? { ...item, status } : item)),
   );
+  const { selectedIds, toggleItem, clearAll } = useBulkSelection();
 
   const canAdd = Boolean(meetingId && memberId);
 
@@ -191,8 +196,20 @@ export function ActionListCompact({ actionItems, meetingId, memberId }: Props) {
             </div>
           </div>
         ) : (
-          <div key={item.id} className="flex items-center justify-between p-2 border rounded">
+          <div
+            key={item.id}
+            className={`flex items-center justify-between p-2 border rounded transition-colors ${
+              enableBulkSelect && selectedIds.has(item.id) ? "bg-primary/5 border-primary/30" : ""
+            }`}
+          >
             <div className="flex items-center gap-2 flex-1 min-w-0">
+              {enableBulkSelect && (
+                <Checkbox
+                  checked={selectedIds.has(item.id)}
+                  onCheckedChange={() => toggleItem(item.id)}
+                  aria-label={`${item.title}を選択`}
+                />
+              )}
               <button
                 onClick={() => cycleStatus(item.id, item.status)}
                 aria-label={`${item.title}のステータスを${statusLabels[nextStatus(item.status)]}に変更`}
@@ -265,6 +282,7 @@ export function ActionListCompact({ actionItems, meetingId, memberId }: Props) {
           </Button>
         </div>
       )}
+      {enableBulkSelect && <BulkActionBar selectedIds={selectedIds} onClearAll={clearAll} />}
     </div>
   );
 }

--- a/src/components/action/action-list-full.tsx
+++ b/src/components/action/action-list-full.tsx
@@ -10,6 +10,7 @@ import { DueDateBadge } from "@/components/action/due-date-badge";
 import { TagBadge } from "@/components/tag/tag-badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { DatePicker } from "@/components/ui/date-picker";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
@@ -47,9 +48,14 @@ type EditFormState = {
   dueDate: string;
 };
 
-type Props = { actionItems: ActionItemRow[]; statusFilter?: string };
+type Props = {
+  actionItems: ActionItemRow[];
+  statusFilter?: string;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
+};
 
-export function ActionListFull({ actionItems, statusFilter }: Props) {
+export function ActionListFull({ actionItems, statusFilter, selectedIds, onToggleSelect }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -69,6 +75,8 @@ export function ActionListFull({ actionItems, statusFilter }: Props) {
       return updated;
     },
   );
+
+  const isBulkMode = selectedIds !== undefined && onToggleSelect !== undefined;
 
   if (actionItems.length === 0) {
     return (
@@ -124,84 +132,97 @@ export function ActionListFull({ actionItems, statusFilter }: Props) {
 
   return (
     <div className={`flex flex-col gap-3 ${isPending ? "opacity-80" : ""}`}>
-      {optimisticItems.map((item) => (
-        <Card key={item.id} className="hover:shadow-sm hover:border-[oklch(0.88_0.008_260)]">
-          {editingId === item.id ? (
-            <CardContent className="p-4 flex flex-col gap-3">
-              <div className="flex flex-col gap-2">
-                <Input
-                  value={editForm.title}
-                  onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
-                  placeholder="タイトル"
-                />
-                <Input
-                  value={editForm.description}
-                  onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
-                  placeholder="説明"
-                />
-                <DatePicker
-                  value={editForm.dueDate}
-                  onChange={(value) => setEditForm({ ...editForm, dueDate: value })}
-                />
-              </div>
-              <div className="flex gap-2 justify-end">
-                <Button variant="outline" size="sm" onClick={handleCancel}>
-                  キャンセル
-                </Button>
-                <Button size="sm" onClick={handleSave} disabled={!editForm.title.trim()}>
-                  保存
-                </Button>
-              </div>
-            </CardContent>
-          ) : (
-            <CardContent className="p-4 flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <Select
-                  value={item.status}
-                  onValueChange={(val) => handleStatusChange(item.id, val)}
-                >
-                  <SelectTrigger className="w-28">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="TODO">未着手</SelectItem>
-                    <SelectItem value="IN_PROGRESS">進行中</SelectItem>
-                    <SelectItem value="DONE">完了</SelectItem>
-                  </SelectContent>
-                </Select>
-                <div>
-                  <p className="font-medium">{item.title}</p>
-                  <p className="text-sm text-muted-foreground">
-                    <Link href={`/members/${item.member.id}`} className="hover:underline">
-                      {item.member.name}
-                    </Link>
-                    {" ・ "}
-                    {formatDate(item.meeting.date)}
-                  </p>
-                  {item.tags && item.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {item.tags.map((tag) => (
-                        <TagBadge key={tag.id} name={tag.name} color={tag.color} size="sm" />
-                      ))}
-                    </div>
-                  )}
+      {optimisticItems.map((item) => {
+        const isSelected = isBulkMode && selectedIds.has(item.id);
+        return (
+          <Card
+            key={item.id}
+            className={`hover:shadow-sm hover:border-[oklch(0.88_0.008_260)] transition-colors ${isSelected ? "bg-primary/5 border-primary/30" : ""}`}
+          >
+            {editingId === item.id ? (
+              <CardContent className="p-4 flex flex-col gap-3">
+                <div className="flex flex-col gap-2">
+                  <Input
+                    value={editForm.title}
+                    onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
+                    placeholder="タイトル"
+                  />
+                  <Input
+                    value={editForm.description}
+                    onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
+                    placeholder="説明"
+                  />
+                  <DatePicker
+                    value={editForm.dueDate}
+                    onChange={(value) => setEditForm({ ...editForm, dueDate: value })}
+                  />
                 </div>
-              </div>
-              <div className="flex items-center gap-3">
-                {item.dueDate && <DueDateBadge dueDate={item.dueDate} status={item.status} />}
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="編集"
-                  onClick={() => handleEdit(item)}
-                >
-                  <Pencil />
-                </Button>
-              </div>
-            </CardContent>
-          )}
-        </Card>
-      ))}
+                <div className="flex gap-2 justify-end">
+                  <Button variant="outline" size="sm" onClick={handleCancel}>
+                    キャンセル
+                  </Button>
+                  <Button size="sm" onClick={handleSave} disabled={!editForm.title.trim()}>
+                    保存
+                  </Button>
+                </div>
+              </CardContent>
+            ) : (
+              <CardContent className="p-4 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  {isBulkMode && (
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => onToggleSelect(item.id)}
+                      aria-label={`${item.title}を選択`}
+                    />
+                  )}
+                  <Select
+                    value={item.status}
+                    onValueChange={(val) => handleStatusChange(item.id, val)}
+                  >
+                    <SelectTrigger className="w-28">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="TODO">未着手</SelectItem>
+                      <SelectItem value="IN_PROGRESS">進行中</SelectItem>
+                      <SelectItem value="DONE">完了</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <div>
+                    <p className="font-medium">{item.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      <Link href={`/members/${item.member.id}`} className="hover:underline">
+                        {item.member.name}
+                      </Link>
+                      {" ・ "}
+                      {formatDate(item.meeting.date)}
+                    </p>
+                    {item.tags && item.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {item.tags.map((tag) => (
+                          <TagBadge key={tag.id} name={tag.name} color={tag.color} size="sm" />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  {item.dueDate && <DueDateBadge dueDate={item.dueDate} status={item.status} />}
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="編集"
+                    onClick={() => handleEdit(item)}
+                  >
+                    <Pencil />
+                  </Button>
+                </div>
+              </CardContent>
+            )}
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/action/action-list-grouped.tsx
+++ b/src/components/action/action-list-grouped.tsx
@@ -30,9 +30,17 @@ type Props = {
   actionItems: ActionItemRow[];
   groupBy: GroupByType;
   statusFilter?: string;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
 };
 
-export function ActionListGrouped({ actionItems, groupBy, statusFilter }: Props) {
+export function ActionListGrouped({
+  actionItems,
+  groupBy,
+  statusFilter,
+  selectedIds,
+  onToggleSelect,
+}: Props) {
   const groups = groupActionItems(actionItems, groupBy);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
@@ -83,7 +91,12 @@ export function ActionListGrouped({ actionItems, groupBy, statusFilter }: Props)
             </button>
             {!isCollapsed && (
               <div className="ml-6">
-                <ActionListFull actionItems={group.items} statusFilter={statusFilter} />
+                <ActionListFull
+                  actionItems={group.items}
+                  statusFilter={statusFilter}
+                  selectedIds={selectedIds}
+                  onToggleSelect={onToggleSelect}
+                />
               </div>
             )}
           </div>

--- a/src/components/action/actions-bulk-container.tsx
+++ b/src/components/action/actions-bulk-container.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { ActionListFull } from "@/components/action/action-list-full";
+import { ActionListGrouped } from "@/components/action/action-list-grouped";
+import { ActionPagination } from "@/components/action/action-pagination";
+import { BulkActionBar } from "@/components/action/bulk-action-bar";
+import { useBulkSelection } from "@/hooks/use-bulk-selection";
+import type { GroupByType } from "@/lib/group-actions";
+
+type TagData = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+type ActionItemRow = {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  dueDate: Date | null;
+  member: { id: string; name: string };
+  meeting: { id: string; date: Date };
+  tags?: TagData[];
+};
+
+type SearchParams = {
+  status?: string;
+  memberId?: string;
+  tag?: string;
+  q?: string;
+  dateFilter?: string;
+  sort?: string;
+  page?: string;
+  groupBy?: string;
+};
+
+type Props = {
+  actionItems: ActionItemRow[];
+  groupBy: GroupByType;
+  isGrouped: boolean;
+  statusFilter?: string;
+  currentPage: number;
+  totalPages: number;
+  searchParams: SearchParams;
+};
+
+export function ActionsBulkContainer({
+  actionItems,
+  groupBy,
+  isGrouped,
+  statusFilter,
+  currentPage,
+  totalPages,
+  searchParams,
+}: Props) {
+  const { selectedIds, toggleItem, clearAll } = useBulkSelection();
+
+  return (
+    <>
+      {isGrouped ? (
+        <ActionListGrouped
+          actionItems={actionItems}
+          groupBy={groupBy}
+          statusFilter={statusFilter}
+          selectedIds={selectedIds}
+          onToggleSelect={toggleItem}
+        />
+      ) : (
+        <>
+          <ActionListFull
+            actionItems={actionItems}
+            statusFilter={statusFilter}
+            selectedIds={selectedIds}
+            onToggleSelect={toggleItem}
+          />
+          <ActionPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            searchParams={searchParams}
+          />
+        </>
+      )}
+      <BulkActionBar selectedIds={selectedIds} onClearAll={clearAll} />
+    </>
+  );
+}

--- a/src/components/action/bulk-action-bar.tsx
+++ b/src/components/action/bulk-action-bar.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { CheckCheck, CircleDot, Clock, Trash2, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  bulkDeleteActionItems,
+  bulkUpdateActionItemStatus,
+} from "@/lib/actions/action-item-actions";
+import { TOAST_MESSAGES } from "@/lib/toast-messages";
+
+type Props = {
+  selectedIds: Set<string>;
+  onClearAll: () => void;
+};
+
+export function BulkActionBar({ selectedIds, onClearAll }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const count = selectedIds.size;
+
+  if (count === 0) return null;
+
+  function handleBulkStatus(status: string) {
+    startTransition(async () => {
+      const result = await bulkUpdateActionItemStatus(Array.from(selectedIds), status);
+      if (result.success) {
+        toast.success(TOAST_MESSAGES.actionItem.bulkStatusChangeSuccess(result.data.count));
+        onClearAll();
+        router.refresh();
+      } else {
+        toast.error(TOAST_MESSAGES.actionItem.bulkStatusChangeError);
+      }
+    });
+  }
+
+  function handleBulkDelete() {
+    startTransition(async () => {
+      const result = await bulkDeleteActionItems(Array.from(selectedIds));
+      if (result.success) {
+        toast.success(TOAST_MESSAGES.actionItem.bulkDeleteSuccess(result.data.count));
+        onClearAll();
+        router.refresh();
+      } else {
+        toast.error(TOAST_MESSAGES.actionItem.bulkDeleteError);
+      }
+      setDeleteOpen(false);
+    });
+  }
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-slide-in">
+      <div className="flex items-center gap-2 bg-background border rounded-xl shadow-lg px-4 py-3">
+        <span className="text-sm font-medium text-foreground mr-1">{count}件選択中</span>
+        <div className="h-4 w-px bg-border mx-1" />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handleBulkStatus("TODO")}
+          disabled={isPending}
+          aria-label="選択アイテムを未着手に変更"
+        >
+          <Clock className="h-4 w-4 mr-1" />
+          未着手
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handleBulkStatus("IN_PROGRESS")}
+          disabled={isPending}
+          aria-label="選択アイテムを進行中に変更"
+        >
+          <CircleDot className="h-4 w-4 mr-1" />
+          進行中
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handleBulkStatus("DONE")}
+          disabled={isPending}
+          aria-label="選択アイテムを完了に変更"
+        >
+          <CheckCheck className="h-4 w-4 mr-1" />
+          完了
+        </Button>
+        <div className="h-4 w-px bg-border mx-1" />
+        <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              disabled={isPending}
+              aria-label="選択アイテムを削除"
+            >
+              <Trash2 className="h-4 w-4 mr-1" />
+              削除
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{count}件のアクションアイテムを削除しますか？</AlertDialogTitle>
+              <AlertDialogDescription>
+                この操作は取り消せません。選択した{count}
+                件のアクションアイテムが完全に削除されます。
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleBulkDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                削除する
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+        <div className="h-4 w-px bg-border mx-1" />
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={onClearAll}
+          aria-label="選択を解除"
+          disabled={isPending}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/meeting/meeting-detail.tsx
+++ b/src/components/meeting/meeting-detail.tsx
@@ -149,6 +149,7 @@ export function MeetingDetail({
           }))}
           meetingId={meetingId}
           memberId={memberId}
+          enableBulkSelect
         />
       </div>
     </div>

--- a/src/hooks/__tests__/use-bulk-selection.test.ts
+++ b/src/hooks/__tests__/use-bulk-selection.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useBulkSelection } from "../use-bulk-selection";
+
+describe("useBulkSelection", () => {
+  it("初期状態は空の Set", () => {
+    const { result } = renderHook(() => useBulkSelection());
+    expect(result.current.count).toBe(0);
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it("toggleItem でアイテムを選択できる", () => {
+    const { result } = renderHook(() => useBulkSelection());
+
+    act(() => {
+      result.current.toggleItem("id-1");
+    });
+
+    expect(result.current.count).toBe(1);
+    expect(result.current.isSelected("id-1")).toBe(true);
+  });
+
+  it("toggleItem で選択済みアイテムを解除できる", () => {
+    const { result } = renderHook(() => useBulkSelection());
+
+    act(() => {
+      result.current.toggleItem("id-1");
+    });
+    act(() => {
+      result.current.toggleItem("id-1");
+    });
+
+    expect(result.current.count).toBe(0);
+    expect(result.current.isSelected("id-1")).toBe(false);
+  });
+
+  it("複数アイテムを選択できる", () => {
+    const { result } = renderHook(() => useBulkSelection());
+
+    act(() => {
+      result.current.toggleItem("id-1");
+      result.current.toggleItem("id-2");
+      result.current.toggleItem("id-3");
+    });
+
+    expect(result.current.count).toBe(3);
+    expect(result.current.isSelected("id-1")).toBe(true);
+    expect(result.current.isSelected("id-2")).toBe(true);
+    expect(result.current.isSelected("id-3")).toBe(true);
+  });
+
+  it("selectAll で全アイテムを選択できる", () => {
+    const { result } = renderHook(() => useBulkSelection());
+
+    act(() => {
+      result.current.selectAll(["id-1", "id-2", "id-3"]);
+    });
+
+    expect(result.current.count).toBe(3);
+    expect(result.current.isSelected("id-1")).toBe(true);
+    expect(result.current.isSelected("id-2")).toBe(true);
+    expect(result.current.isSelected("id-3")).toBe(true);
+  });
+
+  it("clearAll で全選択を解除できる", () => {
+    const { result } = renderHook(() => useBulkSelection());
+
+    act(() => {
+      result.current.selectAll(["id-1", "id-2", "id-3"]);
+    });
+    act(() => {
+      result.current.clearAll();
+    });
+
+    expect(result.current.count).toBe(0);
+    expect(result.current.isSelected("id-1")).toBe(false);
+  });
+
+  it("isSelected は未選択のアイテムに false を返す", () => {
+    const { result } = renderHook(() => useBulkSelection());
+
+    expect(result.current.isSelected("unknown-id")).toBe(false);
+  });
+
+  it("selectedIds は不変オブジェクトを返す（イミュータブル）", () => {
+    const { result } = renderHook(() => useBulkSelection());
+
+    const prev = result.current.selectedIds;
+
+    act(() => {
+      result.current.toggleItem("id-1");
+    });
+
+    expect(result.current.selectedIds).not.toBe(prev);
+  });
+});

--- a/src/hooks/use-bulk-selection.ts
+++ b/src/hooks/use-bulk-selection.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from "react";
+
+type UseBulkSelectionReturn = {
+  selectedIds: Set<string>;
+  toggleItem: (id: string) => void;
+  selectAll: (ids: string[]) => void;
+  clearAll: () => void;
+  isSelected: (id: string) => boolean;
+  count: number;
+};
+
+export function useBulkSelection(): UseBulkSelectionReturn {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggleItem = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback((ids: string[]) => {
+    setSelectedIds(new Set(ids));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const isSelected = useCallback((id: string) => selectedIds.has(id), [selectedIds]);
+
+  return {
+    selectedIds,
+    toggleItem,
+    selectAll,
+    clearAll,
+    isSelected,
+    count: selectedIds.size,
+  };
+}

--- a/src/lib/actions/__tests__/action-item-actions.test.ts
+++ b/src/lib/actions/__tests__/action-item-actions.test.ts
@@ -347,9 +347,10 @@ describe("getLastMeetingAllActions", () => {
   });
 
   it("完了・未完了を分けて返す", async () => {
+    const laterDate = new Date(Date.now() + 1000);
     await createMeeting({
       memberId,
-      date: new Date().toISOString(),
+      date: laterDate.toISOString(),
       topics: [],
       actionItems: [
         { title: "未完了タスク", description: "" },
@@ -371,9 +372,10 @@ describe("getLastMeetingAllActions", () => {
   });
 
   it("完了のみの場合も返す", async () => {
+    const laterDate = new Date(Date.now() + 1000);
     await createMeeting({
       memberId,
-      date: new Date().toISOString(),
+      date: laterDate.toISOString(),
       topics: [],
       actionItems: [{ title: "完了タスク", description: "" }],
     });
@@ -432,9 +434,11 @@ describe("getLastMeetingAllActions", () => {
 
 describe("getLastMeetingPendingActions", () => {
   it("前回ミーティングの未完了アクションを返す", async () => {
+    // beforeEach のミーティングより確実に新しい日付を使用（タイミング競合を防ぐ）
+    const laterDate = new Date(Date.now() + 1000);
     await createMeeting({
       memberId,
-      date: new Date().toISOString(),
+      date: laterDate.toISOString(),
       topics: [],
       actionItems: [
         { title: "未完了タスク", description: "" },

--- a/src/lib/actions/__tests__/action-item-bulk-actions.test.ts
+++ b/src/lib/actions/__tests__/action-item-bulk-actions.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "@/lib/prisma";
+
+import {
+  bulkDeleteActionItems,
+  bulkUpdateActionItemStatus,
+  createActionItemForMeeting,
+} from "../action-item-actions";
+import { createMeeting } from "../meeting-actions";
+import { createMember } from "../member-actions";
+
+let memberId: string;
+let meetingId: string;
+
+beforeEach(async () => {
+  await prisma.actionItem.deleteMany();
+  await prisma.topic.deleteMany();
+  await prisma.meeting.deleteMany();
+  await prisma.member.deleteMany();
+
+  const memberResult = await createMember({ name: "Test Member" });
+  if (!memberResult.success) throw new Error(memberResult.error);
+  memberId = memberResult.data.id;
+
+  const meetingResult = await createMeeting({
+    memberId,
+    date: new Date().toISOString(),
+    topics: [],
+    actionItems: [],
+  });
+  if (!meetingResult.success) throw new Error(meetingResult.error);
+  meetingId = meetingResult.data.id;
+});
+
+async function createItem(title: string) {
+  const r = await createActionItemForMeeting(meetingId, memberId, {
+    title,
+    description: "",
+  });
+  if (!r.success) throw new Error(r.error);
+  return r.data;
+}
+
+describe("bulkUpdateActionItemStatus", () => {
+  it("複数アイテムのステータスをまとめて変更できる", async () => {
+    const a = await createItem("タスクA");
+    const b = await createItem("タスクB");
+
+    const result = await bulkUpdateActionItemStatus([a.id, b.id], "DONE");
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.count).toBe(2);
+
+    const updated = await prisma.actionItem.findMany({
+      where: { id: { in: [a.id, b.id] } },
+    });
+    expect(updated.every((item) => item.status === "DONE")).toBe(true);
+  });
+
+  it("DONE に変更した場合 completedAt がセットされる", async () => {
+    const a = await createItem("タスクA");
+
+    const before = new Date();
+    const result = await bulkUpdateActionItemStatus([a.id], "DONE");
+    const after = new Date();
+
+    expect(result.success).toBe(true);
+    const updated = await prisma.actionItem.findUnique({ where: { id: a.id } });
+    expect(updated?.completedAt).not.toBeNull();
+    expect(updated?.completedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(updated?.completedAt!.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it("DONE 以外に変更した場合 completedAt が null になる", async () => {
+    const a = await createItem("タスクA");
+    // まず DONE にする
+    await bulkUpdateActionItemStatus([a.id], "DONE");
+
+    // TODO に戻す
+    const result = await bulkUpdateActionItemStatus([a.id], "TODO");
+    expect(result.success).toBe(true);
+    const updated = await prisma.actionItem.findUnique({ where: { id: a.id } });
+    expect(updated?.completedAt).toBeNull();
+  });
+
+  it("空の ids を渡した場合エラーを返す", async () => {
+    const result = await bulkUpdateActionItemStatus([], "DONE");
+    expect(result.success).toBe(false);
+  });
+
+  it("不正なステータスを渡した場合エラーを返す", async () => {
+    const a = await createItem("タスクA");
+    const result = await bulkUpdateActionItemStatus([a.id], "INVALID");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("bulkDeleteActionItems", () => {
+  it("複数アイテムをまとめて削除できる", async () => {
+    const a = await createItem("タスクA");
+    const b = await createItem("タスクB");
+    const c = await createItem("タスクC");
+
+    const result = await bulkDeleteActionItems([a.id, b.id]);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.count).toBe(2);
+
+    const remaining = await prisma.actionItem.findMany({ where: { meetingId } });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(c.id);
+  });
+
+  it("空の ids を渡した場合エラーを返す", async () => {
+    const result = await bulkDeleteActionItems([]);
+    expect(result.success).toBe(false);
+  });
+
+  it("存在しない id を渡した場合 count が 0 になる", async () => {
+    const result = await bulkDeleteActionItems(["non-existent-id"]);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.count).toBe(0);
+  });
+});

--- a/src/lib/actions/action-item-actions.ts
+++ b/src/lib/actions/action-item-actions.ts
@@ -12,6 +12,8 @@ import type {
 } from "@/lib/types";
 import type { ActionItemStatusType, UpdateActionItemInput } from "@/lib/validations/action-item";
 import {
+  bulkDeleteSchema,
+  bulkUpdateStatusSchema,
   updateActionItemSchema,
   updateActionItemStatusSchema,
 } from "@/lib/validations/action-item";
@@ -201,6 +203,38 @@ export async function createActionItemForMeeting(
     });
     revalidatePath("/", "layout");
     return result;
+  });
+}
+
+export async function bulkUpdateActionItemStatus(
+  ids: string[],
+  status: string,
+): Promise<ActionResult<{ count: number }>> {
+  return runAction(async () => {
+    const { ids: validatedIds, status: validatedStatus } = bulkUpdateStatusSchema.parse({
+      ids,
+      status,
+    });
+    const completedAt = validatedStatus === "DONE" ? new Date() : null;
+    const result = await prisma.actionItem.updateMany({
+      where: { id: { in: validatedIds } },
+      data: { status: validatedStatus, completedAt },
+    });
+    revalidatePath("/", "layout");
+    return { count: result.count };
+  });
+}
+
+export async function bulkDeleteActionItems(
+  ids: string[],
+): Promise<ActionResult<{ count: number }>> {
+  return runAction(async () => {
+    const { ids: validatedIds } = bulkDeleteSchema.parse({ ids });
+    const result = await prisma.actionItem.deleteMany({
+      where: { id: { in: validatedIds } },
+    });
+    revalidatePath("/", "layout");
+    return { count: result.count };
   });
 }
 

--- a/src/lib/toast-messages.ts
+++ b/src/lib/toast-messages.ts
@@ -28,6 +28,10 @@ export const TOAST_MESSAGES = {
     updateError: "アクションアイテムの更新に失敗しました",
     createSuccess: "アクションアイテムを追加しました",
     createError: "アクションアイテムの追加に失敗しました",
+    bulkStatusChangeSuccess: (count: number) => `${count}件のステータスを更新しました`,
+    bulkStatusChangeError: "一括ステータス変更に失敗しました",
+    bulkDeleteSuccess: (count: number) => `${count}件のアクションアイテムを削除しました`,
+    bulkDeleteError: "一括削除に失敗しました",
   },
   prepare: {
     topicCopied: "話題をアジェンダにコピーしました",

--- a/src/lib/validations/action-item.ts
+++ b/src/lib/validations/action-item.ts
@@ -12,6 +12,17 @@ export const updateActionItemSchema = z.object({
   dueDate: z.string().optional(),
 });
 
+export const bulkUpdateStatusSchema = z.object({
+  ids: z.array(z.string()).min(1, "対象アイテムが選択されていません"),
+  status: actionItemStatus,
+});
+
+export const bulkDeleteSchema = z.object({
+  ids: z.array(z.string()).min(1, "対象アイテムが選択されていません"),
+});
+
 export type ActionItemStatusType = z.infer<typeof actionItemStatus>;
 export type UpdateActionItemStatusInput = z.infer<typeof updateActionItemStatusSchema>;
 export type UpdateActionItemInput = z.infer<typeof updateActionItemSchema>;
+export type BulkUpdateStatusInput = z.infer<typeof bulkUpdateStatusSchema>;
+export type BulkDeleteInput = z.infer<typeof bulkDeleteSchema>;


### PR DESCRIPTION
## 概要

issue #123 の対応。アクションアイテム一覧（アクション一覧ページ・ミーティング詳細）で複数選択・一括操作を可能にし、フォローアップ作業の効率を大幅に改善する。

## 変更内容

### 新規ファイル
- `src/hooks/use-bulk-selection.ts` — 選択状態管理フック（Set<string>ベース、イミュータブル）
- `src/components/action/bulk-action-bar.tsx` — 画面下部 fixed 表示の一括操作バー（ステータス変更・削除・選択解除）
- `src/components/action/actions-bulk-container.tsx` — アクション一覧ページ用クライアントラッパー（グループをまたいだ選択状態管理）
- `src/hooks/__tests__/use-bulk-selection.test.ts` — フックのユニットテスト
- `src/components/action/__tests__/bulk-action-bar.test.tsx` — BulkActionBar のコンポーネントテスト
- `src/lib/actions/__tests__/action-item-bulk-actions.test.ts` — バルク Server Actions のインテグレーションテスト

### 変更ファイル
- `src/lib/actions/action-item-actions.ts` — `bulkUpdateActionItemStatus` / `bulkDeleteActionItems` Server Actions を追加
- `src/lib/validations/action-item.ts` — バルク操作用 Zod スキーマを追加
- `src/lib/toast-messages.ts` — 一括操作のトースト通知メッセージを追加
- `src/components/action/action-list-full.tsx` — `selectedIds` / `onToggleSelect` props（オプション）を追加し後方互換を維持
- `src/components/action/action-list-grouped.tsx` — 選択関連 props をスルーパス
- `src/app/actions/page.tsx` — `ActionsBulkContainer` を使用するよう変更
- `src/components/action/action-list-compact.tsx` — `enableBulkSelect` オプション props を追加
- `src/components/meeting/meeting-detail.tsx` — `enableBulkSelect` を有効化
- `src/lib/actions/__tests__/action-item-actions.test.ts` — 既存テストの日付タイミング競合（フレーキーネス）を修正

## 機能

- **複数選択**: チェックボックスをクリックして選択開始（1件選択でバーが表示）
- **一括ステータス変更**: 未着手 / 進行中 / 完了 をまとめて変更
- **一括削除**: 確認ダイアログ付きで選択アイテムを削除
- **視覚フィードバック**: 選択行に背景色変更（`bg-primary/5 border-primary/30`）
- **選択解除**: × ボタンで全選択解除
- **グループまたぎ対応**: グループ化表示時でも複数グループをまたいで選択可能

## テスト計画

- [x] `npm test` — 121ファイル 1258テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] アクション一覧ページで複数のアクションをチェックして画面下部にバーが表示されることを確認
- [ ] バーの「完了」ボタンで選択アイテムのステータスが一括変更されることを確認
- [ ] バーの「削除」ボタンで確認ダイアログが表示されてから削除されることを確認
- [ ] ミーティング詳細ページのアクションリストでも複数選択・一括操作が動作することを確認
- [ ] グループ化表示（メンバー別・期限別）でグループをまたいだ選択が機能することを確認

Closes #123