### PR TITLE
fix: recharts の width(-1) height(-1) 警告を解消する (issue #244)

### DIFF
--- a/src/components/analytics/action-completion-trend-chart.tsx
+++ b/src/components/analytics/action-completion-trend-chart.tsx
@@ -20,7 +20,18 @@ export function ActionCompletionTrendChart({ data }: { data: ActionMonthlyTrend[
   const mounted = useChartMounted();
   const prefersReducedMotion = useReducedMotion();
 
-  if (!mounted) return null;
+  if (!mounted) {
+    return (
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">月次完了トレンド</CardTitle>
+        </CardHeader>
+        <CardContent className="h-[250px] w-full pt-4">
+          <div className="h-full w-full animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className="h-full">

--- a/src/components/analytics/checkin-trend-chart.tsx
+++ b/src/components/analytics/checkin-trend-chart.tsx
@@ -22,7 +22,18 @@ export function CheckinTrendChart({ data }: { data: CheckinTrendEntry[] }) {
   const mounted = useChartMounted();
   const prefersReducedMotion = useReducedMotion();
 
-  if (!mounted) return null;
+  if (!mounted) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">チェックイン状態の推移</CardTitle>
+        </CardHeader>
+        <CardContent className="h-[260px] w-full pt-4">
+          <div className="h-full w-full animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card>

--- a/src/components/analytics/meeting-frequency-chart.tsx
+++ b/src/components/analytics/meeting-frequency-chart.tsx
@@ -13,7 +13,18 @@ export function MeetingFrequencyChart({ data }: { data: MeetingFrequencyMonth[] 
   const mounted = useChartMounted();
   const prefersReducedMotion = useReducedMotion();
 
-  if (!mounted) return null;
+  if (!mounted) {
+    return (
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">月次1on1実施回数</CardTitle>
+        </CardHeader>
+        <CardContent className="h-[250px] w-full pt-4">
+          <div className="h-full w-full animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className="h-full">

--- a/src/components/analytics/topic-distribution-chart.tsx
+++ b/src/components/analytics/topic-distribution-chart.tsx
@@ -40,7 +40,19 @@ export function TopicDistributionChart({ data }: Props) {
     }));
   }, [data]);
 
-  if (!mounted) return null;
+  if (!mounted) {
+    return (
+      <Card className="h-full flex flex-col">
+        <CardHeader>
+          <CardTitle>話題カテゴリの分布</CardTitle>
+          <CardDescription>これまでの1on1で話された話題の割合</CardDescription>
+        </CardHeader>
+        <CardContent className="flex-1 h-[250px]">
+          <div className="h-full w-full animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    );
+  }
 
   if (data.length === 0) {
     return (
@@ -62,7 +74,7 @@ export function TopicDistributionChart({ data }: Props) {
         <CardTitle>話題カテゴリの分布</CardTitle>
         <CardDescription>これまでの1on1で話された話題の割合</CardDescription>
       </CardHeader>
-      <CardContent className="flex-1 min-h-[250px] relative">
+      <CardContent className="flex-1 h-[250px] relative">
         {/* スクリーンリーダー向け代替テキスト */}
         <div className="sr-only">
           <p>話題カテゴリの分布（合計 {data.reduce((sum, d) => sum + d.count, 0)} 件）</p>

--- a/src/components/analytics/topic-trend-chart.tsx
+++ b/src/components/analytics/topic-trend-chart.tsx
@@ -40,7 +40,19 @@ export function TopicTrendChart({ data }: Props) {
 
   const categories = Object.keys(CATEGORY_LABELS) as TopicCategory[];
 
-  if (!mounted) return null;
+  if (!mounted) {
+    return (
+      <Card className="h-full flex flex-col">
+        <CardHeader>
+          <CardTitle>話題の時系列推移</CardTitle>
+          <CardDescription>月別の各カテゴリの話題数</CardDescription>
+        </CardHeader>
+        <CardContent className="flex-1 h-[250px]">
+          <div className="h-full w-full animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    );
+  }
 
   if (data.length === 0) {
     return (
@@ -62,7 +74,7 @@ export function TopicTrendChart({ data }: Props) {
         <CardTitle>話題の時系列推移</CardTitle>
         <CardDescription>月別の各カテゴリの話題数</CardDescription>
       </CardHeader>
-      <CardContent className="flex-1 min-h-[250px]">
+      <CardContent className="flex-1 h-[250px]">
         {/* スクリーンリーダー向け代替テキスト */}
         <div className="sr-only">
           <p>話題の時系列推移（{data.length} ヶ月分）</p>

--- a/src/hooks/__tests__/use-chart-mounted.test.ts
+++ b/src/hooks/__tests__/use-chart-mounted.test.ts
@@ -1,5 +1,5 @@
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useChartMounted } from "../use-chart-mounted";
 
@@ -9,14 +9,83 @@ describe("useChartMounted", () => {
     expect(result.current).toBe(true);
   });
 
-  it("複数のフックインスタンスで同じ値を返す", () => {
+  it("複数のフックインスタンスが独立して動作する", () => {
     const { result: result1 } = renderHook(() => useChartMounted());
     const { result: result2 } = renderHook(() => useChartMounted());
-    expect(result1.current).toBe(result2.current);
+    expect(result1.current).toBe(true);
+    expect(result2.current).toBe(true);
   });
 
   it("boolean 型を返す", () => {
     const { result } = renderHook(() => useChartMounted());
     expect(typeof result.current).toBe("boolean");
+  });
+
+  describe("ブラウザ環境シミュレーション", () => {
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "development");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("初期状態では false を返し、2フレーム後に true になる", async () => {
+      // requestAnimationFrame をモック
+      const callbacks: FrameRequestCallback[] = [];
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+        callbacks.push(cb);
+        return callbacks.length;
+      });
+
+      const { result } = renderHook(() => useChartMounted());
+
+      // 初期状態は false
+      expect(result.current).toBe(false);
+
+      // 1フレーム目を実行
+      await act(() => {
+        if (callbacks.length > 0) callbacks[0](16);
+      });
+
+      // まだ false（2フレーム待ち）
+      expect(result.current).toBe(false);
+
+      // 2フレーム目を実行
+      await act(() => {
+        if (callbacks.length > 1) callbacks[1](32);
+      });
+
+      // 2フレーム後に true
+      expect(result.current).toBe(true);
+
+      rafSpy.mockRestore();
+    });
+
+    it("アンマウント時に両フレームのリクエストがキャンセルされる", async () => {
+      const cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+      const callbacks: FrameRequestCallback[] = [];
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+        callbacks.push(cb);
+        return callbacks.length;
+      });
+
+      const { unmount } = renderHook(() => useChartMounted());
+
+      // 1フレーム目のコールバックを実行して secondFrameId を設定する
+      await act(() => {
+        if (callbacks.length > 0) callbacks[0](16);
+      });
+
+      unmount();
+
+      // firstFrameId (1) と secondFrameId (2) の両方がキャンセルされる
+      expect(cancelSpy).toHaveBeenCalledTimes(2);
+      expect(cancelSpy).toHaveBeenCalledWith(1);
+      expect(cancelSpy).toHaveBeenCalledWith(2);
+
+      cancelSpy.mockRestore();
+      rafSpy.mockRestore();
+    });
   });
 });

--- a/src/hooks/use-chart-mounted.ts
+++ b/src/hooks/use-chart-mounted.ts
@@ -1,40 +1,39 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useEffect, useState } from "react";
 
-// ブラウザの初回ペイント後にチャートをマウントするための外部ストア。
-// requestAnimationFrame を使い、DOM レイアウト完了後に mounted を true にすることで
-// recharts の "width(-1) and height(-1)" 警告を回避する。
-// テスト環境では同期的に true を返し、既存テストの動作を維持する。
-let chartMounted = process.env.NODE_ENV === "test";
-const chartListeners = new Set<() => void>();
-
-function subscribeToChartMount(listener: () => void) {
-  chartListeners.add(listener);
-  return () => {
-    chartListeners.delete(listener);
-  };
-}
-
-function getChartMountSnapshot() {
-  return chartMounted;
-}
-
-function getChartMountServerSnapshot() {
-  return false;
-}
-
-if (typeof window !== "undefined") {
-  requestAnimationFrame(() => {
-    chartMounted = true;
-    chartListeners.forEach((listener) => listener());
-  });
-}
-
+/**
+ * コンポーネントレベルでチャートのマウント状態を管理するフック。
+ * useEffect 内で requestAnimationFrame を2フレーム待ちし、
+ * DOM レイアウト完了後に mounted を true にすることで
+ * recharts の "width(-1) and height(-1)" 警告を回避する。
+ * テスト環境では同期的に true を返し、既存テストの動作を維持する。
+ */
 export function useChartMounted(): boolean {
-  return useSyncExternalStore(
-    subscribeToChartMount,
-    getChartMountSnapshot,
-    getChartMountServerSnapshot,
-  );
+  // ビルド時に静的置換されるため実行時に変化しない。
+  // テストでの vi.stubEnv 対応のため関数内で評価する。
+  const isTest = process.env.NODE_ENV === "test";
+  const [mounted, setMounted] = useState(isTest);
+
+  useEffect(() => {
+    if (isTest) return;
+
+    let secondFrameId: number | undefined;
+
+    // 2フレーム待ちで DOM レイアウト完了を保証
+    const firstFrameId = requestAnimationFrame(() => {
+      secondFrameId = requestAnimationFrame(() => {
+        setMounted(true);
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrameId);
+      if (secondFrameId !== undefined) {
+        cancelAnimationFrame(secondFrameId);
+      }
+    };
+  }, [isTest]);
+
+  return mounted;
 }


### PR DESCRIPTION
## 概要

issue #244 の対応。recharts を使用しているページ（メンバー詳細・アナリティクス）で発生していた `width(-1) and height(-1) of chart should be a positive number` 警告を解消する。

根本原因は `useChartMounted` がモジュールレベルの `useSyncExternalStore` で1回だけ実行される方式だったため、コンポーネント単位のマウントタイミングと同期していなかった点。

## 変更内容

### 変更ファイル
- `src/hooks/use-chart-mounted.ts` — モジュールレベルの `useSyncExternalStore` + グローバル `requestAnimationFrame` 方式から、コンポーネントレベルの `useState` + `useEffect` + 2フレーム `requestAnimationFrame` 待ち方式に変更。各コンポーネントが独立してマウント状態を管理するようにした
- `src/hooks/__tests__/use-chart-mounted.test.ts` — ブラウザ環境シミュレーションテストを追加（2フレーム待ち動作・クリーンアップ検証）
- `src/components/analytics/meeting-frequency-chart.tsx` — `!mounted` 時に `null` → スケルトン UI を返すように変更
- `src/components/analytics/checkin-trend-chart.tsx` — 同上
- `src/components/analytics/action-completion-trend-chart.tsx` — 同上
- `src/components/analytics/topic-distribution-chart.tsx` — 同上 + コンテナの `min-h-[250px]` → `h-[250px]` に変更して高さを確定
- `src/components/analytics/topic-trend-chart.tsx` — 同上 + コンテナの `min-h-[250px]` → `h-[250px]` に変更して高さを確定

## 修正のポイント

- **コンポーネントレベルのマウント検知**: 各チャートが独立して `requestAnimationFrame` 2フレーム待ちを実行し、DOM レイアウト完了後にチャートを描画
- **CSS の高さ確定**: `min-h` → `h` に変更して `ResponsiveContainer` のコンテナサイズが 0 にならないことを保証
- **スケルトン UI**: `return null` からスケルトンに変更し、レイアウトシフト（CLS）を防止
- **適切なクリーンアップ**: `cancelAnimationFrame` で両フレームのリクエストを確実にキャンセル

## テスト計画

- [x] `npx vitest run src/hooks/__tests__/ src/components/analytics/__tests__/` — 20ファイル 136テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] `/members/[id]` ページでコンソールに `width(-1) height(-1)` 警告が出ないことを確認
- [ ] `/analytics` ページで同様に確認
- [ ] ページ間遷移を繰り返して警告が出ないことを確認
- [ ] チャートが正しくレンダリングされ、レイアウトシフトがないことを確認

Closes #244