### PR TITLE
ux: Empty State の改善とオンボーディングガイド強化 (issue #193)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -123,6 +123,8 @@ export default async function ActionsPage({ searchParams }: Props) {
           currentPage={currentPage}
           totalPages={totalPages}
           searchParams={params}
+          hasMembers={members.length > 0}
+          hasFilter={hasFilter}
         />
       </Suspense>
     </div>

--- a/src/components/action/__tests__/action-list-full.test.tsx
+++ b/src/components/action/__tests__/action-list-full.test.tsx
@@ -58,9 +58,32 @@ const baseItems = [
 ];
 
 describe("ActionListFull", () => {
-  it("空リストのときメッセージを表示する", () => {
-    render(<ActionListFull actionItems={[]} />);
-    expect(screen.getByText("アクションアイテムはありません")).toBeDefined();
+  describe("空リスト表示", () => {
+    it("メンバーなし・フィルタなし → メンバー追加ガイドを表示する", () => {
+      render(<ActionListFull actionItems={[]} hasMembers={false} />);
+      expect(screen.getByText("メンバーを追加して1on1を始めましょう")).toBeDefined();
+    });
+
+    it("メンバーあり・フィルタあり → 条件一致なしメッセージを表示する", () => {
+      render(<ActionListFull actionItems={[]} hasMembers={true} hasFilter={true} />);
+      expect(screen.getByText("条件に一致するアクションアイテムがありません")).toBeDefined();
+    });
+
+    it("メンバーあり・フィルタなし → 達成感メッセージを表示する", () => {
+      render(<ActionListFull actionItems={[]} hasMembers={true} hasFilter={false} />);
+      expect(screen.getByText("すべてのアクションアイテムが完了しています！")).toBeDefined();
+    });
+
+    it("デフォルト（props未指定）でメンバーあり・フィルタなし扱いになる", () => {
+      render(<ActionListFull actionItems={[]} />);
+      expect(screen.getByText("すべてのアクションアイテムが完了しています！")).toBeDefined();
+    });
+
+    it("メンバーなし空状態はメンバー追加ボタンリンクを含む", () => {
+      render(<ActionListFull actionItems={[]} hasMembers={false} />);
+      const link = screen.getByRole("link", { name: "メンバーを追加する" });
+      expect(link.getAttribute("href")).toBe("/members/new");
+    });
   });
 
   it("アクションアイテムのタイトルとメンバー名を表示する", () => {
@@ -183,9 +206,11 @@ describe("ActionListFull", () => {
       expect(screen.getByText("ドキュメント更新")).toBeDefined();
     });
 
-    it("statusFilter を指定して空リストの場合、空状態メッセージを表示する", () => {
-      render(<ActionListFull actionItems={[]} statusFilter="DONE" />);
-      expect(screen.getByText("アクションアイテムはありません")).toBeDefined();
+    it("statusFilter を指定して空リストの場合、hasFilter=true なら条件一致なしを表示する", () => {
+      render(
+        <ActionListFull actionItems={[]} statusFilter="DONE" hasMembers={true} hasFilter={true} />,
+      );
+      expect(screen.getByText("条件に一致するアクションアイテムがありません")).toBeDefined();
     });
   });
 

--- a/src/components/action/action-list-full.tsx
+++ b/src/components/action/action-list-full.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil, SquareCheck } from "lucide-react";
+import { Pencil, SquareCheck, UserPlus } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useOptimistic, useState, useTransition } from "react";
@@ -53,9 +53,55 @@ type Props = {
   statusFilter?: string;
   selectedIds?: Set<string>;
   onToggleSelect?: (id: string) => void;
+  hasMembers?: boolean;
+  hasFilter?: boolean;
 };
 
-export function ActionListFull({ actionItems, statusFilter, selectedIds, onToggleSelect }: Props) {
+function EmptyActionState({
+  hasMembers = true,
+  hasFilter = false,
+}: {
+  hasMembers?: boolean;
+  hasFilter?: boolean;
+}) {
+  if (!hasMembers) {
+    return (
+      <EmptyState
+        icon={UserPlus}
+        title="メンバーを追加して1on1を始めましょう"
+        description="チームメンバーを追加すると、1on1でアクションアイテムを作成・管理できます"
+        action={{ label: "メンバーを追加する", href: "/members/new" }}
+        size="large"
+      />
+    );
+  }
+  if (hasFilter) {
+    return (
+      <EmptyState
+        icon={SquareCheck}
+        title="条件に一致するアクションアイテムがありません"
+        description="フィルター条件を変更して再度お試しください"
+      />
+    );
+  }
+  return (
+    <EmptyState
+      icon={SquareCheck}
+      title="すべてのアクションアイテムが完了しています！"
+      description="1on1で新しいアクションアイテムを作成すると、ここに表示されます"
+      variant="success"
+    />
+  );
+}
+
+export function ActionListFull({
+  actionItems,
+  statusFilter,
+  selectedIds,
+  onToggleSelect,
+  hasMembers,
+  hasFilter,
+}: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -79,13 +125,7 @@ export function ActionListFull({ actionItems, statusFilter, selectedIds, onToggl
   const isBulkMode = selectedIds !== undefined && onToggleSelect !== undefined;
 
   if (actionItems.length === 0) {
-    return (
-      <EmptyState
-        icon={SquareCheck}
-        title="アクションアイテムはありません"
-        description="1on1でアクションアイテムを作成すると、ここに表示されます"
-      />
-    );
+    return <EmptyActionState hasMembers={hasMembers} hasFilter={hasFilter} />;
   }
 
   function handleStatusChange(id: string, newStatus: string) {

--- a/src/components/action/actions-bulk-container.tsx
+++ b/src/components/action/actions-bulk-container.tsx
@@ -43,6 +43,8 @@ type Props = {
   currentPage: number;
   totalPages: number;
   searchParams: SearchParams;
+  hasMembers: boolean;
+  hasFilter: boolean;
 };
 
 export function ActionsBulkContainer({
@@ -53,6 +55,8 @@ export function ActionsBulkContainer({
   currentPage,
   totalPages,
   searchParams,
+  hasMembers,
+  hasFilter,
 }: Props) {
   const { selectedIds, toggleItem, clearAll } = useBulkSelection();
 
@@ -73,6 +77,8 @@ export function ActionsBulkContainer({
             statusFilter={statusFilter}
             selectedIds={selectedIds}
             onToggleSelect={toggleItem}
+            hasMembers={hasMembers}
+            hasFilter={hasFilter}
           />
           <ActionPagination
             currentPage={currentPage}

--- a/src/components/analytics/__tests__/meeting-frequency-chart.test.tsx
+++ b/src/components/analytics/__tests__/meeting-frequency-chart.test.tsx
@@ -15,7 +15,11 @@ describe("MeetingFrequencyChart", () => {
 
   it("renders guidance message in empty state", () => {
     render(<MeetingFrequencyChart data={[]} />);
-    expect(screen.getByText("1on1を実施すると、月次実施回数グラフが表示されます")).toBeDefined();
+    expect(
+      screen.getByText(
+        "1on1を実施すると月次グラフが表示されます。まずはメンバーとの1on1を記録しましょう",
+      ),
+    ).toBeDefined();
   });
 
   it("renders bar chart when data exists", () => {

--- a/src/components/analytics/__tests__/meeting-heatmap.test.tsx
+++ b/src/components/analytics/__tests__/meeting-heatmap.test.tsx
@@ -93,7 +93,9 @@ describe("MeetingHeatmap", () => {
   it("メンバーがいない場合は説明文を表示する", () => {
     render(<MeetingHeatmap data={emptyData} />);
     expect(
-      screen.getByText("1on1を実施すると、メンバー別の頻度マップが表示されます"),
+      screen.getByText(
+        "メンバーと1on1を実施すると、頻度マップが表示されます。まずはメンバーを追加して1on1を始めましょう",
+      ),
     ).toBeDefined();
   });
 

--- a/src/components/analytics/meeting-frequency-chart.tsx
+++ b/src/components/analytics/meeting-frequency-chart.tsx
@@ -23,7 +23,7 @@ export function MeetingFrequencyChart({ data }: { data: MeetingFrequencyMonth[] 
           <EmptyState
             icon={BarChart2}
             title="まだデータがありません"
-            description="1on1を実施すると、月次実施回数グラフが表示されます"
+            description="1on1を実施すると月次グラフが表示されます。まずはメンバーとの1on1を記録しましょう"
             size="compact"
           />
         ) : (

--- a/src/components/analytics/meeting-heatmap.tsx
+++ b/src/components/analytics/meeting-heatmap.tsx
@@ -47,7 +47,7 @@ export function MeetingHeatmap({ data }: Props) {
           <EmptyState
             icon={Calendar}
             title="まだデータがありません"
-            description="1on1を実施すると、メンバー別の頻度マップが表示されます"
+            description="メンバーと1on1を実施すると、頻度マップが表示されます。まずはメンバーを追加して1on1を始めましょう"
             size="compact"
           />
         ) : (

--- a/src/components/member/__tests__/member-list.test.tsx
+++ b/src/components/member/__tests__/member-list.test.tsx
@@ -27,8 +27,8 @@ const baseMember = {
 describe("MemberList", () => {
   it("renders empty state when no members", () => {
     render(<MemberList members={[]} />);
-    expect(screen.getByText("メンバーがまだ登録されていません")).toBeDefined();
-    expect(screen.getByText("メンバーを追加")).toBeDefined();
+    expect(screen.getByText("最初のメンバーを追加しましょう")).toBeDefined();
+    expect(screen.getByText("メンバーを追加する")).toBeDefined();
   });
 
   it("renders member name and department", () => {

--- a/src/components/member/member-list-page.tsx
+++ b/src/components/member/member-list-page.tsx
@@ -4,6 +4,7 @@ import { Search, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { MemberList } from "@/components/member/member-list";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 
 type MemberWithStats = {
@@ -93,9 +94,11 @@ export function MemberListPage({ members }: Props) {
       </div>
 
       {filtered.length === 0 && members.length > 0 ? (
-        <div className="rounded-xl border bg-card p-12 text-center">
-          <p className="text-muted-foreground">条件に一致するメンバーが見つかりません</p>
-        </div>
+        <EmptyState
+          icon={Users}
+          title="条件に一致するメンバーが見つかりません"
+          description="検索条件やフィルターを変更してお試しください"
+        />
       ) : (
         <MemberList members={filtered} />
       )}

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -62,9 +62,9 @@ export function MemberList({ members }: Props) {
     return (
       <EmptyState
         icon={Users}
-        title="メンバーがまだ登録されていません"
-        description="まずメンバーを追加して、1on1を始めましょう"
-        action={{ label: "メンバーを追加", href: "/members/new" }}
+        title="最初のメンバーを追加しましょう"
+        description="チームメンバーを追加すると、1on1の記録・フォローアップを管理できます"
+        action={{ label: "メンバーを追加する", href: "/members/new" }}
         size="large"
       />
     );

--- a/src/components/ui/__tests__/empty-state.test.tsx
+++ b/src/components/ui/__tests__/empty-state.test.tsx
@@ -64,4 +64,44 @@ describe("EmptyState", () => {
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.className).toContain("py-10");
   });
+
+  describe("variant", () => {
+    it("variant=success のとき data-variant 属性が success になる", () => {
+      const { container } = render(<EmptyState icon={Users} title="完了！" variant="success" />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.getAttribute("data-variant")).toBe("success");
+    });
+
+    it("variant 未指定のとき data-variant 属性が default になる", () => {
+      const { container } = render(<EmptyState icon={Users} title="テスト" />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.getAttribute("data-variant")).toBe("default");
+    });
+  });
+
+  describe("secondaryAction", () => {
+    it("secondaryAction が指定された場合、2つ目のボタンを表示する", () => {
+      render(
+        <EmptyState
+          icon={Users}
+          title="テスト"
+          action={{ label: "メインアクション", href: "/main" }}
+          secondaryAction={{ label: "サブアクション", href: "/sub" }}
+        />,
+      );
+      expect(screen.getByRole("link", { name: "メインアクション" })).toBeDefined();
+      expect(screen.getByRole("link", { name: "サブアクション" })).toBeDefined();
+    });
+
+    it("secondaryAction 未指定の場合、2つ目のボタンは表示しない", () => {
+      render(
+        <EmptyState
+          icon={Users}
+          title="テスト"
+          action={{ label: "メインアクション", href: "/main" }}
+        />,
+      );
+      expect(screen.queryByRole("link", { name: "サブアクション" })).toBeNull();
+    });
+  });
 });

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -15,7 +15,9 @@ type Props = {
   readonly title: string;
   readonly description?: string;
   readonly action?: EmptyStateAction;
+  readonly secondaryAction?: EmptyStateAction;
   readonly size?: "compact" | "default" | "large";
+  readonly variant?: "default" | "success";
 };
 
 const sizeClasses = {
@@ -30,25 +32,57 @@ const iconSizeClasses = {
   large: "w-12 h-12",
 } as const;
 
-export function EmptyState({ icon: Icon, title, description, action, size = "default" }: Props) {
+const iconWrapperVariantClasses = {
+  default: "bg-muted",
+  success: "bg-[oklch(0.95_0.05_155)]",
+} as const;
+
+const iconVariantClasses = {
+  default: "text-muted-foreground",
+  success: "text-[oklch(0.35_0.1_155)]",
+} as const;
+
+function ActionButton({ action }: { readonly action: EmptyStateAction }) {
+  if (action.href) {
+    return (
+      <Link href={action.href}>
+        <Button size="sm">{action.label}</Button>
+      </Link>
+    );
+  }
   return (
-    <div className={cn("flex flex-col items-center justify-center text-center", sizeClasses[size])}>
-      <div className="rounded-full bg-muted p-3 mb-3">
-        <Icon className={cn("text-muted-foreground", iconSizeClasses[size])} strokeWidth={1.5} />
+    <Button size="sm" onClick={action.onClick}>
+      {action.label}
+    </Button>
+  );
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  secondaryAction,
+  size = "default",
+  variant = "default",
+}: Props) {
+  return (
+    <div
+      className={cn("flex flex-col items-center justify-center text-center", sizeClasses[size])}
+      data-variant={variant}
+    >
+      <div className={cn("rounded-full p-3 mb-3", iconWrapperVariantClasses[variant])}>
+        <Icon
+          className={cn(iconSizeClasses[size], iconVariantClasses[variant])}
+          strokeWidth={1.5}
+        />
       </div>
       <p className="text-sm font-medium text-foreground/80">{title}</p>
       {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
-      {action && (
-        <div className="mt-4">
-          {action.href ? (
-            <Link href={action.href}>
-              <Button size="sm">{action.label}</Button>
-            </Link>
-          ) : (
-            <Button size="sm" onClick={action.onClick}>
-              {action.label}
-            </Button>
-          )}
+      {(action ?? secondaryAction) && (
+        <div className="mt-4 flex gap-2">
+          {action && <ActionButton action={action} />}
+          {secondaryAction && <ActionButton action={secondaryAction} />}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 概要

issue #193 の対応。初回利用時やデータが存在しない状態での空状態表示を改善し、次のアクションを明確に示すオンボーディングガイドを実装する。

## 変更内容

### 変更ファイル

- `src/components/ui/empty-state.tsx` — `variant="success"` と `secondaryAction` props を追加して拡張
- `src/components/member/member-list.tsx` — 空状態テキストをオンボーディング向けに改善
- `src/components/member/member-list-page.tsx` — 検索結果0件の表示を EmptyState コンポーネントで統一
- `src/components/action/action-list-full.tsx` — `hasMembers`/`hasFilter` props を追加して3パターンの空状態を実装
- `src/components/action/actions-bulk-container.tsx` — `hasMembers`/`hasFilter` を ActionListFull へ中継
- `src/app/actions/page.tsx` — `hasMembers`/`hasFilter` を ActionsBulkContainer へ渡す
- `src/components/analytics/meeting-frequency-chart.tsx` — 空状態の説明文にオンボーディングガイドを追加
- `src/components/analytics/meeting-heatmap.tsx` — 空状態の説明文にオンボーディングガイドを追加

### テストファイル

- `src/components/ui/__tests__/empty-state.test.tsx` — variant・secondaryAction のテスト追加
- `src/components/action/__tests__/action-list-full.test.tsx` — 3パターン空状態のテスト追加・更新
- `src/components/member/__tests__/member-list.test.tsx` — 新テキスト対応に更新
- `src/components/analytics/__tests__/meeting-frequency-chart.test.tsx` — 新テキスト対応に更新
- `src/components/analytics/__tests__/meeting-heatmap.test.tsx` — 新テキスト対応に更新

## 機能

- **EmptyState 拡張**:
  - `variant="success"` でグリーン系スタイル（達成感の表現）
  - `secondaryAction` でサブCTAボタンを追加可能
- **メンバー一覧の空状態**: 「最初のメンバーを追加しましょう」のガイドとCTAボタン
- **MemberListPage の統一**: 検索結果0件を EmptyState コンポーネントで統一（カスタム div を廃止）
- **アクション一覧の空状態（3パターン）**:
  - メンバー未登録 → 「メンバーを追加して1on1を始めましょう」+ /members/new へのリンク
  - フィルター適用中 → 「条件に一致するアクションアイテムがありません」
  - メンバーあり・フィルタなし → 「すべてのアクションアイテムが完了しています！」（success バリアント）
- **アナリティクスのガイダンス強化**: チャートの空状態にオンボーディング向けの説明文を追加

## テスト計画

- [x] `npm test` — 134 ファイル 1367 テスト全パス（ベースライン比 +8 テスト）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー未登録時にメンバー一覧で「最初のメンバーを追加しましょう」が表示される
- [ ] アクション一覧でフィルタあり0件時に「条件に一致するアクションアイテムがありません」が表示される
- [ ] アクション一覧でフィルタなし0件時に「すべてのアクションアイテムが完了しています！」が表示される
- [ ] アナリティクスページでメンバーなし時に改善されたガイダンス文が表示される

Closes #193