### PR TITLE
feat: メンバー一覧テーブルのソートボタンに aria-sort 属性を追加する (issue #205)

### DIFF
--- a/src/components/member/__tests__/member-list.test.tsx
+++ b/src/components/member/__tests__/member-list.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MemberList } from "../member-list";
@@ -86,5 +86,46 @@ describe("MemberList", () => {
     render(<MemberList members={[baseMember]} />);
     const rows = screen.getAllByRole("link");
     expect(rows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  describe("aria-sort", () => {
+    it("shows aria-sort=ascending on 最終1on1 column by default", () => {
+      const { container } = render(<MemberList members={[baseMember]} />);
+      const ths = container.querySelectorAll("th");
+      const lastMeetingTh = Array.from(ths).find((th) => th.textContent?.includes("最終1on1"));
+      expect(lastMeetingTh?.getAttribute("aria-sort")).toBe("ascending");
+    });
+
+    it("shows aria-sort=none on 未完了 column by default (not active sort)", () => {
+      const { container } = render(<MemberList members={[baseMember]} />);
+      const ths = container.querySelectorAll("th");
+      const actionsTh = Array.from(ths).find((th) => th.textContent?.includes("未完了"));
+      expect(actionsTh?.getAttribute("aria-sort")).toBe("none");
+    });
+
+    it("toggles aria-sort to descending when 最終1on1 is clicked", () => {
+      const { container } = render(<MemberList members={[baseMember]} />);
+      const sortButton = screen.getByRole("button", { name: /最終1on1/ });
+      fireEvent.click(sortButton);
+      const ths = container.querySelectorAll("th");
+      const lastMeetingTh = Array.from(ths).find((th) => th.textContent?.includes("最終1on1"));
+      expect(lastMeetingTh?.getAttribute("aria-sort")).toBe("descending");
+    });
+
+    it("switches active sort to 未完了 column when its button is clicked", () => {
+      const { container } = render(<MemberList members={[baseMember]} />);
+      const actionsButton = screen.getByRole("button", { name: /未完了/ });
+      fireEvent.click(actionsButton);
+      const ths = container.querySelectorAll("th");
+      const actionsTh = Array.from(ths).find((th) => th.textContent?.includes("未完了"));
+      const lastMeetingTh = Array.from(ths).find((th) => th.textContent?.includes("最終1on1"));
+      expect(actionsTh?.getAttribute("aria-sort")).toBe("ascending");
+      expect(lastMeetingTh?.getAttribute("aria-sort")).toBe("none");
+    });
+
+    it("renders sr-only text for screen readers on active sort column", () => {
+      render(<MemberList members={[baseMember]} />);
+      expect(screen.getByText("昇順ソート中")).toBeDefined();
+    });
   });
 });

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowUpDown, Users } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Users } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -100,22 +100,66 @@ export function MemberList({ members }: Props) {
             <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3 hidden sm:table-cell">
               部署
             </TableHead>
-            <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
+            <TableHead
+              aria-sort={
+                sortKey === "lastMeeting"
+                  ? sortDir === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+              }
+              className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3"
+            >
               <button
                 onClick={() => toggleSort("lastMeeting")}
                 className="flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors duration-150"
               >
                 最終1on1
-                <ArrowUpDown className="w-3 h-3" />
+                {sortKey === "lastMeeting" ? (
+                  sortDir === "asc" ? (
+                    <ArrowUp className="w-3 h-3" />
+                  ) : (
+                    <ArrowDown className="w-3 h-3" />
+                  )
+                ) : (
+                  <ArrowUpDown className="w-3 h-3" />
+                )}
+                <span className="sr-only">
+                  {sortKey === "lastMeeting"
+                    ? sortDir === "asc"
+                      ? "昇順ソート中"
+                      : "降順ソート中"
+                    : "ソート可能"}
+                </span>
               </button>
             </TableHead>
-            <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3">
+            <TableHead
+              aria-sort={
+                sortKey === "actions" ? (sortDir === "asc" ? "ascending" : "descending") : "none"
+              }
+              className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3"
+            >
               <button
                 onClick={() => toggleSort("actions")}
                 className="flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors duration-150"
               >
                 未完了
-                <ArrowUpDown className="w-3 h-3" />
+                {sortKey === "actions" ? (
+                  sortDir === "asc" ? (
+                    <ArrowUp className="w-3 h-3" />
+                  ) : (
+                    <ArrowDown className="w-3 h-3" />
+                  )
+                ) : (
+                  <ArrowUpDown className="w-3 h-3" />
+                )}
+                <span className="sr-only">
+                  {sortKey === "actions"
+                    ? sortDir === "asc"
+                      ? "昇順ソート中"
+                      : "降順ソート中"
+                    : "ソート可能"}
+                </span>
               </button>
             </TableHead>
             <TableHead className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-4 py-3 hidden md:table-cell">


### PR DESCRIPTION
## 概要

issue #205 の対応。メンバー一覧テーブルのソート列ヘッダーに `aria-sort` 属性を付与し、スクリーンリーダーへのソート状態通知を改善する。

## 変更内容

### 変更ファイル
- `src/components/member/member-list.tsx` — `<TableHead>` に `aria-sort` 属性・ソート方向アイコン切り替え・`sr-only` テキストを追加
- `src/components/member/__tests__/member-list.test.tsx` — `aria-sort` の動作を検証するテスト 5 件を追加

## 実装内容

- **`aria-sort` 属性**: ソート列の `<th>` に `ascending` / `descending` / `none` を付与
- **アイコン切り替え**: ソート状態に応じて `ArrowUp` / `ArrowDown` / `ArrowUpDown` を表示
- **`sr-only` テキスト**: 「昇順ソート中」「降順ソート中」「ソート可能」をスクリーンリーダー向けに通知

## テスト計画

- [x] `npm test -- src/components/member/__tests__/member-list.test.tsx` — 1 ファイル 14 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] スクリーンリーダー（VoiceOver 等）でソート操作時のアナウンスを確認

Closes #205