### PR TITLE
ux: モバイル可読性向上のため補足テキストのフォントサイズを text-xs から text-sm に変更する (issue #207)

### DIFF
--- a/src/components/dashboard/recent-activity-feed.tsx
+++ b/src/components/dashboard/recent-activity-feed.tsx
@@ -47,7 +47,7 @@ function ActivityRow({ activity }: { readonly activity: ActivityItem }) {
             </>
           )}
         </p>
-        <p className="text-xs text-muted-foreground mt-0.5">{formatRelativeDate(date)}</p>
+        <p className="text-sm text-muted-foreground mt-0.5">{formatRelativeDate(date)}</p>
       </div>
     </Link>
   );

--- a/src/components/dashboard/upcoming-actions-section.tsx
+++ b/src/components/dashboard/upcoming-actions-section.tsx
@@ -36,9 +36,9 @@ function ActionRow({
         <p className="text-sm text-foreground truncate group-hover:text-primary transition-colors">
           {item.title}
         </p>
-        <p className="text-xs text-muted-foreground">{item.memberName}</p>
+        <p className="text-sm text-muted-foreground">{item.memberName}</p>
       </div>
-      <span className="text-xs text-muted-foreground flex-shrink-0">
+      <span className="text-sm text-muted-foreground flex-shrink-0">
         {formatDate(item.dueDate)}
       </span>
     </Link>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -225,7 +225,7 @@ export function MemberList({ members }: Props) {
                       </span>
                       {member.position && (
                         <p
-                          className="text-xs text-muted-foreground truncate max-w-[180px]"
+                          className="text-sm text-muted-foreground truncate max-w-[180px]"
                           title={member.position}
                         >
                           {member.position}
@@ -253,7 +253,7 @@ export function MemberList({ members }: Props) {
                       <span className="text-muted-foreground">—</span>
                     )}
                     {member.overdueActionCount > 0 && (
-                      <p className="text-destructive text-xs">{member.overdueActionCount}件超過</p>
+                      <p className="text-destructive text-sm">{member.overdueActionCount}件超過</p>
                     )}
                   </div>
                 </TableCell>

--- a/src/components/member/member-timeline.tsx
+++ b/src/components/member/member-timeline.tsx
@@ -33,7 +33,7 @@ function MeetingEntryContent({
         </span>
         {mood && <span className="text-lg">{mood.emoji}</span>}
       </div>
-      <div className="mt-1 flex gap-3 text-xs text-muted-foreground">
+      <div className="mt-1 flex gap-3 text-sm text-muted-foreground">
         <span>話題 {entry.topicCount}件</span>
         <span>アクション {entry.actionCount}件</span>
       </div>
@@ -54,7 +54,7 @@ function ActionCompletedContent({
       className="block group rounded-lg border border-border bg-card px-4 py-3 hover:bg-muted/50 transition-colors"
     >
       <p className="text-sm font-medium text-foreground group-hover:text-primary">{entry.title}</p>
-      <p className="mt-1 text-xs text-muted-foreground">完了日: {formatDate(entry.completedAt)}</p>
+      <p className="mt-1 text-sm text-muted-foreground">完了日: {formatDate(entry.completedAt)}</p>
     </Link>
   );
 }
@@ -74,7 +74,7 @@ function ActionOverdueContent({
       <p className="text-sm font-medium text-foreground group-hover:text-destructive">
         {entry.title}
       </p>
-      <p className="mt-1 text-xs text-destructive/80">期日: {formatDate(entry.dueDate)}</p>
+      <p className="mt-1 text-sm text-destructive/80">期日: {formatDate(entry.dueDate)}</p>
     </Link>
   );
 }


### PR DESCRIPTION
## 概要

issue #207 の対応。モバイルデバイスでの最小推奨フォントサイズ 14px（WCAG 参考値）に合わせるため、補足テキスト・日付表示・役職名など本文系の情報に使われていた `text-xs`（12px）を `text-sm`（14px）へ変更する。

バッジ内（空間的制約あり）やテーブルヘッダーの `uppercase tracking-wider` 装飾ラベルは `text-xs` を維持する。

## 変更内容

### 変更ファイル
- `src/components/member/member-list.tsx` — 役職テキスト・超過件数テキストを `text-xs` → `text-sm`
- `src/components/dashboard/upcoming-actions-section.tsx` — メンバー名・期限日付テキストを `text-xs` → `text-sm`
- `src/components/dashboard/recent-activity-feed.tsx` — 相対時間表示を `text-xs` → `text-sm`
- `src/components/member/member-timeline.tsx` — 話題/アクション件数・完了日・期日テキストを `text-xs` → `text-sm`

## テスト計画

- [x] `npm test` — 141ファイル 1453テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過（lint-staged で確認）
- [ ] モバイル（375px width）でメンバー一覧・ダッシュボード・タイムラインページをビジュアルチェック
- [ ] フォントサイズ変更によるレイアウト崩れがないことを確認

Closes #207