### PR TITLE
ux: 全メンバーのアクションアイテムを横断的に管理できる「マイタスク」画面を追加する (issue #126)

### DIFF
--- a/src/app/tasks/loading.tsx
+++ b/src/app/tasks/loading.tsx
@@ -1,0 +1,14 @@
+import { ActionListSkeleton } from "@/components/action/action-list-skeleton";
+import { Breadcrumb } from "@/components/layout/breadcrumb";
+
+export default function TasksLoading() {
+  return (
+    <div>
+      <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "マイタスク" }]} />
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">マイタスク</h1>
+      </div>
+      <ActionListSkeleton />
+    </div>
+  );
+}

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,0 +1,69 @@
+import { ClipboardCheck } from "lucide-react";
+
+import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { TaskDateGroup } from "@/components/task/task-date-group";
+import { Badge } from "@/components/ui/badge";
+import { getMyTasks } from "@/lib/actions/action-item-actions";
+import { groupTasksByDueDate } from "@/lib/group-tasks";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  searchParams: Promise<{
+    memberId?: string;
+  }>;
+};
+
+export default async function TasksPage({ searchParams }: Props) {
+  const params = await searchParams;
+
+  const items = await getMyTasks({
+    memberId: params.memberId,
+  });
+
+  const itemsWithTags = items.map((item) => ({
+    ...item,
+    tags: item.tags.map((tt) => tt.tag),
+  }));
+
+  const groups = groupTasksByDueDate(itemsWithTags);
+  const totalCount = items.length;
+  const overdueCount = groups.find((g) => g.key === "overdue")?.items.length ?? 0;
+
+  return (
+    <div className="animate-fade-in-up">
+      <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "マイタスク" }]} />
+      <div className="flex items-center gap-3 mb-2">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">マイタスク</h1>
+        {overdueCount > 0 ? (
+          <Badge variant="destructive" className="text-sm">
+            {overdueCount} 件超過
+          </Badge>
+        ) : totalCount > 0 ? (
+          <Badge variant="secondary" className="text-sm">
+            {totalCount} 件
+          </Badge>
+        ) : null}
+      </div>
+      <p className="text-sm text-muted-foreground mb-6">
+        未完了のアクションアイテム（TODO・進行中）を期限別に表示しています。
+      </p>
+
+      {groups.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <ClipboardCheck className="w-12 h-12 text-muted-foreground/30 mb-4" />
+          <p className="text-muted-foreground font-medium">すべて完了しています！</p>
+          <p className="text-sm text-muted-foreground/70 mt-1">
+            未完了のアクションアイテムはありません
+          </p>
+        </div>
+      ) : (
+        <div>
+          {groups.map((group) => (
+            <TaskDateGroup key={group.key} group={group} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
   BarChart2,
+  ClipboardCheck,
   LayoutDashboard,
   ListChecks,
   Menu,
@@ -35,6 +36,7 @@ const navItems = [
   { href: "/", label: "ダッシュボード", icon: LayoutDashboard },
   { href: "/members", label: "メンバー一覧", icon: Users },
   { href: "/members/new", label: "メンバー追加", icon: UserPlus },
+  { href: "/tasks", label: "マイタスク", icon: ClipboardCheck },
   { href: "/actions", label: "アクション一覧", icon: ListChecks },
   { href: "/analytics", label: "ミーティング分析", icon: BarChart2 },
   { href: "/settings/templates", label: "テンプレート管理", icon: Settings },
@@ -55,7 +57,7 @@ function NavLinks({
         const isActive =
           item.href === "/" || item.href === "/members"
             ? pathname === item.href
-            : pathname.startsWith(item.href);
+            : pathname === item.href || pathname.startsWith(item.href + "/");
         const badge = item.href === "/actions" && actionCount != null && actionCount > 0;
         return (
           <Link

--- a/src/components/task/__tests__/task-date-group.test.tsx
+++ b/src/components/task/__tests__/task-date-group.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TaskDateGroup } from "@/components/task/task-date-group";
+import type { TaskDateGroup as TaskDateGroupType } from "@/lib/group-tasks";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeGroup(overrides: Partial<TaskDateGroupType> = {}): TaskDateGroupType {
+  return {
+    key: "overdue",
+    label: "期限超過",
+    isOverdue: true,
+    items: [
+      {
+        id: "item-1",
+        title: "テストアクション",
+        status: "TODO",
+        dueDate: new Date("2026-02-20"),
+        member: { id: "member-1", name: "田中太郎" },
+        meeting: { id: "meeting-1", date: new Date("2026-02-01") },
+        tags: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("TaskDateGroup", () => {
+  it("グループラベルが表示される", () => {
+    render(<TaskDateGroup group={makeGroup()} />);
+    // h2 要素としてラベルが表示されていることを確認
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveTextContent("期限超過");
+  });
+
+  it("期限超過グループにはアラートアイコンが表示される", () => {
+    const { container } = render(<TaskDateGroup group={makeGroup({ isOverdue: true })} />);
+    // AlertCircle アイコンが存在することを確認（SVG要素）
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("通常グループには赤色スタイルが適用されない", () => {
+    const { container } = render(
+      <TaskDateGroup group={makeGroup({ key: "today", label: "今日", isOverdue: false })} />,
+    );
+    const header = container.querySelector(".bg-destructive\\/10");
+    expect(header).toBeNull();
+  });
+
+  it("アイテム数のバッジが表示される", () => {
+    render(<TaskDateGroup group={makeGroup()} />);
+    // グループヘッダーのアイテム数 span を確認（グループヘッダー内の span）
+    const countSpans = screen
+      .getAllByText("1")
+      .filter(
+        (el) =>
+          el.tagName === "SPAN" &&
+          el.className.includes("ml-auto") &&
+          el.className.includes("text-xs"),
+      );
+    expect(countSpans.length).toBeGreaterThan(0);
+  });
+
+  it("アイテムのタイトルが表示される", () => {
+    render(<TaskDateGroup group={makeGroup()} />);
+    const titles = screen.getAllByText("テストアクション");
+    expect(titles.length).toBeGreaterThan(0);
+  });
+
+  it("メンバー名が表示される", () => {
+    render(<TaskDateGroup group={makeGroup()} />);
+    const memberNames = screen.getAllByText("田中太郎");
+    expect(memberNames.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/task/__tests__/task-item-row.test.tsx
+++ b/src/components/task/__tests__/task-item-row.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TaskItemRow } from "@/components/task/task-item-row";
+
+afterEach(() => {
+  cleanup();
+});
+
+const defaultProps = {
+  title: "テストアクション",
+  status: "TODO" as const,
+  dueDate: null,
+  memberId: "member-1",
+  meetingId: "meeting-1",
+  tags: [],
+};
+
+describe("TaskItemRow", () => {
+  it("タイトルが表示される", () => {
+    render(<TaskItemRow {...defaultProps} />);
+    expect(screen.getByText("テストアクション")).toBeInTheDocument();
+  });
+
+  it("ミーティング詳細ページへのリンクが正しい", () => {
+    render(<TaskItemRow {...defaultProps} />);
+    const links = screen.getAllByRole("link");
+    // 少なくとも1つのリンクが存在し、正しい href を持つ
+    const mainLink = links.find((link) =>
+      link.getAttribute("href")?.includes("/members/member-1/meetings/meeting-1"),
+    );
+    expect(mainLink).toBeInTheDocument();
+  });
+
+  it("タグが表示される", () => {
+    const tags = [{ id: "tag-1", name: "重要", color: "#ff0000" }];
+    render(<TaskItemRow {...defaultProps} tags={tags} />);
+    expect(screen.getByText("重要")).toBeInTheDocument();
+  });
+
+  it("期限超過の場合に期限超過バッジが表示される", () => {
+    const dueDate = new Date("2026-02-20"); // 過去の日付
+    render(<TaskItemRow {...defaultProps} dueDate={dueDate} />);
+    expect(screen.getByText("期限超過")).toBeInTheDocument();
+  });
+});

--- a/src/components/task/__tests__/task-member-group.test.tsx
+++ b/src/components/task/__tests__/task-member-group.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});
+
+import { TaskMemberGroup } from "@/components/task/task-member-group";
+
+const defaultItem = {
+  id: "item-1",
+  title: "テストアクション",
+  status: "TODO" as const,
+  dueDate: null,
+  member: { id: "member-1", name: "田中太郎" },
+  meeting: { id: "meeting-1", date: new Date("2026-02-01") },
+  tags: [],
+};
+
+describe("TaskMemberGroup", () => {
+  it("メンバー名が表示される", () => {
+    render(<TaskMemberGroup memberId="member-1" memberName="田中太郎" items={[defaultItem]} />);
+    expect(screen.getByText("田中太郎")).toBeInTheDocument();
+  });
+
+  it("メンバー詳細ページへのリンクが正しい", () => {
+    render(<TaskMemberGroup memberId="member-1" memberName="田中太郎" items={[defaultItem]} />);
+    const links = screen.getAllByRole("link");
+    const memberLink = links.find((l) => l.getAttribute("href") === "/members/member-1");
+    expect(memberLink).toBeDefined();
+  });
+
+  it("アイテム数バッジが表示される", () => {
+    render(<TaskMemberGroup memberId="member-1" memberName="田中太郎" items={[defaultItem]} />);
+    const badges = screen.getAllByText("1");
+    expect(badges.length).toBeGreaterThan(0);
+  });
+
+  it("複数アイテムが全て表示される", () => {
+    const items = [
+      { ...defaultItem, id: "item-1", title: "アクション1" },
+      { ...defaultItem, id: "item-2", title: "アクション2" },
+    ];
+    render(<TaskMemberGroup memberId="member-1" memberName="田中太郎" items={items} />);
+    expect(screen.getByText("アクション1")).toBeInTheDocument();
+    expect(screen.getByText("アクション2")).toBeInTheDocument();
+    const badges = screen.getAllByText("2");
+    expect(badges.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/task/task-date-group.tsx
+++ b/src/components/task/task-date-group.tsx
@@ -1,0 +1,59 @@
+import { AlertCircle } from "lucide-react";
+
+import type { TaskItemForGrouping } from "@/lib/group-tasks";
+import { groupTasksByMember } from "@/lib/group-tasks";
+
+import { TaskMemberGroup } from "./task-member-group";
+
+type Tag = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+type TaskDateGroup = {
+  key: string;
+  label: string;
+  items: TaskItemForGrouping[];
+  isOverdue: boolean;
+};
+
+type TaskDateGroupProps = {
+  readonly group: TaskDateGroup;
+};
+
+export function TaskDateGroup({ group }: TaskDateGroupProps) {
+  const memberGroups = groupTasksByMember(group.items);
+
+  return (
+    <div className="mb-6">
+      <div
+        className={`flex items-center gap-2 px-4 py-2 mb-2 rounded-lg ${
+          group.isOverdue
+            ? "bg-destructive/10 text-destructive"
+            : "bg-muted/50 text-muted-foreground"
+        }`}
+      >
+        {group.isOverdue && <AlertCircle className="w-4 h-4 shrink-0" />}
+        <h2 className="text-sm font-semibold">{group.label}</h2>
+        <span
+          className={`ml-auto text-xs rounded-full px-2 py-0.5 font-medium ${
+            group.isOverdue
+              ? "bg-destructive/20 text-destructive"
+              : "bg-muted text-muted-foreground"
+          }`}
+        >
+          {group.items.length}
+        </span>
+      </div>
+      {memberGroups.map((mg) => (
+        <TaskMemberGroup
+          key={mg.memberId}
+          memberId={mg.memberId}
+          memberName={mg.memberName}
+          items={mg.items}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/task/task-item-row.tsx
+++ b/src/components/task/task-item-row.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Circle, Clock } from "lucide-react";
+import Link from "next/link";
+
+import { DueDateBadge } from "@/components/action/due-date-badge";
+import type { ActionItemStatusType } from "@/lib/validations/action-item";
+
+type Tag = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+type TaskItemRowProps = {
+  readonly title: string;
+  readonly status: ActionItemStatusType;
+  readonly dueDate: Date | null;
+  readonly memberId: string;
+  readonly meetingId: string;
+  readonly tags: Tag[];
+};
+
+export function TaskItemRow({
+  title,
+  status,
+  dueDate,
+  memberId,
+  meetingId,
+  tags,
+}: TaskItemRowProps) {
+  const StatusIcon = status === "IN_PROGRESS" ? Clock : Circle;
+
+  return (
+    <Link
+      href={`/members/${memberId}/meetings/${meetingId}`}
+      className="flex items-start gap-3 px-4 py-3 hover:bg-accent/50 transition-colors duration-150 rounded-lg group"
+    >
+      <StatusIcon
+        className={`w-4 h-4 mt-0.5 shrink-0 ${
+          status === "IN_PROGRESS" ? "text-primary" : "text-muted-foreground"
+        }`}
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-foreground truncate group-hover:text-primary transition-colors">
+          {title}
+        </p>
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {tags.map((tag) => (
+              <span
+                key={tag.id}
+                className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium"
+                style={{ backgroundColor: `${tag.color}20`, color: tag.color }}
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      {dueDate && (
+        <div className="shrink-0">
+          <DueDateBadge dueDate={dueDate} status={status} />
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/src/components/task/task-member-group.tsx
+++ b/src/components/task/task-member-group.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+
+import { AvatarInitial } from "@/components/ui/avatar-initial";
+import type { ActionItemStatusType } from "@/lib/validations/action-item";
+
+import { TaskItemRow } from "./task-item-row";
+
+type Tag = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+type TaskItem = {
+  id: string;
+  title: string;
+  status: ActionItemStatusType;
+  dueDate: Date | null;
+  member: { id: string; name: string };
+  meeting: { id: string; date: Date };
+  tags: Tag[];
+};
+
+type TaskMemberGroupProps = {
+  readonly memberId: string;
+  readonly memberName: string;
+  readonly items: TaskItem[];
+};
+
+export function TaskMemberGroup({ memberId, memberName, items }: TaskMemberGroupProps) {
+  return (
+    <div className="mb-4">
+      <Link
+        href={`/members/${memberId}`}
+        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <AvatarInitial name={memberName} size="sm" />
+        <span>{memberName}</span>
+        <span className="ml-auto text-xs bg-muted rounded-full px-2 py-0.5">{items.length}</span>
+      </Link>
+      <div className="pl-4">
+        {items.map((item) => (
+          <TaskItemRow
+            key={item.id}
+            title={item.title}
+            status={item.status}
+            dueDate={item.dueDate}
+            memberId={item.member.id}
+            meetingId={item.meeting.id}
+            tags={item.tags}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/group-tasks.test.ts
+++ b/src/lib/__tests__/group-tasks.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { TaskItemForGrouping } from "@/lib/group-tasks";
+import { groupTasksByDueDate, groupTasksByMember } from "@/lib/group-tasks";
+
+function makeItem(overrides: Partial<TaskItemForGrouping> = {}): TaskItemForGrouping {
+  return {
+    id: "item-1",
+    title: "テストアイテム",
+    status: "TODO",
+    dueDate: null,
+    member: { id: "member-1", name: "田中太郎" },
+    meeting: { id: "meeting-1", date: new Date("2026-02-01") },
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("groupTasksByDueDate", () => {
+  const now = new Date("2026-02-24T12:00:00");
+
+  it("期限なしアイテムは「期限なし」グループに入る", () => {
+    const items = [makeItem({ dueDate: null })];
+    const groups = groupTasksByDueDate(items, now);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("no-date");
+    expect(groups[0].label).toBe("期限なし");
+    expect(groups[0].isOverdue).toBe(false);
+  });
+
+  it("期限超過アイテムは「期限超過」グループに入り isOverdue が true", () => {
+    const items = [makeItem({ dueDate: new Date("2026-02-20") })];
+    const groups = groupTasksByDueDate(items, now);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("overdue");
+    expect(groups[0].isOverdue).toBe(true);
+  });
+
+  it("今日期限のアイテムは「今日」グループに入る", () => {
+    const items = [makeItem({ dueDate: new Date("2026-02-24") })];
+    const groups = groupTasksByDueDate(items, now);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("today");
+  });
+
+  it("今週期限のアイテムは「今週」グループに入る", () => {
+    const items = [makeItem({ dueDate: new Date("2026-02-26") })];
+    const groups = groupTasksByDueDate(items, now);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("this-week");
+  });
+
+  it("来週以降のアイテムは「来週以降」グループに入る", () => {
+    const items = [makeItem({ dueDate: new Date("2026-03-10") })];
+    const groups = groupTasksByDueDate(items, now);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("later");
+  });
+
+  it("アイテムがない場合は空配列を返す", () => {
+    const groups = groupTasksByDueDate([], now);
+    expect(groups).toHaveLength(0);
+  });
+
+  it("空のグループは返さない", () => {
+    const items = [makeItem({ dueDate: new Date("2026-02-20") })];
+    const groups = groupTasksByDueDate(items, now);
+    expect(groups.every((g) => g.items.length > 0)).toBe(true);
+  });
+
+  it("複数のグループに振り分けられる", () => {
+    const items = [
+      makeItem({ id: "1", dueDate: new Date("2026-02-20") }), // overdue
+      makeItem({ id: "2", dueDate: new Date("2026-02-24") }), // today
+      makeItem({ id: "3", dueDate: null }), // no-date
+    ];
+    const groups = groupTasksByDueDate(items, now);
+    expect(groups).toHaveLength(3);
+    expect(groups[0].key).toBe("overdue");
+    expect(groups[1].key).toBe("today");
+    expect(groups[2].key).toBe("no-date");
+  });
+});
+
+describe("groupTasksByMember", () => {
+  it("同一メンバーのアイテムがグループ化される", () => {
+    const items = [
+      makeItem({ id: "1", member: { id: "m1", name: "田中" } }),
+      makeItem({ id: "2", member: { id: "m1", name: "田中" } }),
+    ];
+    const groups = groupTasksByMember(items);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].memberId).toBe("m1");
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  it("異なるメンバーのアイテムが別々のグループになる", () => {
+    const items = [
+      makeItem({ id: "1", member: { id: "m1", name: "田中" } }),
+      makeItem({ id: "2", member: { id: "m2", name: "佐藤" } }),
+    ];
+    const groups = groupTasksByMember(items);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("空配列を渡すと空配列を返す", () => {
+    const groups = groupTasksByMember([]);
+    expect(groups).toHaveLength(0);
+  });
+});

--- a/src/lib/actions/action-item-actions.ts
+++ b/src/lib/actions/action-item-actions.ts
@@ -279,3 +279,23 @@ export async function getLastMeetingAllActions(
     pendingActions,
   };
 }
+
+export async function getMyTasks(filters: { memberId?: string } = {}) {
+  const where: Prisma.ActionItemWhereInput = {
+    status: { not: "DONE" },
+  };
+  if (filters.memberId) where.memberId = filters.memberId;
+
+  const items = await prisma.actionItem.findMany({
+    where,
+    orderBy: [{ dueDate: "asc" }, { member: { name: "asc" } }, { createdAt: "desc" }],
+    take: 200,
+    include: {
+      member: { select: { id: true, name: true } },
+      meeting: { select: { id: true, date: true } },
+      tags: { include: { tag: true } },
+    },
+  });
+
+  return items;
+}

--- a/src/lib/group-tasks.ts
+++ b/src/lib/group-tasks.ts
@@ -1,0 +1,93 @@
+import type { ActionItemStatusType } from "@/lib/validations/action-item";
+
+type Tag = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+export type TaskItemForGrouping = {
+  id: string;
+  title: string;
+  status: ActionItemStatusType;
+  dueDate: Date | null;
+  member: { id: string; name: string };
+  meeting: { id: string; date: Date };
+  tags: Tag[];
+};
+
+export type TaskDateGroup = {
+  key: string;
+  label: string;
+  items: TaskItemForGrouping[];
+  isOverdue: boolean;
+};
+
+export function groupTasksByDueDate(
+  items: TaskItemForGrouping[],
+  now: Date = new Date(),
+): TaskDateGroup[] {
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrow = new Date(
+    todayStart.getFullYear(),
+    todayStart.getMonth(),
+    todayStart.getDate() + 1,
+  );
+
+  const dayOfWeek = todayStart.getDay();
+  const daysUntilNextMonday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
+  const nextMonday = new Date(
+    todayStart.getFullYear(),
+    todayStart.getMonth(),
+    todayStart.getDate() + daysUntilNextMonday,
+  );
+
+  const groups: TaskDateGroup[] = [
+    { key: "overdue", label: "期限超過", items: [], isOverdue: true },
+    { key: "today", label: "今日", items: [], isOverdue: false },
+    { key: "this-week", label: "今週", items: [], isOverdue: false },
+    { key: "later", label: "来週以降", items: [], isOverdue: false },
+    { key: "no-date", label: "期限なし", items: [], isOverdue: false },
+  ];
+
+  for (const item of items) {
+    if (!item.dueDate) {
+      groups[4].items.push(item);
+      continue;
+    }
+    const d = new Date(item.dueDate);
+    const dueStart = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+    if (dueStart < todayStart) {
+      groups[0].items.push(item);
+    } else if (dueStart < tomorrow) {
+      groups[1].items.push(item);
+    } else if (dueStart < nextMonday) {
+      groups[2].items.push(item);
+    } else {
+      groups[3].items.push(item);
+    }
+  }
+
+  return groups.filter((g) => g.items.length > 0);
+}
+
+export type MemberGroup = {
+  memberId: string;
+  memberName: string;
+  items: TaskItemForGrouping[];
+};
+
+export function groupTasksByMember(items: TaskItemForGrouping[]): MemberGroup[] {
+  const map = new Map<string, MemberGroup>();
+  for (const item of items) {
+    const key = item.member.id;
+    const existing = map.get(key);
+    if (existing) {
+      map.set(key, { ...existing, items: [...existing.items, item] });
+    } else {
+      map.set(key, { memberId: key, memberName: item.member.name, items: [item] });
+    }
+  }
+  return Array.from(map.values());
+}


### PR DESCRIPTION
## 概要

issue #126 の対応。サイドバーに「マイタスク」ナビゲーションを追加し、全メンバーの未完了アクションアイテム（TODO・IN_PROGRESS）を期限別グループで一覧表示する画面を実装した。

## 変更内容

### 新規ファイル

- `src/app/tasks/page.tsx` — マイタスクページ（force-dynamic）。期限別グループ表示・空状態対応
- `src/app/tasks/loading.tsx` — ローディングスケルトン
- `src/lib/group-tasks.ts` — `groupTasksByDueDate` / `groupTasksByMember` グループ化ロジック（イミュータブル実装）
- `src/components/task/task-date-group.tsx` — 期限グループヘッダー（期限超過は赤ハイライト）
- `src/components/task/task-member-group.tsx` — グループ内のメンバー別サブリスト
- `src/components/task/task-item-row.tsx` — タスク行（クリックでミーティング詳細へ遷移）
- `src/lib/__tests__/group-tasks.test.ts` — グループ化ロジックのユニットテスト（11件）
- `src/components/task/__tests__/task-date-group.test.tsx` — コンポーネントテスト（6件）
- `src/components/task/__tests__/task-item-row.test.tsx` — コンポーネントテスト（4件）
- `src/components/task/__tests__/task-member-group.test.tsx` — コンポーネントテスト（4件）

### 変更ファイル

- `src/components/layout/sidebar.tsx` — 「マイタスク」メニュー項目（ClipboardCheck アイコン）を追加、isActive 判定を `pathname === href || startsWith(href + "/")` に修正
- `src/lib/actions/action-item-actions.ts` — `getMyTasks` Server Action を追加（TODO/IN_PROGRESS のみ・上限 200 件・期限順ソート）

## 機能

- **期限別グループ表示**: 期限超過 → 今日 → 今週 → 来週以降 → 期限なし の5段階グループ
- **メンバー別サブグループ**: 各期限グループ内をメンバーごとに整理
- **期限超過ハイライト**: AlertCircle アイコン + `bg-destructive/10` で赤色強調
- **ミーティング詳細への遷移**: アイテムクリックで `/members/[id]/meetings/[meetingId]` に遷移
- **空状態表示**: 全アイテム完了時に「すべて完了しています！」メッセージを表示
- **既存 `/actions` との差別化**: DONE 除外・期限別固定グループで「今すぐ対応すべきもの」に特化

## テスト計画

- [x] `npm test` — 128ファイル 1297テスト全パス（エラー 0）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] サイドバーに「マイタスク」メニューが表示されること
- [ ] `/tasks` にアクセスして期限別グループが表示されること
- [ ] 期限超過アイテムに赤ハイライトが適用されること
- [ ] アイテムクリックでミーティング詳細ページに遷移できること
- [ ] 全アイテム完了時に空状態メッセージが表示されること

Closes #126