### PR TITLE
feat: メンバー詳細ページに直近チェックインサマリービューを追加する (issue #194)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -8,6 +8,7 @@ import { TopicAnalyticsSection } from "@/components/analytics/topic-analytics-se
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { MeetingHistory } from "@/components/meeting/meeting-history";
 import { CalendarExportButton } from "@/components/member/calendar-export-button";
+import { CheckinSummarySection } from "@/components/member/checkin-summary-section";
 import { MemberActionsDropdown } from "@/components/member/member-actions-dropdown";
 import {
   type MemberDetailTab,
@@ -100,6 +101,8 @@ export default async function MemberDetailPage({ params, searchParams }: Props) 
         pendingActionCount={member.pendingActionItems.length}
         meetingIntervalDays={member.meetingIntervalDays}
       />
+
+      <CheckinSummarySection memberId={id} />
 
       <TopicAnalyticsSection memberId={id} />
       <ActionAnalyticsSection memberId={id} />

--- a/src/components/member/__tests__/checkin-summary.test.tsx
+++ b/src/components/member/__tests__/checkin-summary.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckinSummary } from "../checkin-summary";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CheckinSummary", () => {
+  it("データが空のときは「チェックインデータがありません」を表示する", () => {
+    render(<CheckinSummary data={[]} />);
+    expect(screen.getByText("チェックインデータがありません")).toBeInTheDocument();
+  });
+
+  it("データがあるとき3つの指標ラベルを表示する", () => {
+    const data = [
+      { date: "2026-01-01", health: 4, mood: 3, workload: 2 },
+      { date: "2026-01-08", health: 5, mood: 4, workload: 3 },
+    ];
+    render(<CheckinSummary data={data} />);
+    expect(screen.getByText("体調")).toBeInTheDocument();
+    expect(screen.getByText("気分")).toBeInTheDocument();
+    expect(screen.getByText("負荷")).toBeInTheDocument();
+  });
+
+  it("5件のデータを表示できる", () => {
+    const data = [
+      { date: "2026-01-01", health: 4, mood: 3, workload: 2 },
+      { date: "2026-01-08", health: 5, mood: 4, workload: 3 },
+      { date: "2026-01-15", health: 3, mood: 3, workload: 4 },
+      { date: "2026-01-22", health: 4, mood: 5, workload: 2 },
+      { date: "2026-01-29", health: 2, mood: 2, workload: 5 },
+    ];
+    render(<CheckinSummary data={data} />);
+    // 最新ラベルが表示される
+    expect(screen.getByText("最新")).toBeInTheDocument();
+  });
+
+  it("nullスコアの場合もクラッシュしない", () => {
+    const data = [
+      { date: "2026-01-01", health: null, mood: 3, workload: null },
+      { date: "2026-01-08", health: 5, mood: null, workload: 3 },
+    ];
+    render(<CheckinSummary data={data} />);
+    expect(screen.getByText("体調")).toBeInTheDocument();
+  });
+
+  it("スコア1-2のとき危険色クラスが適用される", () => {
+    const data = [{ date: "2026-01-01", health: 1, mood: 2, workload: 1 }];
+    const { container } = render(<CheckinSummary data={data} />);
+    const dangerDots = container.querySelectorAll("[data-score-level='danger']");
+    expect(dangerDots.length).toBeGreaterThan(0);
+  });
+
+  it("スコア3のとき警告色クラスが適用される", () => {
+    const data = [{ date: "2026-01-01", health: 3, mood: 3, workload: 3 }];
+    const { container } = render(<CheckinSummary data={data} />);
+    const warningDots = container.querySelectorAll("[data-score-level='warning']");
+    expect(warningDots.length).toBeGreaterThan(0);
+  });
+
+  it("スコア4-5のとき良好色クラスが適用される", () => {
+    const data = [{ date: "2026-01-01", health: 4, mood: 5, workload: 4 }];
+    const { container } = render(<CheckinSummary data={data} />);
+    const goodDots = container.querySelectorAll("[data-score-level='good']");
+    expect(goodDots.length).toBeGreaterThan(0);
+  });
+
+  it("1件のデータでも正しく表示される", () => {
+    const data = [{ date: "2026-01-01", health: 4, mood: 3, workload: 2 }];
+    render(<CheckinSummary data={data} />);
+    expect(screen.getByText("体調")).toBeInTheDocument();
+    expect(screen.getByText("最新")).toBeInTheDocument();
+  });
+});

--- a/src/components/member/checkin-summary-section.tsx
+++ b/src/components/member/checkin-summary-section.tsx
@@ -1,0 +1,20 @@
+import { getRecentCheckinSummary } from "@/lib/actions/analytics-actions";
+
+import { CheckinSummary } from "./checkin-summary";
+
+type Props = {
+  memberId: string;
+};
+
+export async function CheckinSummarySection({ memberId }: Props) {
+  const data = await getRecentCheckinSummary(memberId, 5);
+
+  return (
+    <div className="mt-6 animate-fade-in-up stagger-2">
+      <h2 className="text-sm font-semibold tracking-tight mb-3 text-muted-foreground uppercase">
+        直近のチェックイン状態
+      </h2>
+      <CheckinSummary data={data} />
+    </div>
+  );
+}

