### PR TITLE
refactor: Server Actions の Prisma エラー分類処理とユニットテストを追加する (issue #195)

### DIFF
--- a/src/lib/actions/__tests__/types.test.ts
+++ b/src/lib/actions/__tests__/types.test.ts
@@ -1,3 +1,4 @@
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
@@ -117,5 +118,73 @@ describe("runAction", () => {
     });
     expect(consoleSpy).toHaveBeenCalledWith("[Server Action Error]", expect.any(Error));
     consoleSpy.mockRestore();
+  });
+
+  describe("PrismaClientKnownRequestError", () => {
+    it("P2002 (ユニーク制約違反) で「すでに同じ名前のデータが存在します」を返す", async () => {
+      const result = await runAction(async () => {
+        throw new PrismaClientKnownRequestError(
+          "Unique constraint failed on the fields: (`name`)",
+          {
+            code: "P2002",
+            clientVersion: "6.0.0",
+          },
+        );
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("すでに同じ名前のデータが存在します");
+        expect(result.fieldErrors).toBeUndefined();
+      }
+    });
+
+    it("P2025 (レコードが見つからない) で「対象のデータが見つかりません」を返す", async () => {
+      const result = await runAction(async () => {
+        throw new PrismaClientKnownRequestError(
+          "An operation failed because it depends on one or more records that were required but not found.",
+          {
+            code: "P2025",
+            clientVersion: "6.0.0",
+          },
+        );
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("対象のデータが見つかりません");
+        expect(result.fieldErrors).toBeUndefined();
+      }
+    });
+
+    it("その他の Prisma エラーコードでは「データベースエラーが発生しました」を返す", async () => {
+      const result = await runAction(async () => {
+        throw new PrismaClientKnownRequestError(
+          "Foreign key constraint failed on the field: `memberId`",
+          {
+            code: "P2003",
+            clientVersion: "6.0.0",
+          },
+        );
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("データベースエラーが発生しました");
+        expect(result.fieldErrors).toBeUndefined();
+      }
+    });
+
+    it("Prisma エラー発生時に console.error でサーバーサイドログを出力する", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      await runAction(async () => {
+        throw new PrismaClientKnownRequestError("Record not found", {
+          code: "P2025",
+          clientVersion: "6.0.0",
+        });
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[Server Action Error]",
+        expect.any(PrismaClientKnownRequestError),
+      );
+      consoleSpy.mockRestore();
+    });
   });
 });

--- a/src/lib/actions/types.ts
+++ b/src/lib/actions/types.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { ZodError } from "zod";
 
 /**
@@ -10,9 +11,19 @@ export type ActionResult<T = void> =
   | { success: true; data: T }
   | { success: false; error: string; fieldErrors?: Record<string, string[]> };
 
+function toPrismaErrorMessage(err: PrismaClientKnownRequestError): string {
+  if (err.code === "P2002") return "すでに同じ名前のデータが存在します";
+  if (err.code === "P2025") return "対象のデータが見つかりません";
+  return "データベースエラーが発生しました";
+}
+
 /**
  * Server Action のエラーを ActionResult に変換するヘルパー。
  * try-catch ブロックのラッパーとして使用する。
+ * - ZodError: バリデーションエラーとして fieldErrors を付与
+ * - PrismaClientKnownRequestError: エラーコードに応じた日本語メッセージ
+ * - Error: そのメッセージをそのまま返す
+ * - その他: 予期しないエラーメッセージを返す
  */
 export async function runAction<T>(fn: () => Promise<T>): Promise<ActionResult<T>> {
   try {
@@ -31,6 +42,9 @@ export async function runAction<T>(fn: () => Promise<T>): Promise<ActionResult<T
         fieldErrors[field].push(issue.message);
       }
       return { success: false, error: message, fieldErrors };
+    }
+    if (err instanceof PrismaClientKnownRequestError) {
+      return { success: false, error: toPrismaErrorMessage(err) };
     }
     const message = err instanceof Error ? err.message : "予期しないエラーが発生しました";
     return { success: false, error: message };


### PR DESCRIPTION
## 概要

issue #195 の対応。`runAction` ラッパーに `PrismaClientKnownRequestError` の分類処理を追加し、エラーコードに応じた日本語ユーザーメッセージを返すようにした。また `types.test.ts` に Prisma エラーのユニットテストを追加し、全エラー種別のカバレッジを向上させた。

## 変更内容

### 変更ファイル

- `src/lib/actions/types.ts` — `PrismaClientKnownRequestError` のインポートと分類関数 `toPrismaErrorMessage` を追加。`runAction` の catch ブロックに Prisma エラーの分類処理を追加
- `src/lib/actions/__tests__/types.test.ts` — `PrismaClientKnownRequestError` の分類テスト 4 件を追加

## 実装内容

### Prismaエラーの分類処理

| エラーコード | 意味 | ユーザー向けメッセージ |
|---|---|---|
| `P2002` | ユニーク制約違反 | 「すでに同じ名前のデータが存在します」 |
| `P2025` | レコードが見つからない | 「対象のデータが見つかりません」 |
| その他 | その他のDBエラー | 「データベースエラーが発生しました」 |

### テストカバレッジ

追加前: Zod・一般 Error・非 Error オブジェクトのテストのみ
追加後: 上記に加えて Prisma エラー（P2002・P2025・その他）と console.error ログもカバー

## テスト計画

- [x] `npm test` — 136 ファイル 1393 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過

Closes #195