### PR TITLE
fix: UI変更に伴いE2Eテストのセレクタを修正する

### DIFF
--- a/e2e/action-filters.spec.ts
+++ b/e2e/action-filters.spec.ts
@@ -29,10 +29,11 @@ test.describe("アクションフィルタリング", () => {
 
   /**
    * メンバーフィルターのコンボボックスを取得する
-   * ActionFilters の SelectTrigger は w-44 クラスを持つ
+   * ActionFilters には w-44 の SelectTrigger が2つ（グループ化・メンバー）あるため
+   * 2番目（nth(1)）を取得する
    */
   function getMemberFilter(page: import("@playwright/test").Page) {
-    return page.locator("main button[role='combobox'].w-44");
+    return page.locator("main button[role='combobox'].w-44").nth(1);
   }
 
   test("フィルターUIが表示される", async ({ page }) => {

--- a/e2e/actions.spec.ts
+++ b/e2e/actions.spec.ts
@@ -23,7 +23,7 @@ test.describe("アクションアイテム", () => {
     await page.getByPlaceholder("アクションのタイトル").first().fill(actionTitle);
 
     // 保存ボタンをクリック → ClosingDialog が表示されるので確認する
-    await page.getByRole("button", { name: "1on1を保存" }).click();
+    await page.getByRole("button", { name: "1on1を保存" }).first().click();
     await confirmSaveMeeting(page);
     await expect(page.getByRole("heading", { name: memberName })).toBeVisible({ timeout: 15000 });
   }
@@ -83,16 +83,16 @@ test.describe("アクションアイテム", () => {
     await expect(page.getByText(actionTitle)).toBeVisible({ timeout: 10000 });
 
     // アクションアイテムのカード内のステータスセレクトを見つける
-    // ActionListFull のカード構造: Card > CardContent > div(flex) > Select + div(info)
-    const actionCard = page
-      .locator("main")
-      .locator("div")
+    // ActionListFull のカード構造: Card > CardContent > div(flex) > Select(w-28) + div(info)
+    // アクション名を含む Card 要素内の combobox を探す
+    const actionCardElement = page
+      .locator("main [class*='card']")
       .filter({ hasText: actionTitle })
-      .locator("button[role='combobox']")
       .first();
+    const statusCombobox = actionCardElement.locator("button[role='combobox']");
 
-    if (await actionCard.isVisible()) {
-      await actionCard.click();
+    if (await statusCombobox.isVisible()) {
+      await statusCombobox.click();
 
       // 「進行中」を選択
       await page.getByRole("option", { name: "進行中" }).click();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -103,7 +103,7 @@ export async function createMeetingFromDetail(
   }
 
   // 保存ボタンをクリック → ClosingDialog が表示されるので確認する
-  await page.getByRole("button", { name: "1on1を保存" }).click();
+  await page.getByRole("button", { name: "1on1を保存" }).first().click();
   await confirmSaveMeeting(page);
   await expect(page.getByRole("heading", { name: memberName })).toBeVisible({ timeout: 15000 });
 }
@@ -113,6 +113,10 @@ export async function createMeetingFromDetail(
  * 事前にメンバー詳細ページにいて、ミーティングが存在することが前提
  */
 export async function navigateToFirstMeetingDetail(page: Page, memberName: string) {
+  // デフォルトタブが「タイムライン」なので「1on1履歴」タブに切り替える
+  await page.getByRole("tab", { name: "1on1履歴" }).click();
+  await page.waitForURL(/tab=history/, { timeout: 10000 });
+
   const meetingCards = page.locator(
     "main a[href*='/meetings/']:not([href$='/new']):not([href$='/prepare'])",
   );
@@ -122,6 +126,17 @@ export async function navigateToFirstMeetingDetail(page: Page, memberName: strin
   await expect(page.getByRole("heading", { name: `${memberName}との1on1` })).toBeVisible({
     timeout: 10000,
   });
+}
+
+/**
+ * ミーティング詳細ページの「...」メニューから削除ダイアログを開く
+ * MeetingHeaderActions の DropdownMenu を操作する
+ */
+export async function openMeetingDeleteDialog(page: Page) {
+  // Radix UI DropdownMenuTrigger: data-slot="dropdown-menu-trigger" 属性を持つボタン
+  const menuTrigger = page.locator("button[data-slot='dropdown-menu-trigger']");
+  await menuTrigger.click();
+  await page.getByRole("menuitem", { name: "削除" }).click();
 }
 
 /**

--- a/e2e/meeting-delete.spec.ts
+++ b/e2e/meeting-delete.spec.ts
@@ -4,6 +4,7 @@ import {
   createMeetingFromDetail,
   createMemberAndNavigateToDetail,
   navigateToFirstMeetingDetail,
+  openMeetingDeleteDialog,
 } from "./helpers";
 
 test.describe("ミーティング削除", () => {
@@ -13,8 +14,8 @@ test.describe("ミーティング削除", () => {
     await createMeetingFromDetail(page, memberName, { topicTitle: "削除テスト用話題" });
     await navigateToFirstMeetingDetail(page, memberName);
 
-    // 削除ボタンをクリック
-    await page.getByRole("button", { name: "削除" }).click();
+    // 「...」ドロップダウンメニューを開いて「削除」を選択
+    await openMeetingDeleteDialog(page);
 
     // 削除確認ダイアログが表示される
     await expect(page.getByText("ミーティングを削除しますか？")).toBeVisible();
@@ -27,8 +28,8 @@ test.describe("ミーティング削除", () => {
     await createMeetingFromDetail(page, memberName, { topicTitle: "キャンセルテスト話題" });
     await navigateToFirstMeetingDetail(page, memberName);
 
-    // 削除ダイアログを開く
-    await page.getByRole("button", { name: "削除" }).click();
+    // 「...」ドロップダウンメニューを開いて「削除」を選択
+    await openMeetingDeleteDialog(page);
     await expect(page.getByText("ミーティングを削除しますか？")).toBeVisible();
 
     // キャンセル
@@ -47,8 +48,8 @@ test.describe("ミーティング削除", () => {
     await createMeetingFromDetail(page, memberName, { topicTitle: "削除される話題" });
     await navigateToFirstMeetingDetail(page, memberName);
 
-    // 削除ダイアログを開く
-    await page.getByRole("button", { name: "削除" }).click();
+    // 「...」ドロップダウンメニューを開いて「削除」を選択
+    await openMeetingDeleteDialog(page);
     await expect(page.getByText("ミーティングを削除しますか？")).toBeVisible();
 
     // 削除を実行

--- a/e2e/meeting-prepare.spec.ts
+++ b/e2e/meeting-prepare.spec.ts
@@ -21,17 +21,14 @@ test.describe("ミーティング準備", () => {
     await page.getByRole("link", { name: "1on1 を準備" }).click();
     await expect(page.getByRole("heading", { name: `${memberName}との1on1 準備` })).toBeVisible();
 
-    // アジェンダセクションが表示される（exact: true でメンバー名とのマッチを防ぐ）
+    // アジェンダセクションが表示される（CardTitle として表示）
     await expect(page.getByText("アジェンダ", { exact: true })).toBeVisible();
 
-    // テンプレートセクションが表示される
-    await expect(page.getByRole("heading", { name: "テンプレート" })).toBeVisible();
+    // テンプレートセクションが表示される（CardTitle: "テンプレートを適用"）
+    await expect(page.getByText("テンプレートを適用")).toBeVisible();
 
-    // 未完了アクションセクションが表示される
-    await expect(page.getByText("未完了アクション", { exact: true })).toBeVisible();
-
-    // 過去のミーティングセクションが表示される
-    await expect(page.getByText("過去のミーティング", { exact: true })).toBeVisible();
+    // 前回の振り返りセクションが表示される
+    await expect(page.getByText("前回の振り返り")).toBeVisible();
   });
 
   test("アジェンダに話題を追加・削除できる", async ({ page }) => {
@@ -55,7 +52,8 @@ test.describe("ミーティング準備", () => {
     await topicInputs.nth(1).fill("2つ目の話題");
 
     // 削除ボタンが表示される（2つ以上の場合のみ）
-    const deleteButtons = page.getByRole("button", { name: "削除" });
+    // PrepareTopicItem の aria-label は「{title}を削除」の形式
+    const deleteButtons = page.getByRole("button", { name: /を削除$/ });
     await expect(deleteButtons.first()).toBeVisible();
 
     // 1つ目の話題を削除
@@ -75,8 +73,8 @@ test.describe("ミーティング準備", () => {
     // 話題を入力
     await page.getByPlaceholder("話題のタイトル").first().fill("準備した話題");
 
-    // ミーティングを開始ボタンをクリック
-    await page.getByRole("link", { name: /ミーティングを開始/ }).click();
+    // 記録を開始ボタンをクリック
+    await page.getByRole("link", { name: /記録を開始/ }).click();
 
     // ミーティング作成ページの URL に遷移するのを待つ（/meetings/new を含む）
     await page.waitForURL(/\/meetings\/new/, { timeout: 15000 });
@@ -116,7 +114,7 @@ test.describe("ミーティング準備", () => {
     await page.getByRole("link", { name: "1on1 を準備" }).click();
     await expect(page.getByRole("heading", { name: `${memberName}との1on1 準備` })).toBeVisible();
 
-    // 過去のミーティングセクションにデータが表示される
-    await expect(page.getByText("過去のミーティング")).toBeVisible();
+    // 前回の振り返りセクションにデータが表示される
+    await expect(page.getByText("前回の振り返り")).toBeVisible();
   });
 });

--- a/e2e/meetings.spec.ts
+++ b/e2e/meetings.spec.ts
@@ -31,14 +31,14 @@ test.describe("ミーティング管理", () => {
     await page.getByPlaceholder("話題のタイトル").first().fill("プロジェクト進捗");
 
     // 保存ボタンをクリック → ClosingDialog が表示されるので確認する
-    await page.getByRole("button", { name: "1on1を保存" }).click();
+    await page.getByRole("button", { name: "1on1を保存" }).first().click();
     await confirmSaveMeeting(page);
 
     // メンバー詳細ページに遷移
     await expect(page.getByRole("heading", { name: memberName })).toBeVisible({ timeout: 15000 });
 
-    // 1on1履歴が表示される
-    await expect(page.getByRole("heading", { name: "1on1履歴" })).toBeVisible();
+    // 1on1履歴タブが表示される
+    await expect(page.getByRole("tab", { name: "1on1履歴" })).toBeVisible();
   });
 
   test("ミーティングにトピックを追加できる", async ({ page }) => {
@@ -62,7 +62,7 @@ test.describe("ミーティング管理", () => {
     await topicInputs.nth(1).fill("2つ目の話題");
 
     // 保存ボタンをクリック → ClosingDialog が表示されるので確認する
-    await page.getByRole("button", { name: "1on1を保存" }).click();
+    await page.getByRole("button", { name: "1on1を保存" }).first().click();
     await confirmSaveMeeting(page);
 
     // メンバー詳細ページに遷移
@@ -90,7 +90,7 @@ test.describe("ミーティング管理", () => {
     await actionTitleInput.first().fill("テストレポートを作成する");
 
     // 保存ボタンをクリック → ClosingDialog が表示されるので確認する
-    await page.getByRole("button", { name: "1on1を保存" }).click();
+    await page.getByRole("button", { name: "1on1を保存" }).first().click();
     await confirmSaveMeeting(page);
 
     // メンバー詳細ページに遷移
@@ -108,9 +108,13 @@ test.describe("ミーティング管理", () => {
     await page.getByRole("link", { name: "新規1on1" }).click();
     await page.getByPlaceholder("話題のタイトル").first().fill("詳細表示テスト用トピック");
     // 保存ボタンをクリック → ClosingDialog が表示されるので確認する
-    await page.getByRole("button", { name: "1on1を保存" }).click();
+    await page.getByRole("button", { name: "1on1を保存" }).first().click();
     await confirmSaveMeeting(page);
     await expect(page.getByRole("heading", { name: memberName })).toBeVisible({ timeout: 15000 });
+
+    // デフォルトタブが「タイムライン」なので「1on1履歴」タブに切り替える
+    await page.getByRole("tab", { name: "1on1履歴" }).click();
+    await page.waitForURL(/tab=history/, { timeout: 10000 });
 
     // 1on1履歴セクションの最初のリンクをクリック
     // "new" や "prepare" を除く実際のミーティングリンクを対象にする

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -59,11 +59,11 @@ test.describe("メンバー管理", () => {
     await expect(page.getByRole("heading", { name: memberName })).toBeVisible();
     await expect(page.getByText("プロダクト部 / PM")).toBeVisible();
 
-    // 1on1履歴セクションが表示される
-    await expect(page.getByRole("heading", { name: "1on1履歴" })).toBeVisible();
+    // 1on1履歴タブが表示される
+    await expect(page.getByRole("tab", { name: "1on1履歴" })).toBeVisible();
 
-    // アクションアイテムセクションが表示される
-    await expect(page.getByRole("heading", { name: "アクションアイテム" })).toBeVisible();
+    // アクションアイテムタブが表示される
+    await expect(page.getByRole("tab", { name: "アクションアイテム" })).toBeVisible();
 
     // 新規1on1ボタンが表示される
     await expect(page.getByRole("link", { name: "新規1on1" })).toBeVisible();

--- a/e2e/simulation.spec.ts
+++ b/e2e/simulation.spec.ts
@@ -51,7 +51,7 @@ test.describe("一連の業務フローシミュレーション", () => {
     await actionTitleInput.first().fill(newActionTitle);
 
     // 保存ボタンをクリック → ClosingDialog が表示されるので確認する
-    await page.getByRole("button", { name: "1on1を保存" }).click();
+    await page.getByRole("button", { name: "1on1を保存" }).first().click();
     await confirmSaveMeeting(page);
     await expect(page.getByRole("heading", { name: memberName })).toBeVisible({ timeout: 15000 });
 
@@ -65,15 +65,14 @@ test.describe("一連の業務フローシミュレーション", () => {
     await expect(page.getByText(newActionTitle)).toBeVisible({ timeout: 10000 });
 
     // 5. アクションのステータスを「完了」に変更する
-    const actionCard = page
-      .locator("main")
-      .locator("div")
+    const actionCardElement = page
+      .locator("main [class*='card']")
       .filter({ hasText: newActionTitle })
-      .locator("button[role='combobox']")
       .first();
+    const statusCombobox = actionCardElement.locator("button[role='combobox']");
 
-    if (await actionCard.isVisible()) {
-      await actionCard.click();
+    if (await statusCombobox.isVisible()) {
+      await statusCombobox.click();
       await page.getByRole("option", { name: "完了" }).click();
 
       // リロードして反映を確認


### PR DESCRIPTION
## 概要

直近のUI変更（タブUI、保存ボタンの複数配置、ドロップダウンメニュー化など）によって壊れていた E2E テストを修正。49テスト全てが通過することを確認した。

## 変更内容

### 変更ファイル
- `e2e/helpers.ts` — 保存ボタンに `.first()` 追加、タブ切り替え処理追加、`openMeetingDeleteDialog` ヘルパー関数を追加
- `e2e/meetings.spec.ts` — 保存ボタン `.first()` 追加、`heading` → `tab` ロールに変更
- `e2e/actions.spec.ts` — 保存ボタン `.first()` 追加、combobox ロケータをユニーク化
- `e2e/simulation.spec.ts` — 保存ボタン `.first()` 追加、combobox ロケータをユニーク化
- `e2e/members.spec.ts` — `getByRole("heading")` → `getByRole("tab")` に変更
- `e2e/meeting-prepare.spec.ts` — セクション名・ボタン名を現在のUIに合わせて更新
- `e2e/action-filters.spec.ts` — フィルターロケータを `.nth(1)` でユニーク化
- `e2e/meeting-delete.spec.ts` — ドロップダウン経由の削除ダイアログ操作に変更

## 修正した問題

| 根本原因 | 修正件数 |
|---------|---------|
| `meeting-form.tsx` の保存ボタンが2箇所（strict mode violation） | 15件 |
| メンバー詳細ページのタブUI変更 | 1件 |
| 準備ページ・フィルターUIの構造変更 | 5件 |

## テスト計画

- [x] `npm run test:e2e` — 49テスト全パス (2.4m)
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過