### PR TITLE
fix: 新規ミーティング作成画面の React Hydration エラーを修正する (issue #245)

### DIFF
--- a/src/components/action/__tests__/action-list-compact.test.tsx
+++ b/src/components/action/__tests__/action-list-compact.test.tsx
@@ -44,7 +44,7 @@ const baseItems = [
     title: "テストタスク1",
     description: "説明1",
     status: "TODO",
-    dueDate: new Date("2026-03-01"),
+    dueDate: new Date("2099-12-31"),
     meeting: { date: new Date("2026-02-15") },
   },
   {

--- a/src/components/action/__tests__/action-list-full.test.tsx
+++ b/src/components/action/__tests__/action-list-full.test.tsx
@@ -42,7 +42,7 @@ const baseItems = [
     title: "レビュー依頼",
     description: "PRのレビューをする",
     status: "TODO",
-    dueDate: new Date("2026-03-01"),
+    dueDate: new Date("2099-12-31"),
     member: { id: "member-1", name: "田中太郎" },
     meeting: { id: "meeting-1", date: new Date("2026-02-15") },
   },

--- a/src/hooks/use-meeting-form.ts
+++ b/src/hooks/use-meeting-form.ts
@@ -9,7 +9,7 @@ import {
 } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { useRouter } from "next/navigation";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import type { ConditionField } from "@/components/meeting/condition-selector";
@@ -37,10 +37,15 @@ export function useMeetingForm({
   const isEditing = !!initialData;
 
   const [date, setDate] = useState(
-    initialData
-      ? new Date(initialData.date).toISOString().split("T")[0]
-      : new Date().toISOString().split("T")[0],
+    initialData ? new Date(initialData.date).toISOString().split("T")[0] : "",
   );
+
+  useEffect(() => {
+    if (!initialData) {
+      setDate(new Date().toISOString().split("T")[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [topics, setTopics] = useState<TopicFormData[]>(
     initialData


### PR DESCRIPTION
## 概要

issue #245 の対応。新規 1on1 作成ページ（`/members/[id]/meetings/new`）で発生していた React Hydration エラーを修正する。

`use-meeting-form.ts` の `useState` 初期値に `new Date()` を使用していたため、SSR 実行時刻とクライアントハイドレーション時刻の差異により HTML 不一致が生じていた。

## 変更内容

### 変更ファイル

- `src/hooks/use-meeting-form.ts` — date の初期値を空文字列に変更し、`useEffect` でクライアント側でのみ現在日付をセットするよう修正
- `src/components/action/__tests__/action-list-compact.test.tsx` — `baseItems` の `dueDate` が現在日付の3日以内に入り「もうすぐ期限」バッジが表示されるためテストが失敗していた問題を修正（日付を 2099-12-31 に変更）
- `src/components/action/__tests__/action-list-full.test.tsx` — 同上

## 修正内容の詳細

```typescript
// Before: SSR/CSR で時刻が異なり Hydration エラーが発生
const [date, setDate] = useState(
  initialData
    ? new Date(initialData.date).toISOString().split("T")[0]
    : new Date().toISOString().split("T")[0],  // ← SSR と CSR で値が異なる
);

// After: SSR/CSR ともに "" で一致 → Hydration エラー解消
const [date, setDate] = useState(
  initialData ? new Date(initialData.date).toISOString().split("T")[0] : "",
);

useEffect(() => {
  if (!initialData) {
    setDate(new Date().toISOString().split("T")[0]);  // ← クライアント側でのみ実行
  }
  // eslint-disable-next-line react-hooks/exhaustive-deps
}, []);
```

## テスト計画

- [x] `npm test` — 141 ファイル 1459 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] 開発サーバー起動後、`/members/[id]/meetings/new` を開きブラウザの DevTools console に Hydration エラーが出ないことを確認
- [ ] 日付フィールドに当日日付が正しく表示されることを確認
- [ ] 編集モード（`initialData` あり）で日付フィールドが正しく表示されることを確認

Closes #245