### PR TITLE
feat: フィルター結果変更をスクリーンリーダーに通知する aria-live region を追加する (issue #201)

### DIFF
--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -5,6 +5,7 @@ import { ActionListSkeleton } from "@/components/action/action-list-skeleton";
 import { ActionsBulkContainer } from "@/components/action/actions-bulk-container";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { Badge } from "@/components/ui/badge";
+import { FilterResultAnnouncer } from "@/components/ui/filter-result-announcer";
 import { getActionItems } from "@/lib/actions/action-item-actions";
 import { getMembers } from "@/lib/actions/member-actions";
 import { getTags } from "@/lib/actions/tag-actions";
@@ -99,6 +100,11 @@ export default async function ActionsPage({ searchParams }: Props) {
   return (
     <div className="animate-fade-in-up">
       <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "アクション一覧" }]} />
+      <FilterResultAnnouncer
+        count={total}
+        itemLabel="アクション"
+        emptyMessage="該当するアクションが見つかりませんでした"
+      />
       <div className="flex items-center gap-3 mb-6">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">アクション一覧</h1>
         {hasFilter ? (

--- a/src/components/member/__tests__/member-list-page.test.tsx
+++ b/src/components/member/__tests__/member-list-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -129,5 +129,54 @@ describe("MemberListPage", () => {
     const deptSelect = screen.getByRole("combobox", { name: "部署で絞り込む" });
     await user.selectOptions(deptSelect, "エンジニアリング");
     expect(screen.getByText("2人")).toBeDefined();
+  });
+
+  describe("aria-live region", () => {
+    it("aria-live='polite' の通知エリアが存在する", () => {
+      const { container } = render(<MemberListPage members={members} />);
+      const liveRegion = container.querySelector("[aria-live='polite']");
+      expect(liveRegion).not.toBeNull();
+    });
+
+    it("部署フィルタ適用後に件数メッセージが更新される", async () => {
+      const user = userEvent.setup();
+      render(<MemberListPage members={members} />);
+      const deptSelect = screen.getByRole("combobox", { name: "部署で絞り込む" });
+      await user.selectOptions(deptSelect, "エンジニアリング");
+      expect(screen.getByText("2 件のメンバーが見つかりました")).toBeDefined();
+    });
+
+    it("検索入力中は '検索中...' を表示する", () => {
+      vi.useFakeTimers();
+      render(<MemberListPage members={members} />);
+      const searchInput = screen.getByPlaceholderText("名前で検索...");
+      fireEvent.change(searchInput, { target: { value: "田" } });
+      expect(screen.getByText("検索中...")).toBeDefined();
+      vi.useRealTimers();
+    });
+
+    it("デバウンス後に件数メッセージが表示される", () => {
+      vi.useFakeTimers();
+      render(<MemberListPage members={members} />);
+      const searchInput = screen.getByPlaceholderText("名前で検索...");
+      fireEvent.change(searchInput, { target: { value: "田中" } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(screen.getByText("1 件のメンバーが見つかりました")).toBeDefined();
+      vi.useRealTimers();
+    });
+
+    it("0件のとき '該当するメンバーが見つかりませんでした' を表示する", () => {
+      vi.useFakeTimers();
+      render(<MemberListPage members={members} />);
+      const searchInput = screen.getByPlaceholderText("名前で検索...");
+      fireEvent.change(searchInput, { target: { value: "存在しない名前" } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(screen.getByText("該当するメンバーが見つかりませんでした")).toBeDefined();
+      vi.useRealTimers();
+    });
   });
 });

--- a/src/components/member/member-list-page.tsx
+++ b/src/components/member/member-list-page.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { MemberList } from "@/components/member/member-list";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
+import { useDebounce } from "@/hooks/use-debounce";
 
 type MemberWithStats = {
   readonly id: string;
@@ -25,6 +26,8 @@ export function MemberListPage({ members }: Props) {
   const [search, setSearch] = useState("");
   const [department, setDepartment] = useState("");
   const [position, setPosition] = useState("");
+  const debouncedSearch = useDebounce(search, 300);
+  const isSearching = search !== debouncedSearch;
 
   const departments = useMemo(() => {
     const set = new Set(members.map((m) => m.department).filter(Boolean) as string[]);
@@ -45,8 +48,17 @@ export function MemberListPage({ members }: Props) {
     });
   }, [members, search, department, position]);
 
+  const liveMessage = isSearching
+    ? "検索中..."
+    : filtered.length === 0
+      ? "該当するメンバーが見つかりませんでした"
+      : `${filtered.length} 件のメンバーが見つかりました`;
+
   return (
     <div>
+      <div aria-live="polite" className="sr-only">
+        {liveMessage}
+      </div>
       <div className="flex flex-col sm:flex-row gap-3 mb-4">
         <div className="relative flex-1 max-w-xs">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />

--- a/src/components/ui/__tests__/filter-result-announcer.test.tsx
+++ b/src/components/ui/__tests__/filter-result-announcer.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FilterResultAnnouncer } from "../filter-result-announcer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FilterResultAnnouncer", () => {
+  it("aria-live='polite' の通知エリアが存在する", () => {
+    const { container } = render(<FilterResultAnnouncer count={5} itemLabel="アクション" />);
+    const region = container.querySelector("[aria-live='polite']");
+    expect(region).not.toBeNull();
+  });
+
+  it("初回レンダリング時はメッセージが空（通知を発しない）", () => {
+    const { container } = render(<FilterResultAnnouncer count={5} itemLabel="アクション" />);
+    const region = container.querySelector("[aria-live='polite']");
+    // aria-live region は存在するが初回はメッセージが空
+    expect(region?.textContent).toBe("");
+  });
+
+  it("sr-only クラスが付与されている", () => {
+    const { container } = render(<FilterResultAnnouncer count={5} itemLabel="アクション" />);
+    const region = container.querySelector("[aria-live='polite']");
+    expect(region?.className).toContain("sr-only");
+  });
+});

--- a/src/components/ui/filter-result-announcer.tsx
+++ b/src/components/ui/filter-result-announcer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  readonly count: number;
+  readonly itemLabel: string;
+  readonly emptyMessage?: string;
+};
+
+export function FilterResultAnnouncer({ count, itemLabel, emptyMessage }: Props) {
+  const [message, setMessage] = useState("");
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    const id = setTimeout(() => {
+      setMessage(
+        count === 0
+          ? (emptyMessage ?? `該当する${itemLabel}が見つかりませんでした`)
+          : `${count} 件の${itemLabel}が見つかりました`,
+      );
+    }, 0);
+    return () => clearTimeout(id);
+  }, [count, itemLabel, emptyMessage]);
+
+  return (
+    <div aria-live="polite" className="sr-only">
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

issue #201 の対応。検索・フィルター操作でリスト件数が変化した際に、スクリーンリーダーへ変更内容を通知する `aria-live="polite"` リージョンを追加した（WCAG 2.1 SC 4.1.3 準拠）。

## 変更内容

### 新規ファイル
- `src/components/ui/filter-result-announcer.tsx` — アクション一覧ページ（サーバーコンポーネント）向けのクライアント実装。`useRef` で初回レンダリング時の通知を抑制し、件数変化時のみ `aria-live` テキストを更新する。
- `src/components/ui/__tests__/filter-result-announcer.test.tsx` — FilterResultAnnouncer の単体テスト（3件）。

### 変更ファイル
- `src/components/member/member-list-page.tsx` — `useDebounce` を導入し、検索中は「検索中...」、デバウンス完了後に件数または「見つかりません」を `aria-live` リージョンへ出力。
- `src/app/actions/page.tsx` — `FilterResultAnnouncer` を配置して `total` 件数の変化を通知。
- `src/components/member/__tests__/member-list-page.test.tsx` — `aria-live region` の挙動テスト（5件）を追加。`vi.useFakeTimers()` + `fireEvent.change` でデバウンス制御を検証。

## テスト計画

- [x] `npm test` — 140ファイル 1445テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過（lint-staged で確認済み）
- [ ] スクリーンリーダー（VoiceOver等）で実際にアナウンスされることを確認

Closes #201