--- a/src/components/member/checkin-summary.tsx
+++ b/src/components/member/checkin-summary.tsx
@@ -1,0 +1,90 @@
+import type { CheckinTrendEntry } from "@/lib/actions/analytics-actions";
+import { cn } from "@/lib/utils";
+
+type ScoreLevel = "good" | "warning" | "danger" | "none";
+
+function getScoreLevel(score: number | null): ScoreLevel {
+  if (score === null) return "none";
+  if (score <= 2) return "danger";
+  if (score === 3) return "warning";
+  return "good";
+}
+
+function getScoreColorClass(level: ScoreLevel): string {
+  switch (level) {
+    case "good":
+      return "bg-emerald-500/80";
+    case "warning":
+      return "bg-amber-400/80";
+    case "danger":
+      return "bg-destructive/70";
+    case "none":
+      return "bg-muted";
+  }
+}
+
+type ScoreDotProps = {
+  score: number | null;
+  label: string;
+  date: string;
+};
+
+function ScoreDot({ score, label, date }: ScoreDotProps) {
+  const level = getScoreLevel(score);
+  const colorClass = getScoreColorClass(level);
+  const scoreText = score !== null ? `${score}/5` : "データなし";
+
+  return (
+    <div
+      className={cn("w-7 h-7 rounded-full flex items-center justify-center", colorClass)}
+      title={`${date} ${label}: ${scoreText}`}
+      aria-label={`${date} ${label}: ${scoreText}`}
+      data-score-level={level === "none" ? undefined : level}
+    >
+      {score !== null && (
+        <span className="text-[10px] font-medium text-white leading-none">{score}</span>
+      )}
+    </div>
+  );
+}
+
+const ROWS = [
+  { label: "体調", key: "health" as const },
+  { label: "気分", key: "mood" as const },
+  { label: "負荷", key: "workload" as const },
+] as const;
+
+type Props = {
+  data: CheckinTrendEntry[];
+};
+
+export function CheckinSummary({ data }: Props) {
+  if (data.length === 0) {
+    return <p className="text-sm text-muted-foreground">チェックインデータがありません</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {ROWS.map(({ label, key }) => (
+        <div key={key} className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground w-8 shrink-0">{label}</span>
+          <div className="flex gap-1.5 flex-wrap">
+            {data.map((entry, i) => (
+              <ScoreDot key={i} score={entry[key]} label={label} date={entry.date} />
+            ))}
+          </div>
+        </div>
+      ))}
+      <div className="flex items-center gap-2">
+        <span className="w-8 shrink-0" />
+        <div className="flex gap-1.5">
+          {data.map((_, i) => (
+            <span key={i} className="text-[10px] text-muted-foreground w-7 text-center">
+              {i === 0 && data.length > 1 ? "古" : i === data.length - 1 ? "最新" : ""}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/actions/analytics-actions.ts
+++ b/src/lib/actions/analytics-actions.ts
@@ -48,6 +48,32 @@ export async function getCheckinTrend(memberId: string, limit = 12): Promise<Che
   }));
 }
 
+export async function getRecentCheckinSummary(
+  memberId: string,
+  limit = 5,
+): Promise<CheckinTrendEntry[]> {
+  const meetings = await prisma.meeting.findMany({
+    where: {
+      memberId,
+      OR: [
+        { conditionHealth: { not: null } },
+        { conditionMood: { not: null } },
+        { conditionWorkload: { not: null } },
+      ],
+    },
+    orderBy: { date: "desc" },
+    take: limit,
+    select: { date: true, conditionHealth: true, conditionMood: true, conditionWorkload: true },
+  });
+
+  return meetings.reverse().map((m) => ({
+    date: formatDate(m.date),
+    health: m.conditionHealth,
+    mood: m.conditionMood,
+    workload: m.conditionWorkload,
+  }));
+}
+
 export async function getMemberTopicTrends(memberId: string) {
   const topics = await prisma.topic.findMany({
     where: { meeting: { memberId } },


### PR DESCRIPTION
## 概要

issue #194 の対応。メンバー詳細ページにミーティング準備前の状態把握を効率化するため、直近5回分のチェックイン（体調・気分・業務負荷）をカラードットで視覚的に表示するサマリービューを追加する。

## 変更内容

### 新規ファイル
- `src/components/member/checkin-summary.tsx` — チェックインサマリービューコンポーネント（スコアに応じたカラードット表示）
- `src/components/member/checkin-summary-section.tsx` — データ取得を担うサーバーコンポーネント（ラッパー）
- `src/components/member/__tests__/checkin-summary.test.tsx` — ユニットテスト（8件）

### 変更ファイル
- `src/lib/actions/analytics-actions.ts` — `getRecentCheckinSummary` 関数を追加（直近5件を降順取得→昇順で返す）
- `src/app/members/[id]/page.tsx` — MemberStatsBar の直下に CheckinSummarySection を追加

## 機能

- **カラードット表示**: スコアに応じた3色分け
  - 1-2: 赤（危険）
  - 3: 黄（警告）
  - 4-5: 緑（良好）
- **3指標表示**: 体調・気分・業務負荷を各行に表示
- **時系列**: 古→最新の順で左から右に並べ、ラベル表示
- **データなし対応**: チェックイン記録がない場合は「チェックインデータがありません」を表示
- **モバイル対応**: `flex-wrap` レイアウトでスクロールなく表示

## テスト計画

- [x] `npm test` — 136ファイル 1389テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー詳細ページを開き、MemberStatsBar 直下にチェックイン状態が表示されることを確認
- [ ] チェックインデータなしのメンバーで「チェックインデータがありません」が表示されることを確認
- [ ] モバイル幅でレイアウトが崩れないことを確認

Closes #194