### PR TITLE
ux: 非同期処理中に視覚的ローディングスピナーを追加する (issue #204)

### DIFF
--- a/src/components/meeting/meeting-form.tsx
+++ b/src/components/meeting/meeting-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -68,7 +68,7 @@ export function MeetingForm(props: MeetingFormProps) {
 
   return (
     <>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      <form onSubmit={handleSubmit} aria-busy={isSubmitting} className="flex flex-col gap-6">
         <div className="flex items-end justify-between gap-4">
           <div className="flex flex-col gap-2 flex-1">
             <Label htmlFor="date">日付 *</Label>
@@ -81,6 +81,7 @@ export function MeetingForm(props: MeetingFormProps) {
             />
           </div>
           <Button type="submit" variant="outline" disabled={isSubmitting}>
+            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {submitLabel}
           </Button>
         </div>
@@ -146,6 +147,7 @@ export function MeetingForm(props: MeetingFormProps) {
 
         <div className="sticky bottom-0 z-10 bg-background border-t pt-3 pb-3">
           <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {submitLabel}
           </Button>
         </div>

--- a/src/components/meeting/new-meeting-dialog.tsx
+++ b/src/components/meeting/new-meeting-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -28,16 +29,18 @@ type Props = {
 export function NewMeetingDialog({ open, onClose, members }: Props) {
   const router = useRouter();
   const [selectedMemberId, setSelectedMemberId] = useState<string>(members[0]?.id ?? "");
+  const [isNavigating, setIsNavigating] = useState(false);
 
   const handleCreate = () => {
     if (!selectedMemberId) return;
+    setIsNavigating(true);
     onClose();
     router.push(`/members/${selectedMemberId}/meetings/new`);
   };
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-sm">
+      <DialogContent className="sm:max-w-sm" aria-busy={isNavigating}>
         <DialogHeader>
           <DialogTitle className="font-semibold tracking-tight">新規ミーティングを作成</DialogTitle>
           <DialogDescription>ミーティングを作成するメンバーを選択してください。</DialogDescription>
@@ -78,7 +81,8 @@ export function NewMeetingDialog({ open, onClose, members }: Props) {
             キャンセル
           </Button>
           {members.length > 0 && (
-            <Button onClick={handleCreate} disabled={!selectedMemberId}>
+            <Button onClick={handleCreate} disabled={!selectedMemberId || isNavigating}>
+              {isNavigating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               作成
             </Button>
           )}

--- a/src/components/member/member-delete-dialog.tsx
+++ b/src/components/member/member-delete-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trash2 } from "lucide-react";
+import { Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -70,7 +70,7 @@ export function MemberDeleteDialog({ memberId, memberName, open: openProp, onOpe
           削除
         </Button>
       </AlertDialogTrigger>
-      <AlertDialogContent>
+      <AlertDialogContent aria-busy={loading}>
         <AlertDialogHeader>
           <AlertDialogTitle>メンバーを削除しますか？</AlertDialogTitle>
           <AlertDialogDescription>
@@ -88,6 +88,7 @@ export function MemberDeleteDialog({ memberId, memberName, open: openProp, onOpe
         <AlertDialogFooter>
           <AlertDialogCancel disabled={loading}>キャンセル</AlertDialogCancel>
           <Button variant="destructive" onClick={handleDelete} disabled={loading}>
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {loading ? "削除中..." : "削除する"}
           </Button>
         </AlertDialogFooter>

--- a/src/components/member/member-form.tsx
+++ b/src/components/member/member-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -86,7 +87,7 @@ export function MemberForm({ initialData, onSuccess }: Props) {
   }
 
   const content = (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+    <form onSubmit={handleSubmit} aria-busy={isSubmitting} className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
         <Label htmlFor="name">名前 *</Label>
         <Input
@@ -140,6 +141,7 @@ export function MemberForm({ initialData, onSuccess }: Props) {
           キャンセル
         </Button>
         <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {isSubmitting
             ? isEditing
               ? "更新中..."


### PR DESCRIPTION
## 概要

issue #204 の対応。削除・作成・更新などの非同期処理中にテキスト変化のみではなく `Loader2` スピナーアイコン（lucide-react）を表示し、ユーザーへの視覚的フィードバックを改善する。

## 変更内容

### 変更ファイル
- `src/components/member/member-delete-dialog.tsx` — 削除ボタンに `Loader2` スピナー追加、`AlertDialogContent` に `aria-busy` 設定
- `src/components/member/member-form.tsx` — 送信ボタン（登録中/更新中）に `Loader2` スピナー追加、`form` に `aria-busy` 設定
- `src/components/meeting/meeting-form.tsx` — 上部・下部スティッキーの 2 つの送信ボタンに `Loader2` スピナー追加、`form` に `aria-busy` 設定
- `src/components/meeting/new-meeting-dialog.tsx` — `isNavigating` state を追加し、作成ボタンにスピナー追加、`DialogContent` に `aria-busy` 設定

## 変更詳細

各ボタンに以下のパターンを適用:
```tsx
import { Loader2 } from "lucide-react"

<Button disabled={isLoading}>
  {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
  {isLoading ? "処理中..." : "実行する"}
</Button>
```

処理中のコンテナ（`form` / `AlertDialogContent` / `DialogContent`）に `aria-busy={isLoading}` を設定し、スクリーンリーダーへの通知も対応。

## テスト計画

- [x] `vitest run` — 4 ファイル 51 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー削除ダイアログでスピナーが表示されることを手動確認
- [ ] メンバー作成・編集フォームでスピナーが表示されることを手動確認
- [ ] ミーティングフォームの保存/更新ボタンでスピナーが表示されることを手動確認
- [ ] 新規ミーティングダイアログの作成ボタンでスピナーが表示されることを手動確認

Closes #204