### PR TITLE
refactor: コンポーネントのアクセシビリティ体系的改善（ARIA属性・キーボードナビゲーション統一）(issue #197)

### DIFF
--- a/src/components/action/action-filters.tsx
+++ b/src/components/action/action-filters.tsx
@@ -56,6 +56,7 @@ export function ActionFilters({ members, tags = [] }: Props) {
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           className="pl-9"
+          aria-label="アクション検索"
         />
       </div>
       <div className="flex gap-3 flex-wrap">

--- a/src/components/action/action-list-compact.tsx
+++ b/src/components/action/action-list-compact.tsx
@@ -174,16 +174,19 @@ export function ActionListCompact({ actionItems, meetingId, memberId, enableBulk
                 value={editForm.title}
                 onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
                 placeholder="タイトル"
+                aria-label="タイトル"
               />
               <Input
                 value={editForm.description}
                 onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
                 placeholder="説明"
+                aria-label="説明"
               />
               <Input
                 type="date"
                 value={editForm.dueDate}
                 onChange={(e) => setEditForm({ ...editForm, dueDate: e.target.value })}
+                aria-label="期限"
               />
             </div>
             <div className="flex gap-2 justify-end">
@@ -252,11 +255,13 @@ export function ActionListCompact({ actionItems, meetingId, memberId, enableBulk
               onChange={(e) => setAddForm({ ...addForm, title: e.target.value })}
               placeholder="アクションのタイトル"
               autoFocus
+              aria-label="タイトル"
             />
             <Input
               type="date"
               value={addForm.dueDate}
               onChange={(e) => setAddForm({ ...addForm, dueDate: e.target.value })}
+              aria-label="期限"
             />
           </div>
           <div className="flex gap-2 justify-end">

--- a/src/components/action/action-list-full.tsx
+++ b/src/components/action/action-list-full.tsx
@@ -186,11 +186,13 @@ export function ActionListFull({
                     value={editForm.title}
                     onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
                     placeholder="タイトル"
+                    aria-label="タイトル"
                   />
                   <Input
                     value={editForm.description}
                     onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
                     placeholder="説明"
+                    aria-label="説明"
                   />
                   <DatePicker
                     value={editForm.dueDate}

--- a/src/components/layout/global-search.tsx
+++ b/src/components/layout/global-search.tsx
@@ -17,6 +17,7 @@ export function GlobalSearch() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResults | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const [, startTransition] = useTransition();
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -25,6 +26,7 @@ export function GlobalSearch() {
   const closeDropdown = useCallback(() => {
     setIsOpen(false);
     setResults(null);
+    setActiveIndex(-1);
   }, []);
 
   // Cmd+K / Ctrl+K でフォーカス
@@ -52,6 +54,7 @@ export function GlobalSearch() {
 
   const handleQueryChange = (value: string) => {
     setQuery(value);
+    setActiveIndex(-1);
 
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
@@ -73,11 +76,52 @@ export function GlobalSearch() {
     }, DEBOUNCE_MS);
   };
 
+  // 全アイテムのフラットなリストを構築してキーボードナビゲーションに使用
+  const allItems = results
+    ? [
+        ...results.members.map((m) => ({
+          id: `search-member-${m.id}`,
+          href: `/members/${m.id}`,
+        })),
+        ...results.topics.map((t) => ({
+          id: `search-topic-${t.id}`,
+          href: `/members/${t.memberId}/meetings/${t.meetingId}`,
+        })),
+        ...results.actionItems.map((a) => ({
+          id: `search-action-${a.id}`,
+          href: a.meetingId
+            ? `/members/${a.memberId}/meetings/${a.meetingId}`
+            : `/members/${a.memberId}`,
+        })),
+        ...results.tags.map((tag) => ({
+          id: `search-tag-${tag.id}`,
+          href: `/actions?tag=${tag.id}`,
+        })),
+      ]
+    : [];
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Escape") {
       closeDropdown();
       setQuery("");
       inputRef.current?.blur();
+      return;
+    }
+
+    if (!isOpen || allItems.length === 0) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev + 1) % allItems.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev <= 0 ? allItems.length - 1 : prev - 1));
+    } else if (e.key === "Enter" && activeIndex >= 0) {
+      e.preventDefault();
+      const item = allItems[activeIndex];
+      if (item) {
+        handleNavigate(item.href);
+      }
     }
   };
 
@@ -94,6 +138,9 @@ export function GlobalSearch() {
       results.actionItems.length > 0 ||
       results.tags.length > 0);
 
+  const activeDescendant =
+    activeIndex >= 0 && allItems[activeIndex] ? allItems[activeIndex].id : undefined;
+
   return (
     <div ref={containerRef} className="relative">
       <div className="relative">
@@ -109,6 +156,12 @@ export function GlobalSearch() {
           onChange={(e) => handleQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="検索..."
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls="global-search-results"
+          aria-autocomplete="list"
+          aria-haspopup="listbox"
+          aria-activedescendant={activeDescendant}
           aria-label="グローバル検索"
           className={cn(
             "w-full rounded-md border border-border bg-background py-1.5 pl-8 pr-8 text-sm",
@@ -135,6 +188,7 @@ export function GlobalSearch() {
 
       {isOpen && (
         <div
+          id="global-search-results"
           role="listbox"
           aria-label="検索結果"
           className={cn(
@@ -146,13 +200,15 @@ export function GlobalSearch() {
             <div className="max-h-80 overflow-y-auto py-1">
               {results.members.length > 0 && (
                 <SearchSection label="メンバー">
-                  {results.members.map((member) => (
+                  {results.members.map((member, i) => (
                     <SearchItem
                       key={member.id}
+                      id={`search-member-${member.id}`}
                       icon={<User size={12} />}
                       primary={member.name}
                       secondary={[member.department, member.position].filter(Boolean).join(" · ")}
                       query={query}
+                      isActive={activeIndex === i}
                       onClick={() => handleNavigate(`/members/${member.id}`)}
                     />
                   ))}
@@ -160,13 +216,15 @@ export function GlobalSearch() {
               )}
               {results.topics.length > 0 && (
                 <SearchSection label="話題">
-                  {results.topics.map((topic) => (
+                  {results.topics.map((topic, i) => (
                     <SearchItem
                       key={topic.id}
+                      id={`search-topic-${topic.id}`}
                       icon={<MessageSquare size={12} />}
                       primary={topic.title}
                       secondary={topic.memberName}
                       query={query}
+                      isActive={activeIndex === results.members.length + i}
                       onClick={() =>
                         handleNavigate(`/members/${topic.memberId}/meetings/${topic.meetingId}`)
                       }
@@ -176,13 +234,15 @@ export function GlobalSearch() {
               )}
               {results.actionItems.length > 0 && (
                 <SearchSection label="アクションアイテム">
-                  {results.actionItems.map((item) => (
+                  {results.actionItems.map((item, i) => (
                     <SearchItem
                       key={item.id}
+                      id={`search-action-${item.id}`}
                       icon={<CheckSquare size={12} />}
                       primary={item.title}
                       secondary={item.memberName}
                       query={query}
+                      isActive={activeIndex === results.members.length + results.topics.length + i}
                       onClick={() =>
                         item.meetingId
                           ? handleNavigate(`/members/${item.memberId}/meetings/${item.meetingId}`)
@@ -194,12 +254,20 @@ export function GlobalSearch() {
               )}
               {results.tags.length > 0 && (
                 <SearchSection label="タグ">
-                  {results.tags.map((tag) => (
+                  {results.tags.map((tag, i) => (
                     <SearchItem
                       key={tag.id}
+                      id={`search-tag-${tag.id}`}
                       icon={<Tag size={12} />}
                       primary={tag.name}
                       query={query}
+                      isActive={
+                        activeIndex ===
+                        results.members.length +
+                          results.topics.length +
+                          results.actionItems.length +
+                          i
+                      }
                       onClick={() => handleNavigate(`/actions?tag=${tag.id}`)}
                     />
                   ))}
@@ -227,28 +295,34 @@ function SearchSection({ label, children }: { label: string; children: React.Rea
 }
 
 function SearchItem({
+  id,
   icon,
   primary,
   secondary,
   query,
+  isActive,
   onClick,
 }: {
+  id: string;
   icon: React.ReactNode;
   primary: string;
   secondary?: string;
   query: string;
+  isActive?: boolean;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
+      id={id}
       onClick={onClick}
       role="option"
-      aria-selected="false"
+      aria-selected={isActive ?? false}
       className={cn(
         "flex w-full items-start gap-2.5 px-3 py-2 text-left text-sm",
         "hover:bg-accent hover:text-accent-foreground",
         "cursor-pointer transition-colors",
+        isActive && "bg-accent text-accent-foreground",
       )}
     >
       <span className="mt-0.5 shrink-0 text-muted-foreground">{icon}</span>

--- a/src/components/meeting/__tests__/condition-selector.test.tsx
+++ b/src/components/meeting/__tests__/condition-selector.test.tsx
@@ -23,19 +23,32 @@ describe("ConditionSelector", () => {
     expect(screen.getByText(/業務量/)).toBeInTheDocument();
   });
 
-  it("各軸に5つのボタンが表示されること（合計15ボタン）", () => {
+  it("各軸に5つのラジオボタンが表示されること（合計15ボタン）", () => {
     render(<ConditionSelector {...defaultProps} />);
-    const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(15);
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(15);
+  });
+
+  it("各軸のボタン群が role=radiogroup を持つこと", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    const groups = screen.getAllByRole("radiogroup");
+    expect(groups).toHaveLength(3);
+  });
+
+  it("radiogroup に対応するコンディション軸の aria-label が付くこと", () => {
+    render(<ConditionSelector {...defaultProps} />);
+    expect(screen.getByRole("radiogroup", { name: "体調" })).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: "気分" })).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: "業務量" })).toBeInTheDocument();
   });
 
   it("体調のボタンをクリックすると conditionHealth で onConditionChange が呼ばれること", async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(<ConditionSelector {...defaultProps} onConditionChange={handleChange} />);
-    const buttons = screen.getAllByRole("button");
+    const radios = screen.getAllByRole("radio");
     // 最初の5つが体調ボタン
-    await user.click(buttons[2]); // value=3
+    await user.click(radios[2]); // value=3
     expect(handleChange).toHaveBeenCalledWith("conditionHealth", 3);
   });
 
@@ -43,9 +56,9 @@ describe("ConditionSelector", () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(<ConditionSelector {...defaultProps} onConditionChange={handleChange} />);
-    const buttons = screen.getAllByRole("button");
+    const radios = screen.getAllByRole("radio");
     // 6〜10番目が気分ボタン
-    await user.click(buttons[5]); // value=1
+    await user.click(radios[5]); // value=1
     expect(handleChange).toHaveBeenCalledWith("conditionMood", 1);
   });
 
@@ -53,18 +66,18 @@ describe("ConditionSelector", () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(<ConditionSelector {...defaultProps} onConditionChange={handleChange} />);
-    const buttons = screen.getAllByRole("button");
+    const radios = screen.getAllByRole("radio");
     // 11〜15番目が業務量ボタン
-    await user.click(buttons[10]); // value=1
+    await user.click(radios[10]); // value=1
     expect(handleChange).toHaveBeenCalledWith("conditionWorkload", 1);
   });
 
-  it("選択済みのボタンに aria-pressed=true が付くこと", () => {
+  it("選択済みのボタンに aria-checked=true が付くこと", () => {
     render(<ConditionSelector {...defaultProps} conditionHealth={3} />);
-    const buttons = screen.getAllByRole("button");
+    const radios = screen.getAllByRole("radio");
     // 体調の3番目（index=2）が選択済み
-    expect(buttons[2]).toHaveAttribute("aria-pressed", "true");
-    expect(buttons[0]).toHaveAttribute("aria-pressed", "false");
+    expect(radios[2]).toHaveAttribute("aria-checked", "true");
+    expect(radios[0]).toHaveAttribute("aria-checked", "false");
   });
 
   it("選択済みと同じボタンを再クリックすると null で onConditionChange が呼ばれること", async () => {
@@ -73,9 +86,9 @@ describe("ConditionSelector", () => {
     render(
       <ConditionSelector {...defaultProps} conditionHealth={2} onConditionChange={handleChange} />,
     );
-    const buttons = screen.getAllByRole("button");
+    const radios = screen.getAllByRole("radio");
     // 体調の2番目（index=1）をクリック → null
-    await user.click(buttons[1]);
+    await user.click(radios[1]);
     expect(handleChange).toHaveBeenCalledWith("conditionHealth", null);
   });
 

--- a/src/components/meeting/__tests__/meeting-form.test.tsx
+++ b/src/components/meeting/__tests__/meeting-form.test.tsx
@@ -79,7 +79,7 @@ describe("MeetingForm", () => {
   it("renders condition selector buttons in CheckinSection", () => {
     render(<MeetingForm memberId="m1" />);
     // Condition selector has buttons with aria-label for each axis
-    const healthButtons = screen.getAllByRole("button", { name: /体調:/ });
+    const healthButtons = screen.getAllByRole("radio", { name: /体調:/ });
     expect(healthButtons.length).toBeGreaterThan(0);
   });
 

--- a/src/components/meeting/auto-save-indicator.tsx
+++ b/src/components/meeting/auto-save-indicator.tsx
@@ -29,6 +29,7 @@ export function AutoSaveIndicator({ status, onRetry, onIdle }: Props) {
 
   return (
     <div
+      role="status"
       className={cn(
         "flex items-center gap-1.5 text-xs transition-opacity duration-300",
         status === "saving" && "text-muted-foreground",

--- a/src/components/meeting/checkin-section.tsx
+++ b/src/components/meeting/checkin-section.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { getRandomCheckinMessage } from "@/lib/checkin-messages";
 
@@ -51,21 +52,28 @@ export function CheckinSection({
         <IcebreakerCard />
 
         <div className="space-y-2">
-          <p className="text-sm font-medium text-slate-700">コンディション</p>
-          <ConditionSelector
-            conditionHealth={conditionHealth}
-            conditionMood={conditionMood}
-            conditionWorkload={conditionWorkload}
-            previousConditionHealth={previousConditionHealth}
-            previousConditionMood={previousConditionMood}
-            previousConditionWorkload={previousConditionWorkload}
-            onConditionChange={onConditionChange}
-          />
+          <p id="checkin-condition-label" className="text-sm font-medium text-slate-700">
+            コンディション
+          </p>
+          <div aria-labelledby="checkin-condition-label">
+            <ConditionSelector
+              conditionHealth={conditionHealth}
+              conditionMood={conditionMood}
+              conditionWorkload={conditionWorkload}
+              previousConditionHealth={previousConditionHealth}
+              previousConditionMood={previousConditionMood}
+              previousConditionWorkload={previousConditionWorkload}
+              onConditionChange={onConditionChange}
+            />
+          </div>
         </div>
 
         <div className="space-y-2">
-          <p className="text-sm font-medium text-slate-700">メモ</p>
+          <Label htmlFor="checkin-note" className="text-sm font-medium text-slate-700">
+            メモ
+          </Label>
           <Textarea
+            id="checkin-note"
             value={checkinNote}
             onChange={(e) => onCheckinNoteChange(e.target.value)}
             placeholder="気になることや共有したいことを入力..."

--- a/src/components/meeting/condition-bar.tsx
+++ b/src/components/meeting/condition-bar.tsx
@@ -1,11 +1,23 @@
 export const MAX_CONDITION = 5;
 
-export function ConditionBar({ value }: { value: number }) {
+type Props = {
+  value: number;
+  label?: string;
+};
+
+export function ConditionBar({ value, label }: Props) {
   const clamped = Math.max(0, Math.min(MAX_CONDITION, value));
   const filled = "\u25CF".repeat(clamped);
   const empty = "\u25CB".repeat(MAX_CONDITION - clamped);
   return (
-    <span className="font-mono text-sm">
+    <span
+      role="meter"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={MAX_CONDITION}
+      aria-label={label}
+      className="font-mono text-sm"
+    >
       {filled}
       {empty}（{clamped}/{MAX_CONDITION}）
     </span>

--- a/src/components/meeting/condition-selector.tsx
+++ b/src/components/meeting/condition-selector.tsx
@@ -128,13 +128,14 @@ export function ConditionSelector({
                 </span>
                 <span className="text-xs text-slate-400">{axis.minLabel}</span>
               </div>
-              <div className="flex items-center gap-1">
+              <div role="radiogroup" aria-label={axis.label} className="flex items-center gap-1">
                 {axis.options.map((option) => (
                   <button
                     key={option.value}
                     type="button"
+                    role="radio"
                     aria-label={`${axis.label}: ${option.label}`}
-                    aria-pressed={currentValue === option.value}
+                    aria-checked={currentValue === option.value}
                     onClick={() => handleSelect(axis.field, option.value)}
                     className={`flex h-8 w-8 items-center justify-center rounded-md text-sm font-medium transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-primary ${
                       currentValue === option.value

--- a/src/components/meeting/elapsed-timer.tsx
+++ b/src/components/meeting/elapsed-timer.tsx
@@ -15,7 +15,9 @@ export function ElapsedTimer({ startedAt }: Props) {
     <div className="flex items-center gap-2 text-sm text-muted-foreground">
       <span className="inline-flex h-2 w-2 animate-pulse rounded-full bg-red-500" />
       <Clock className="h-4 w-4" />
-      <span className="font-mono">{formatted}</span>
+      <span role="timer" aria-live="off" aria-label={`経過時間 ${formatted}`} className="font-mono">
+        {formatted}
+      </span>
     </div>
   );
 }

--- a/src/components/meeting/meeting-form.tsx
+++ b/src/components/meeting/meeting-form.tsx
@@ -98,8 +98,10 @@ export function MeetingForm(props: MeetingFormProps) {
         />
 
         <div className="flex flex-col gap-2">
-          <Label>ミーティングの雰囲気</Label>
-          <MoodSelector value={mood} onChange={setMood} />
+          <Label id="mood-label">ミーティングの雰囲気</Label>
+          <div aria-labelledby="mood-label">
+            <MoodSelector value={mood} onChange={setMood} />
+          </div>
           {mood && (
             <p className="text-xs text-muted-foreground">
               選択をもう一度クリックすると解除できます

--- a/src/components/meeting/meeting-prepare.tsx
+++ b/src/components/meeting/meeting-prepare.tsx
@@ -4,6 +4,7 @@ import {
   closestCenter,
   DndContext,
   type DragEndEvent,
+  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
@@ -11,7 +12,7 @@ import {
 import { arrayMove, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { PrepareActionChecklist } from "@/components/meeting/prepare-action-checklist";
@@ -22,6 +23,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import type { MeetingTemplate as DbMeetingTemplate } from "@/generated/prisma/client";
+import {
+  createAnnouncements,
+  screenReaderInstructions,
+  sortableKeyboardCoordinates,
+} from "@/lib/dnd-accessibility";
 import type { MeetingTemplate, TopicCategory } from "@/lib/meeting-templates";
 import { TOAST_MESSAGES } from "@/lib/toast-messages";
 import { cn } from "@/lib/utils";
@@ -88,7 +94,11 @@ export function MeetingPrepare({
   const [isTemplateOpen, setIsTemplateOpen] = useState(false);
   const agendaRef = useRef<HTMLDivElement>(null);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+  const agendaAnnouncements = useMemo(() => createAnnouncements("話題"), []);
 
   function handleTemplateReplace(template: MeetingTemplate) {
     setSelectedTemplateId(template.id);
@@ -257,6 +267,10 @@ export function MeetingPrepare({
                 sensors={sensors}
                 collisionDetection={closestCenter}
                 onDragEnd={handleTopicDragEnd}
+                accessibility={{
+                  announcements: agendaAnnouncements,
+                  screenReaderInstructions,
+                }}
               >
                 <SortableContext
                   items={topics.map((t) => t.id)}

--- a/src/components/meeting/mood-selector.tsx
+++ b/src/components/meeting/mood-selector.tsx
@@ -13,7 +13,7 @@ export function MoodSelector({ value, onChange }: Props) {
   };
 
   return (
-    <div className="flex items-center gap-1">
+    <div role="group" aria-label="ミーティングの雰囲気" className="flex items-center gap-1">
       {MOOD_OPTIONS.map((option) => (
         <button
           key={option.value}

--- a/src/components/meeting/prepare-topic-item.tsx
+++ b/src/components/meeting/prepare-topic-item.tsx
@@ -54,6 +54,11 @@ export function PrepareTopicItem({
     transition,
   };
 
+  const itemId = id || String(index);
+  const categoryId = `prepare-${itemId}-category`;
+  const titleId = `prepare-${itemId}-title`;
+  const notesId = `prepare-${itemId}-notes`;
+
   return (
     <div
       ref={setNodeRef}
@@ -75,9 +80,9 @@ export function PrepareTopicItem({
           <GripVertical className="w-4 h-4" />
         </button>
         <div className="flex-1">
-          <Label>カテゴリ</Label>
+          <Label htmlFor={categoryId}>カテゴリ</Label>
           <Select value={category} onValueChange={(val) => onUpdate(index, "category", val)}>
-            <SelectTrigger>
+            <SelectTrigger id={categoryId}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -90,8 +95,9 @@ export function PrepareTopicItem({
           </Select>
         </div>
         <div className="flex-[2]">
-          <Label>タイトル</Label>
+          <Label htmlFor={titleId}>タイトル</Label>
           <Input
+            id={titleId}
             value={title}
             onChange={(e) => onUpdate(index, "title", e.target.value)}
             placeholder="話題のタイトル"
@@ -111,8 +117,9 @@ export function PrepareTopicItem({
         )}
       </div>
       <div>
-        <Label>メモ</Label>
+        <Label htmlFor={notesId}>メモ</Label>
         <Textarea
+          id={notesId}
           value={notes}
           onChange={(e) => onUpdate(index, "notes", e.target.value)}
           placeholder="事前メモ（任意）"

--- a/src/components/meeting/recording-topic-item.tsx
+++ b/src/components/meeting/recording-topic-item.tsx
@@ -33,6 +33,7 @@ export function RecordingTopicItem({ topic, onNotesChange, onBlur }: Props) {
         placeholder="メモを入力..."
         rows={3}
         className="resize-none"
+        aria-label={`${topic.title}のメモ`}
       />
     </div>
   );

--- a/src/components/meeting/sortable-action-item.tsx
+++ b/src/components/meeting/sortable-action-item.tsx
@@ -53,6 +53,11 @@ export function SortableActionItem({
     transition,
   };
 
+  const itemId = id || String(index);
+  const titleId = `action-${itemId}-title`;
+  const dueDateId = `action-${itemId}-dueDate`;
+  const descriptionId = `action-${itemId}-description`;
+
   function handleTagsChange(newTags: TagData[]) {
     onTagsChange?.(index, newTags);
   }
@@ -76,24 +81,30 @@ export function SortableActionItem({
           <GripVertical className="w-4 h-4" />
         </button>
         <div className="flex-[2]">
-          <Label>タイトル</Label>
+          <Label htmlFor={titleId}>タイトル</Label>
           <Input
+            id={titleId}
             value={title}
             onChange={(e) => onUpdate(index, "title", e.target.value)}
             placeholder="アクションのタイトル"
           />
         </div>
         <div className="flex-1">
-          <Label>期限</Label>
-          <DatePicker value={dueDate} onChange={(value) => onUpdate(index, "dueDate", value)} />
+          <Label htmlFor={dueDateId}>期限</Label>
+          <DatePicker
+            id={dueDateId}
+            value={dueDate}
+            onChange={(value) => onUpdate(index, "dueDate", value)}
+          />
         </div>
         <Button type="button" variant="ghost" size="sm" onClick={() => onRemove(index)}>
           削除
         </Button>
       </div>
       <div>
-        <Label>説明</Label>
+        <Label htmlFor={descriptionId}>説明</Label>
         <Input
+          id={descriptionId}
           value={description}
           onChange={(e) => onUpdate(index, "description", e.target.value)}
           placeholder="詳細（任意）"

--- a/src/components/meeting/sortable-topic-item.tsx
+++ b/src/components/meeting/sortable-topic-item.tsx
@@ -69,6 +69,11 @@ export function SortableTopicItem({
     transition,
   };
 
+  const itemId = id || String(index);
+  const categoryId = `topic-${itemId}-category`;
+  const titleId = `topic-${itemId}-title`;
+  const notesId = `topic-${itemId}-notes`;
+
   function handleTagsChange(newTags: TagData[]) {
     onTagsChange?.(index, newTags);
   }
@@ -92,9 +97,9 @@ export function SortableTopicItem({
           <GripVertical className="w-4 h-4" />
         </button>
         <div className="flex-1">
-          <Label>カテゴリ</Label>
+          <Label htmlFor={categoryId}>カテゴリ</Label>
           <Select value={category} onValueChange={(val) => onUpdate(index, "category", val)}>
-            <SelectTrigger>
+            <SelectTrigger id={categoryId}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -107,8 +112,9 @@ export function SortableTopicItem({
           </Select>
         </div>
         <div className="flex-[2]">
-          <Label>タイトル</Label>
+          <Label htmlFor={titleId}>タイトル</Label>
           <Input
+            id={titleId}
             value={title}
             onChange={(e) => onUpdate(index, "title", e.target.value)}
             placeholder="話題のタイトル"
@@ -142,8 +148,9 @@ export function SortableTopicItem({
       {isExpanded && (
         <>
           <div>
-            <Label>メモ</Label>
+            <Label htmlFor={notesId}>メモ</Label>
             <Textarea
+              id={notesId}
               value={notes}
               onChange={(e) => onUpdate(index, "notes", e.target.value)}
               placeholder="詳細メモ"

--- a/src/components/meeting/template-form-dialog.tsx
+++ b/src/components/meeting/template-form-dialog.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -103,6 +104,7 @@ export function TemplateFormDialog({ template, trigger }: Props) {
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEdit ? "テンプレートを編集" : "テンプレートを作成"}</DialogTitle>
+          <DialogDescription>テンプレートの名前、説明、トピックを設定します。</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-4">
           <div>
@@ -147,7 +149,10 @@ export function TemplateFormDialog({ template, trigger }: Props) {
                       value={topic.category}
                       onValueChange={(val) => updateTopicField(index, "category", val)}
                     >
-                      <SelectTrigger className="h-8 text-xs">
+                      <SelectTrigger
+                        className="h-8 text-xs"
+                        aria-label={`トピック${index + 1}のカテゴリ`}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -164,6 +169,7 @@ export function TemplateFormDialog({ template, trigger }: Props) {
                     onChange={(e) => updateTopicField(index, "title", e.target.value)}
                     placeholder="トピックのタイトル"
                     className="h-8 text-sm flex-1"
+                    aria-label={`トピック${index + 1}のタイトル`}
                   />
                   <Button
                     type="button"

--- a/src/components/member/member-delete-dialog.tsx
+++ b/src/components/member/member-delete-dialog.tsx
@@ -78,7 +78,11 @@ export function MemberDeleteDialog({ memberId, memberName, open: openProp, onOpe
             のデータを削除します。関連するミーティング記録やアクションアイテムもすべて削除されます。この操作は取り消せません。
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <p className="text-sm text-destructive" style={error ? undefined : { display: "none" }}>
+        <p
+          role="alert"
+          className="text-sm text-destructive"
+          style={error ? undefined : { display: "none" }}
+        >
           {error}
         </p>
         <AlertDialogFooter>

--- a/src/components/member/member-detail-tab-nav.tsx
+++ b/src/components/member/member-detail-tab-nav.tsx
@@ -23,6 +23,7 @@ export function MemberDetailTabNav({ memberId, currentTab }: Props) {
       {TABS.map((tab) => (
         <Link
           key={tab.value}
+          id={`tab-${tab.value}`}
           href={`/members/${memberId}?tab=${tab.value}`}
           role="tab"
           aria-selected={currentTab === tab.value}

--- a/src/components/member/member-form.tsx
+++ b/src/components/member/member-form.tsx
@@ -130,7 +130,11 @@ export function MemberForm({ initialData, onSuccess }: Props) {
           ))}
         </select>
       </div>
-      {error && <p className="text-sm text-destructive">{error}</p>}
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
       <div className="flex gap-2">
         <Button type="button" variant="outline" onClick={handleCancel} disabled={isSubmitting}>
           キャンセル

--- a/src/components/tag/__tests__/tag-input.test.tsx
+++ b/src/components/tag/__tests__/tag-input.test.tsx
@@ -20,7 +20,7 @@ afterEach(() => {
 describe("TagInput", () => {
   it("入力フィールドが表示される", () => {
     render(<TagInput selectedTags={[]} onTagsChange={vi.fn()} />);
-    expect(screen.getByRole("textbox")).toBeDefined();
+    expect(screen.getByRole("combobox")).toBeDefined();
   });
 
   it("placeholder が表示される", () => {

--- a/src/components/tag/tag-input.tsx
+++ b/src/components/tag/tag-input.tsx
@@ -115,6 +115,7 @@ export function TagInput({
     suggestions.some((s) => s.name.toLowerCase() === inputValue.trim().toLowerCase());
 
   const showNewTagOption = inputValue.trim().length > 0 && !hasExactMatch;
+  const showSuggestions = isOpen && (suggestions.length > 0 || showNewTagOption);
 
   return (
     <div ref={containerRef} className="relative">
@@ -141,6 +142,11 @@ export function TagInput({
         onChange={(e) => handleInputChange(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
+        role="combobox"
+        aria-expanded={showSuggestions}
+        aria-controls="tag-suggestions"
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
         className={cn(
           "w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm",
           "text-foreground placeholder:text-muted-foreground",
@@ -150,8 +156,9 @@ export function TagInput({
       />
 
       {/* サジェストドロップダウン */}
-      {isOpen && (suggestions.length > 0 || showNewTagOption) && (
+      {showSuggestions && (
         <div
+          id="tag-suggestions"
           role="listbox"
           aria-label="タグの候補"
           className={cn(

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -11,13 +11,20 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { cn } from "@/lib/utils";
 
 interface DatePickerProps {
+  id?: string;
   value?: string;
   onChange: (value: string) => void;
   placeholder?: string;
   className?: string;
 }
 
-function DatePicker({ value, onChange, placeholder = "日付を選択", className }: DatePickerProps) {
+function DatePicker({
+  id,
+  value,
+  onChange,
+  placeholder = "日付を選択",
+  className,
+}: DatePickerProps) {
   const [open, setOpen] = React.useState(false);
 
   const selectedDate = value ? parseISO(value) : undefined;
@@ -35,6 +42,7 @@ function DatePicker({ value, onChange, placeholder = "日付を選択", classNam
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          id={id}
           variant="outline"
           className={cn(
             "w-full justify-start text-left font-normal",

--- a/src/hooks/__tests__/use-meeting-form.test.ts
+++ b/src/hooks/__tests__/use-meeting-form.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/lib/actions/meeting-actions", () => ({
 }));
 
 vi.mock("@/lib/dnd-accessibility", () => ({
+  sortableKeyboardCoordinates: vi.fn(),
   createAnnouncements: vi.fn(() => ({
     onDragStart: vi.fn(() => ""),
     onDragOver: vi.fn(() => ""),

--- a/src/hooks/use-meeting-form.ts
+++ b/src/hooks/use-meeting-form.ts
@@ -23,7 +23,7 @@ import {
 } from "@/components/meeting/meeting-form.types";
 import type { TagData } from "@/components/meeting/sortable-action-item";
 import { createMeeting, updateMeeting } from "@/lib/actions/meeting-actions";
-import { createAnnouncements } from "@/lib/dnd-accessibility";
+import { createAnnouncements, sortableKeyboardCoordinates } from "@/lib/dnd-accessibility";
 import { TOAST_MESSAGES } from "@/lib/toast-messages";
 
 export function useMeetingForm({
@@ -89,7 +89,10 @@ export function useMeetingForm({
   const [showClosingDialog, setShowClosingDialog] = useState(false);
   const errorRef = useRef<HTMLDivElement>(null);
 
-  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
   const topicAnnouncements = useMemo(() => createAnnouncements("話題"), []);
   const actionAnnouncements = useMemo(() => createAnnouncements("アクション"), []);
 

--- a/src/lib/dnd-accessibility.ts
+++ b/src/lib/dnd-accessibility.ts
@@ -1,4 +1,7 @@
 import type { Announcements, ScreenReaderInstructions } from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+
+export { sortableKeyboardCoordinates };
 
 export const screenReaderInstructions: ScreenReaderInstructions = {
   draggable:


### PR DESCRIPTION
## 概要

issue #197 の対応。DnD コンポーネント・モーダルダイアログ・フォーム・カスタムウィジェットのARIA属性・キーボードナビゲーション・フォーカス管理を体系的に改善し、キーボードのみでもアプリを利用できる水準を目指す。

## 変更内容

### 変更ファイル（28ファイル）

#### DnD キーボード操作の改善
- `src/lib/dnd-accessibility.ts` — `sortableKeyboardCoordinates` を export に追加
- `src/hooks/use-meeting-form.ts` — `KeyboardSensor` に `coordinateGetter` を設定（矢印キーでのドラッグ移動）
- `src/components/meeting/meeting-prepare.tsx` — `KeyboardSensor` と `DndContext accessibility` prop を追加

#### モーダル/ダイアログのフォーカス管理
- `src/components/meeting/template-form-dialog.tsx` — `DialogDescription` 追加、トピック入力に `aria-label` を追加

#### フォーム要素の aria-label / htmlFor 設定
- `src/components/meeting/sortable-topic-item.tsx` — Label `htmlFor` と Input/Select の `id` を追加
- `src/components/meeting/sortable-action-item.tsx` — 同上
- `src/components/meeting/prepare-topic-item.tsx` — 同上
- `src/components/meeting/recording-topic-item.tsx` — Textarea に `aria-label` を追加
- `src/components/meeting/checkin-section.tsx` — コンディションラベルと Textarea の `htmlFor`/`id` を設定
- `src/components/meeting/meeting-form.tsx` — 雰囲気ラベルと MoodSelector の `aria-labelledby` を設定
- `src/components/action/action-filters.tsx` — 検索 Input に `aria-label="アクション検索"` を追加
- `src/components/action/action-list-compact.tsx` — インライン編集・追加フォームの Input に `aria-label` を追加
- `src/components/action/action-list-full.tsx` — 同上
- `src/components/member/member-form.tsx` — エラーメッセージに `role="alert"` を追加
- `src/components/member/member-delete-dialog.tsx` — 同上
- `src/components/ui/date-picker.tsx` — `id` prop を追加（Label 紐付けのため）

#### カスタムウィジェットの ARIA 改善
- `src/components/meeting/mood-selector.tsx` — `role="group"` と `aria-label` を追加
- `src/components/meeting/condition-selector.tsx` — `role="radiogroup"` と `role="radio"` + `aria-checked` に変更
- `src/components/meeting/condition-bar.tsx` — `role="meter"` と `aria-valuenow`/`min`/`max`/`label` を追加
- `src/components/meeting/elapsed-timer.tsx` — `role="timer"` と `aria-live="off"` を追加
- `src/components/meeting/auto-save-indicator.tsx` — `role="status"` を追加
- `src/components/layout/global-search.tsx` — combobox パターン適用（`aria-expanded`, `aria-controls`, キーボードナビゲーション実装）
- `src/components/tag/tag-input.tsx` — combobox パターン適用
- `src/components/member/member-detail-tab-nav.tsx` — 各タブに `id="tab-${tab.value}"` を追加

#### テスト修正・追加
- `src/components/meeting/__tests__/condition-selector.test.tsx` — `role="radiogroup"` / `role="radio"` / `aria-checked` に対応したテストを更新・追加
- `src/components/meeting/__tests__/meeting-form.test.tsx` — `getAllByRole("radio")` に変更
- `src/components/tag/__tests__/tag-input.test.tsx` — `getByRole("combobox")` に変更
- `src/hooks/__tests__/use-meeting-form.test.ts` — `sortableKeyboardCoordinates` をモックに追加

## テスト計画

- [x] `npm test` — 136ファイル 1395テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] キーボードのみでDnD（矢印キー）が動作することを手動確認
- [ ] Tab キーでフォーム要素を順番に移動できることを手動確認
- [ ] スクリーンリーダー（VoiceOver）でメインフロー操作を確認

Closes #197