### PR TITLE
fix: メンバー一覧テーブルで長いテキストが折り返す問題を修正する (issue #203)

### DIFF
--- a/src/components/member/__tests__/member-list.test.tsx
+++ b/src/components/member/__tests__/member-list.test.tsx
@@ -88,6 +88,74 @@ describe("MemberList", () => {
     expect(rows.length).toBeGreaterThanOrEqual(1);
   });
 
+  describe("truncate 対応", () => {
+    it("メンバー名の span に truncate クラスが付与されている", () => {
+      const longNameMember = {
+        ...baseMember,
+        name: "とても長いメンバー名前フルネームテスト用データ",
+      };
+      render(<MemberList members={[longNameMember]} />);
+
+      const nameSpan = screen.getByText(longNameMember.name);
+      expect(nameSpan.className).toContain("truncate");
+    });
+
+    it("メンバー名の span に title 属性が設定されている", () => {
+      const longNameMember = {
+        ...baseMember,
+        name: "とても長いメンバー名前フルネームテスト用データ",
+      };
+      render(<MemberList members={[longNameMember]} />);
+
+      const nameSpan = screen.getByText(longNameMember.name);
+      expect(nameSpan.getAttribute("title")).toBe(longNameMember.name);
+    });
+
+    it("役職に truncate クラスが付与されている", () => {
+      const longPositionMember = {
+        ...baseMember,
+        position: "非常に長い役職名テスト用データシニアプリンシパルエンジニア",
+      };
+      render(<MemberList members={[longPositionMember]} />);
+
+      const positionEl = screen.getByText(longPositionMember.position);
+      expect(positionEl.className).toContain("truncate");
+    });
+
+    it("役職に title 属性が設定されている", () => {
+      const longPositionMember = {
+        ...baseMember,
+        position: "非常に長い役職名テスト用データシニアプリンシパルエンジニア",
+      };
+      render(<MemberList members={[longPositionMember]} />);
+
+      const positionEl = screen.getByText(longPositionMember.position);
+      expect(positionEl.getAttribute("title")).toBe(longPositionMember.position);
+    });
+
+    it("部署に truncate クラスが付与されている", () => {
+      const longDeptMember = {
+        ...baseMember,
+        department: "とても長い部署名テスト用データプロダクトエンジニアリング部門",
+      };
+      render(<MemberList members={[longDeptMember]} />);
+
+      const deptEl = screen.getByText(longDeptMember.department);
+      expect(deptEl.className).toContain("truncate");
+    });
+
+    it("部署に title 属性が設定されている", () => {
+      const longDeptMember = {
+        ...baseMember,
+        department: "とても長い部署名テスト用データプロダクトエンジニアリング部門",
+      };
+      render(<MemberList members={[longDeptMember]} />);
+
+      const deptEl = screen.getByText(longDeptMember.department);
+      expect(deptEl.getAttribute("title")).toBe(longDeptMember.department);
+    });
+  });
+
   describe("aria-sort", () => {
     it("shows aria-sort=ascending on 最終1on1 column by default", () => {
       const { container } = render(<MemberList members={[baseMember]} />);

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -214,18 +214,33 @@ export function MemberList({ members }: Props) {
                 className="hover:bg-muted/50 hover:shadow-sm cursor-pointer transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <TableCell className="px-4 py-3">
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
                     <AvatarInitial name={member.name} size="sm" />
-                    <div>
-                      <span className="font-medium text-sm">{member.name}</span>
+                    <div className="min-w-0">
+                      <span
+                        className="font-medium text-sm block truncate max-w-[180px]"
+                        title={member.name}
+                      >
+                        {member.name}
+                      </span>
                       {member.position && (
-                        <p className="text-xs text-muted-foreground">{member.position}</p>
+                        <p
+                          className="text-xs text-muted-foreground truncate max-w-[180px]"
+                          title={member.position}
+                        >
+                          {member.position}
+                        </p>
                       )}
                     </div>
                   </div>
                 </TableCell>
                 <TableCell className="px-4 py-3 text-sm text-muted-foreground hidden sm:table-cell">
-                  {member.department ?? "—"}
+                  <span
+                    className="block truncate max-w-[120px]"
+                    title={member.department ?? undefined}
+                  >
+                    {member.department ?? "—"}
+                  </span>
                 </TableCell>
                 <TableCell className="px-4 py-3 text-sm text-muted-foreground">
                   {formatRelativeDate(lastDate)}


### PR DESCRIPTION
## 概要

issue #203 の対応。メンバー一覧テーブルで長いテキストがセル幅を超えた際に折り返す問題を修正する。

## 変更内容

- `src/components/member/member-list.tsx`
  - メンバー名カラムの `span` に `truncate max-w-[180px]` を適用
  - メンバー名・役職に `title` 属性を追加（フルテキストのツールチップ表示）
  - 役職（`position`）に `truncate max-w-[180px]` と `title` を適用
  - 部署（`department`）カラムを `span` でラップし `truncate max-w-[120px]` と `title` を適用
  - `flex` コンテナと内側の `div` に `min-w-0` を追加（truncate が正しく機能するための修正）
- `src/components/member/__tests__/member-list.test.tsx`
  - truncate 対応のテストケースを 6 件追加（名前・役職・部署それぞれの truncate クラスと title 属性）

## 受け入れ条件の確認

- [x] メンバー名カラムに `truncate` を適用
- [x] `title` 属性でフルテキストをツールチップ表示（アクセシビリティ対応）
- [x] 役職・部署カラムにも truncate 対応
- [x] 既存テスト 1451 件すべてパス

## テスト計画

- [x] `npm test` — 全 1451 テスト GREEN を確認
- [x] `npm run format:check` — Prettier フォーマット違反なしを確認
- [ ] 長い名前・部署・役職のメンバーでメンバー一覧ページを目視確認
- [ ] モバイル（375px）・タブレット（768px）でレイアウト崩れがないことを確認

Closes #203