### PR TITLE
feat: メンバーごとの成長目標・OKR管理機能を追加する (issue #226)

### DIFF
--- a/prisma/migrations/20260225153543_add_goal/migration.sql
+++ b/prisma/migrations/20260225153543_add_goal/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Goal" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "memberId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "progress" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'IN_PROGRESS',
+    "dueDate" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Goal_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "Member" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Goal_memberId_idx" ON "Goal"("memberId");
+
+-- CreateIndex
+CREATE INDEX "Goal_memberId_status_idx" ON "Goal"("memberId", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Member {
 
   meetings    Meeting[]
   actionItems ActionItem[]
+  goals       Goal[]
 }
 
 model Meeting {
@@ -128,6 +129,29 @@ model ActionItemTag {
 
   @@id([actionItemId, tagId])
   @@index([tagId])
+}
+
+model Goal {
+  id          String     @id @default(uuid())
+  memberId    String
+  title       String
+  description String     @default("")
+  progress    Int        @default(0)
+  status      GoalStatus @default(IN_PROGRESS)
+  dueDate     DateTime?
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+
+  member Member @relation(fields: [memberId], references: [id], onDelete: Cascade)
+
+  @@index([memberId])
+  @@index([memberId, status])
+}
+
+enum GoalStatus {
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
 }
 
 model MeetingTemplate {

--- a/src/app/members/[id]/meetings/prepare/page.tsx
+++ b/src/app/members/[id]/meetings/prepare/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { MeetingPrepare } from "@/components/meeting/meeting-prepare";
 import { getLastMeetingAllActions, getPendingActionItems } from "@/lib/actions/action-item-actions";
+import { getActiveGoals } from "@/lib/actions/goal-actions";
 import { getMember } from "@/lib/actions/member-actions";
 import { getCustomTemplates } from "@/lib/actions/template-actions";
 import { formatDateLong } from "@/lib/format";
@@ -18,10 +19,11 @@ export default async function PrepareMeetingPage({ params }: Props) {
 
   const today = formatDateLong(new Date());
 
-  const [pendingActions, lastMeetingData, customTemplates] = await Promise.all([
+  const [pendingActions, lastMeetingData, customTemplates, activeGoals] = await Promise.all([
     getPendingActionItems(id),
     getLastMeetingAllActions(id),
     getCustomTemplates(),
+    getActiveGoals(id),
   ]);
 
   return (
@@ -44,6 +46,7 @@ export default async function PrepareMeetingPage({ params }: Props) {
         pendingActions={pendingActions}
         lastMeetingData={lastMeetingData}
         customTemplates={customTemplates}
+        activeGoals={activeGoals}
       />
     </div>
   );

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ActionListCompact } from "@/components/action/action-list-compact";
 import { ActionAnalyticsSection } from "@/components/analytics/action-analytics-section";
 import { CheckinTrendSection } from "@/components/analytics/checkin-trend-section";
 import { TopicAnalyticsSection } from "@/components/analytics/topic-analytics-section";
+import { GoalList } from "@/components/goal/goal-list";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { MeetingHistory } from "@/components/meeting/meeting-history";
 import { CalendarExportButton } from "@/components/member/calendar-export-button";
@@ -21,6 +22,7 @@ import { MoodTrendChart } from "@/components/member/mood-trend-chart";
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { getGoals } from "@/lib/actions/goal-actions";
 import { getMoodTrend } from "@/lib/actions/meeting-actions";
 import { getMember, getMemberMeetings, getMemberTimeline } from "@/lib/actions/member-actions";
 import { calcNextRecommendedDate } from "@/lib/schedule";
@@ -31,7 +33,7 @@ type Props = {
 };
 
 function resolveTab(tab: string | undefined): MemberDetailTab {
-  if (tab === "history" || tab === "actions") return tab;
+  if (tab === "history" || tab === "actions" || tab === "goals") return tab;
   return "timeline";
 }
 
@@ -52,9 +54,10 @@ export default async function MemberDetailPage({ params, searchParams }: Props) 
     member.meetingIntervalDays,
   );
 
-  const [meetingsPage, timeline] = await Promise.all([
+  const [meetingsPage, timeline, goals] = await Promise.all([
     currentTab === "history" ? getMemberMeetings(id, page) : Promise.resolve(null),
     currentTab === "timeline" ? getMemberTimeline(id) : Promise.resolve(null),
+    currentTab === "goals" ? getGoals(id) : Promise.resolve(null),
   ]);
 
   return (
@@ -144,6 +147,13 @@ export default async function MemberDetailPage({ params, searchParams }: Props) 
           <>
             <Separator className="mb-6" />
             <ActionListCompact actionItems={member.actionItems} />
+          </>
+        )}
+
+        {currentTab === "goals" && goals !== null && (
+          <>
+            <Separator className="mb-6" />
+            <GoalList goals={goals} memberId={id} />
           </>
         )}
       </div>

--- a/src/components/goal/__tests__/goal-list.test.tsx
+++ b/src/components/goal/__tests__/goal-list.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { Goal } from "@/generated/prisma/client";
+
+import { GoalList } from "../goal-list";
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/goal-actions", () => ({
+  createGoal: vi.fn(),
+  updateGoal: vi.fn(),
+  deleteGoal: vi.fn(),
+  updateGoalProgress: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const memberId = "member-1";
+
+const mockGoals: Goal[] = [
+  {
+    id: "goal-1",
+    memberId,
+    title: "TypeScript習得",
+    description: "型システムを理解する",
+    progress: 30,
+    status: "IN_PROGRESS",
+    dueDate: new Date("2026-06-01"),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "goal-2",
+    memberId,
+    title: "完了した目標",
+    description: "",
+    progress: 100,
+    status: "COMPLETED",
+    dueDate: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+describe("GoalList", () => {
+  it("目標一覧を表示する", () => {
+    render(<GoalList goals={mockGoals} memberId={memberId} />);
+    expect(screen.getByText("TypeScript習得")).toBeDefined();
+    expect(screen.getByText("完了した目標")).toBeDefined();
+  });
+
+  it("空の場合はEmptyStateを表示する", () => {
+    render(<GoalList goals={[]} memberId={memberId} />);
+    expect(screen.getByText("目標がありません")).toBeDefined();
+  });
+
+  it("目標を追加ボタンが表示される", () => {
+    render(<GoalList goals={[]} memberId={memberId} />);
+    expect(screen.getByText("目標を追加")).toBeDefined();
+  });
+
+  it("フィルタボタンが表示される", () => {
+    render(<GoalList goals={mockGoals} memberId={memberId} />);
+    const buttons = screen.getAllByRole("button");
+    const filterLabels = ["すべて", "進行中", "完了", "キャンセル"];
+    for (const label of filterLabels) {
+      expect(buttons.some((btn) => btn.textContent === label)).toBe(true);
+    }
+  });
+
+  it("進行中フィルタで進行中の目標のみ表示される", async () => {
+    const user = userEvent.setup();
+    render(<GoalList goals={mockGoals} memberId={memberId} />);
+
+    const filterButtons = screen.getAllByRole("button");
+    const inProgressBtn = filterButtons.find((btn) => btn.textContent === "進行中");
+    expect(inProgressBtn).toBeDefined();
+    await user.click(inProgressBtn!);
+
+    expect(screen.getByText("TypeScript習得")).toBeDefined();
+    expect(screen.queryByText("完了した目標")).toBeNull();
+  });
+
+  it("完了フィルタで完了した目標のみ表示される", async () => {
+    const user = userEvent.setup();
+    render(<GoalList goals={mockGoals} memberId={memberId} />);
+
+    const filterButtons = screen.getAllByRole("button");
+    const completedBtn = filterButtons.find((btn) => btn.textContent === "完了");
+    await user.click(completedBtn!);
+
+    expect(screen.queryByText("TypeScript習得")).toBeNull();
+    expect(screen.getByText("完了した目標")).toBeDefined();
+  });
+});

--- a/src/components/goal/__tests__/goal-progress-bar.test.tsx
+++ b/src/components/goal/__tests__/goal-progress-bar.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GoalProgressBar } from "../goal-progress-bar";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("GoalProgressBar", () => {
+  it("進捗0%を表示する", () => {
+    render(<GoalProgressBar progress={0} />);
+    expect(screen.getByText("0%")).toBeDefined();
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("0");
+  });
+
+  it("進捗50%を表示する", () => {
+    render(<GoalProgressBar progress={50} />);
+    expect(screen.getByText("50%")).toBeDefined();
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("進捗100%を表示する", () => {
+    render(<GoalProgressBar progress={100} />);
+    expect(screen.getByText("100%")).toBeDefined();
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("負の値を0にクランプする", () => {
+    render(<GoalProgressBar progress={-10} />);
+    expect(screen.getByText("0%")).toBeDefined();
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("0");
+  });
+
+  it("100超の値を100にクランプする", () => {
+    render(<GoalProgressBar progress={120} />);
+    expect(screen.getByText("100%")).toBeDefined();
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("aria-labelが正しい", () => {
+    render(<GoalProgressBar progress={75} />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-label")).toBe("進捗 75%");
+  });
+
+  it("size smでh-1.5クラスが適用される", () => {
+    const { container } = render(<GoalProgressBar progress={50} size="sm" />);
+    const trackDiv = container.querySelector(".h-1\\.5");
+    expect(trackDiv).not.toBeNull();
+  });
+
+  it("size mdでh-2.5クラスが適用される", () => {
+    const { container } = render(<GoalProgressBar progress={50} size="md" />);
+    const trackDiv = container.querySelector(".h-2\\.5");
+    expect(trackDiv).not.toBeNull();
+  });
+});

--- a/src/components/goal/goal-card.tsx
+++ b/src/components/goal/goal-card.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Calendar, Pencil, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import type { Goal } from "@/generated/prisma/client";
+import { deleteGoal, updateGoalProgress } from "@/lib/actions/goal-actions";
+import { cn } from "@/lib/utils";
+
+import { GoalProgressBar } from "./goal-progress-bar";
+
+type Props = {
+  goal: Goal;
+  onEdit: (goal: Goal) => void;
+};
+
+const STATUS_CONFIG = {
+  IN_PROGRESS: { label: "進行中", variant: "default" as const },
+  COMPLETED: { label: "完了", variant: "secondary" as const },
+  CANCELLED: { label: "キャンセル", variant: "outline" as const },
+} as const;
+
+function formatDueDate(date: Date | null): string | null {
+  if (!date) return null;
+  return new Date(date).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function isOverdue(dueDate: Date | null, status: string): boolean {
+  if (!dueDate || status !== "IN_PROGRESS") return false;
+  return new Date(dueDate) < new Date(new Date().toDateString());
+}
+
+export function GoalCard({ goal, onEdit }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const statusConfig = STATUS_CONFIG[goal.status as keyof typeof STATUS_CONFIG];
+  const dueDateStr = formatDueDate(goal.dueDate);
+  const overdue = isOverdue(goal.dueDate, goal.status);
+
+  function handleProgressChange(value: number[]) {
+    startTransition(async () => {
+      await updateGoalProgress(goal.id, value[0]);
+      router.refresh();
+    });
+  }
+
+  function handleDelete() {
+    startTransition(async () => {
+      await deleteGoal(goal.id);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div
+      className={cn(
+        "border rounded-lg p-4 flex flex-col gap-3 transition-opacity",
+        isPending && "opacity-60",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="text-sm font-semibold tracking-tight truncate">{goal.title}</h3>
+            <Badge variant={statusConfig.variant} className="shrink-0 text-xs">
+              {statusConfig.label}
+            </Badge>
+          </div>
+          {goal.description && (
+            <p className="text-xs text-muted-foreground line-clamp-2">{goal.description}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => onEdit(goal)}
+            aria-label="編集"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          {showDeleteConfirm ? (
+            <div className="flex items-center gap-1">
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={handleDelete}
+              >
+                削除
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setShowDeleteConfirm(false)}
+              >
+                戻す
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-destructive"
+              onClick={() => setShowDeleteConfirm(true)}
+              aria-label="削除"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <GoalProgressBar progress={goal.progress} />
+
+      {goal.status === "IN_PROGRESS" && (
+        <Slider
+          value={[goal.progress]}
+          onValueCommit={handleProgressChange}
+          min={0}
+          max={100}
+          step={5}
+          className="w-full"
+          aria-label="進捗スライダー"
+        />
+      )}
+
+      {dueDateStr && (
+        <div
+          className={cn(
+            "flex items-center gap-1 text-xs",
+            overdue ? "text-destructive" : "text-muted-foreground",
+          )}
+        >
+          <Calendar className="h-3 w-3" />
+          <span>期限: {dueDateStr}</span>
+          {overdue && <span className="font-medium">（期限切れ）</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/goal/goal-form-dialog.tsx
+++ b/src/components/goal/goal-form-dialog.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { Textarea } from "@/components/ui/textarea";
+import type { Goal } from "@/generated/prisma/client";
+import { createGoal, updateGoal } from "@/lib/actions/goal-actions";
+
+type Props = {
+  memberId: string;
+  goal?: Goal | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function toDateInputValue(date: Date | null | undefined): string {
+  if (!date) return "";
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function GoalForm({
+  memberId,
+  goal,
+  onClose,
+}: {
+  memberId: string;
+  goal?: Goal | null;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const isEditing = !!goal;
+
+  const [title, setTitle] = useState(goal?.title ?? "");
+  const [description, setDescription] = useState(goal?.description ?? "");
+  const [progress, setProgress] = useState(goal?.progress ?? 0);
+  const [status, setStatus] = useState<string>(goal?.status ?? "IN_PROGRESS");
+  const [dueDate, setDueDate] = useState(toDateInputValue(goal?.dueDate));
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    startTransition(async () => {
+      const input = {
+        title,
+        description,
+        progress,
+        status: status as "IN_PROGRESS" | "COMPLETED" | "CANCELLED",
+        dueDate: dueDate || undefined,
+      };
+
+      const result = isEditing
+        ? await updateGoal(goal.id, input)
+        : await createGoal(memberId, input);
+
+      if (result.success) {
+        toast.success(isEditing ? "目標を更新しました" : "目標を作成しました");
+        onClose();
+        router.refresh();
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <DialogHeader>
+        <DialogTitle className="text-lg font-semibold tracking-tight">
+          {isEditing ? "目標を編集" : "新しい目標を追加"}
+        </DialogTitle>
+        <DialogDescription>
+          {isEditing ? "目標の内容を変更できます。" : "メンバーの成長目標を設定します。"}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-4 py-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="goal-title">タイトル</Label>
+          <Input
+            id="goal-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="例: TypeScriptの習得"
+            required
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="goal-description">説明</Label>
+          <Textarea
+            id="goal-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="目標の詳細や背景..."
+            rows={3}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label>進捗: {progress}%</Label>
+          <Slider
+            value={[progress]}
+            onValueChange={(v) => setProgress(v[0])}
+            min={0}
+            max={100}
+            step={5}
+            aria-label="進捗"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="goal-status">ステータス</Label>
+          <Select value={status} onValueChange={setStatus}>
+            <SelectTrigger id="goal-status">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="IN_PROGRESS">進行中</SelectItem>
+              <SelectItem value="COMPLETED">完了</SelectItem>
+              <SelectItem value="CANCELLED">キャンセル</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="goal-due-date">期限</Label>
+          <Input
+            id="goal-due-date"
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onClose}>
+          キャンセル
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "保存中..." : isEditing ? "更新" : "作成"}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+export function GoalFormDialog({ memberId, goal, open, onOpenChange }: Props) {
+  const formKey = goal?.id ?? "new";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {open && (
+          <GoalForm
+            key={formKey}
+            memberId={memberId}
+            goal={goal}
+            onClose={() => onOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/goal/goal-list.tsx
+++ b/src/components/goal/goal-list.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Plus, Target } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import type { Goal } from "@/generated/prisma/client";
+
+import { GoalCard } from "./goal-card";
+import { GoalFormDialog } from "./goal-form-dialog";
+
+type FilterValue = "all" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+
+const FILTER_OPTIONS: { value: FilterValue; label: string }[] = [
+  { value: "all", label: "すべて" },
+  { value: "IN_PROGRESS", label: "進行中" },
+  { value: "COMPLETED", label: "完了" },
+  { value: "CANCELLED", label: "キャンセル" },
+];
+
+type Props = {
+  goals: Goal[];
+  memberId: string;
+};
+
+export function GoalList({ goals, memberId }: Props) {
+  const [filter, setFilter] = useState<FilterValue>("all");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingGoal, setEditingGoal] = useState<Goal | null>(null);
+
+  const filteredGoals = filter === "all" ? goals : goals.filter((g) => g.status === filter);
+
+  function handleEdit(goal: Goal) {
+    setEditingGoal(goal);
+    setDialogOpen(true);
+  }
+
+  function handleAdd() {
+    setEditingGoal(null);
+    setDialogOpen(true);
+  }
+
+  function handleDialogClose(open: boolean) {
+    setDialogOpen(open);
+    if (!open) setEditingGoal(null);
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1">
+          {FILTER_OPTIONS.map((option) => (
+            <Button
+              key={option.value}
+              variant={filter === option.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => setFilter(option.value)}
+              className="text-xs"
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+        <Button size="sm" onClick={handleAdd}>
+          <Plus className="h-4 w-4 mr-1" />
+          目標を追加
+        </Button>
+      </div>
+
+      {filteredGoals.length === 0 ? (
+        <EmptyState
+          icon={Target}
+          title={goals.length === 0 ? "目標がありません" : "該当する目標がありません"}
+          description={
+            goals.length === 0
+              ? "「目標を追加」ボタンからメンバーの成長目標を設定しましょう。"
+              : "フィルター条件を変更してください。"
+          }
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {filteredGoals.map((goal) => (
+            <GoalCard key={goal.id} goal={goal} onEdit={handleEdit} />
+          ))}
+        </div>
+      )}
+
+      <GoalFormDialog
+        memberId={memberId}
+        goal={editingGoal}
+        open={dialogOpen}
+        onOpenChange={handleDialogClose}
+      />
+    </div>
+  );
+}

--- a/src/components/goal/goal-progress-bar.tsx
+++ b/src/components/goal/goal-progress-bar.tsx
@@ -1,0 +1,28 @@
+type Props = {
+  progress: number;
+  size?: "sm" | "md";
+};
+
+export function GoalProgressBar({ progress, size = "md" }: Props) {
+  const height = size === "sm" ? "h-1.5" : "h-2.5";
+  const clampedProgress = Math.max(0, Math.min(100, progress));
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className={`flex-1 bg-muted rounded-full overflow-hidden ${height}`}>
+        <div
+          className="h-full bg-primary rounded-full transition-all duration-300"
+          style={{ width: `${clampedProgress}%` }}
+          role="progressbar"
+          aria-valuenow={clampedProgress}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`進捗 ${clampedProgress}%`}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums w-8 text-right">
+        {clampedProgress}%
+      </span>
+    </div>
+  );
+}

--- a/src/components/meeting/meeting-prepare.tsx
+++ b/src/components/meeting/meeting-prepare.tsx
@@ -6,13 +6,14 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import Link from "next/link";
 
 import { PrepareActionChecklist } from "@/components/meeting/prepare-action-checklist";
+import { PrepareGoalsSection } from "@/components/meeting/prepare-goals-section";
 import { PrepareTopicItem } from "@/components/meeting/prepare-topic-item";
 import { PreviousMeetingReview } from "@/components/meeting/previous-meeting-review";
 import { TemplateSelector } from "@/components/meeting/template-selector";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import type { MeetingTemplate as DbMeetingTemplate } from "@/generated/prisma/client";
+import type { Goal, MeetingTemplate as DbMeetingTemplate } from "@/generated/prisma/client";
 import { useMeetingPrepare } from "@/hooks/use-meeting-prepare";
 import { screenReaderInstructions } from "@/lib/dnd-accessibility";
 import { cn } from "@/lib/utils";
@@ -37,6 +38,7 @@ type Props = {
   pendingActions: PendingAction[];
   lastMeetingData: LastMeetingData;
   customTemplates?: DbMeetingTemplate[];
+  activeGoals?: Goal[];
 };
 
 export function MeetingPrepare({
@@ -44,6 +46,7 @@ export function MeetingPrepare({
   pendingActions,
   lastMeetingData,
   customTemplates = [],
+  activeGoals = [],
 }: Props) {
   const {
     topics,
@@ -82,6 +85,22 @@ export function MeetingPrepare({
             />
           </CardContent>
         </Card>
+
+        {activeGoals.length > 0 && (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">
+                進行中の目標
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  ({activeGoals.length}件)
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <PrepareGoalsSection goals={activeGoals} />
+            </CardContent>
+          </Card>
+        )}
 
         {pendingActions.length > 0 && (
           <Collapsible open={isPendingActionsOpen} onOpenChange={setIsPendingActionsOpen}>

--- a/src/components/meeting/prepare-goals-section.tsx
+++ b/src/components/meeting/prepare-goals-section.tsx
@@ -1,0 +1,36 @@
+import { GoalProgressBar } from "@/components/goal/goal-progress-bar";
+import type { Goal } from "@/generated/prisma/client";
+
+type Props = {
+  goals: Goal[];
+};
+
+export function PrepareGoalsSection({ goals }: Props) {
+  if (goals.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {goals.map((goal) => (
+        <div key={goal.id} className="flex flex-col gap-1 p-3 border rounded-lg">
+          <div className="flex justify-between items-center">
+            <span className="text-sm font-medium">{goal.title}</span>
+            {goal.dueDate && (
+              <span className="text-xs text-muted-foreground">
+                期限:{" "}
+                {new Date(goal.dueDate).toLocaleDateString("ja-JP", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </span>
+            )}
+          </div>
+          <GoalProgressBar progress={goal.progress} size="sm" />
+          {goal.description && (
+            <p className="text-xs text-muted-foreground line-clamp-2">{goal.description}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/member/__tests__/member-detail-tab-nav.test.tsx
+++ b/src/components/member/__tests__/member-detail-tab-nav.test.tsx
@@ -27,11 +27,12 @@ vi.mock("next/link", () => ({
 const memberId = "member-1";
 
 describe("MemberDetailTabNav", () => {
-  it("3つのタブを表示する", () => {
+  it("4つのタブを表示する", () => {
     render(<MemberDetailTabNav memberId={memberId} currentTab="timeline" />);
     expect(screen.getByText("タイムライン")).toBeDefined();
     expect(screen.getByText("1on1履歴")).toBeDefined();
     expect(screen.getByText("アクションアイテム")).toBeDefined();
+    expect(screen.getByText("目標")).toBeDefined();
   });
 
   it("タイムラインタブのリンクURLが正しい", () => {
@@ -50,6 +51,12 @@ describe("MemberDetailTabNav", () => {
     render(<MemberDetailTabNav memberId={memberId} currentTab="timeline" />);
     const actionsLink = screen.getByRole("link", { name: "アクションアイテム" });
     expect(actionsLink.getAttribute("href")).toBe(`/members/${memberId}?tab=actions`);
+  });
+
+  it("目標タブのリンクURLが正しい", () => {
+    render(<MemberDetailTabNav memberId={memberId} currentTab="timeline" />);
+    const goalsLink = screen.getByRole("link", { name: "目標" });
+    expect(goalsLink.getAttribute("href")).toBe(`/members/${memberId}?tab=goals`);
   });
 
   it("currentTabに応じてアクティブスタイルが適用される", () => {

--- a/src/components/member/member-detail-tab-nav.tsx
+++ b/src/components/member/member-detail-tab-nav.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 import { cn } from "@/lib/utils";
 
-export type MemberDetailTab = "timeline" | "history" | "actions";
+export type MemberDetailTab = "timeline" | "history" | "actions" | "goals";
 
 type Props = {
   memberId: string;
@@ -15,6 +15,7 @@ const TABS: { value: MemberDetailTab; label: string }[] = [
   { value: "timeline", label: "タイムライン" },
   { value: "history", label: "1on1履歴" },
   { value: "actions", label: "アクションアイテム" },
+  { value: "goals", label: "目標" },
 ];
 
 export function MemberDetailTabNav({ memberId, currentTab }: Props) {

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Slider as SliderPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
+    [value, defaultValue, min, max],
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/src/lib/actions/__tests__/goal-actions.test.ts
+++ b/src/lib/actions/__tests__/goal-actions.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "@/lib/prisma";
+
+import {
+  createGoal,
+  deleteGoal,
+  getActiveGoals,
+  getGoals,
+  updateGoal,
+  updateGoalProgress,
+} from "../goal-actions";
+
+let memberId: string;
+
+beforeEach(async () => {
+  await prisma.goal.deleteMany();
+  await prisma.actionItem.deleteMany();
+  await prisma.topic.deleteMany();
+  await prisma.meeting.deleteMany();
+  await prisma.member.deleteMany();
+  const member = await prisma.member.create({
+    data: { name: "テストメンバー" },
+  });
+  memberId = member.id;
+});
+
+describe("getGoals", () => {
+  it("メンバーの目標一覧を返す", async () => {
+    await prisma.goal.createMany({
+      data: [
+        { memberId, title: "目標A" },
+        { memberId, title: "目標B", status: "COMPLETED", progress: 100 },
+      ],
+    });
+    const result = await getGoals(memberId);
+    expect(result).toHaveLength(2);
+  });
+
+  it("目標がない場合は空配列を返す", async () => {
+    const result = await getGoals(memberId);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("getActiveGoals", () => {
+  it("進行中の目標のみを返す", async () => {
+    await prisma.goal.createMany({
+      data: [
+        { memberId, title: "進行中", status: "IN_PROGRESS" },
+        { memberId, title: "完了", status: "COMPLETED", progress: 100 },
+        { memberId, title: "キャンセル", status: "CANCELLED" },
+      ],
+    });
+    const result = await getActiveGoals(memberId);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("進行中");
+  });
+});
+
+describe("createGoal", () => {
+  it("目標を作成できる", async () => {
+    const result = await createGoal(memberId, {
+      title: "TypeScript習得",
+      description: "型システムを理解する",
+      progress: 20,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.title).toBe("TypeScript習得");
+      expect(result.data.progress).toBe(20);
+      expect(result.data.status).toBe("IN_PROGRESS");
+    }
+  });
+
+  it("期限付きの目標を作成できる", async () => {
+    const result = await createGoal(memberId, {
+      title: "期限付き目標",
+      dueDate: "2026-06-01",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dueDate).not.toBeNull();
+    }
+  });
+
+  it("タイトルが空の場合はエラーを返す", async () => {
+    const result = await createGoal(memberId, { title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("メンバーIDが空の場合はエラーを返す", async () => {
+    const result = await createGoal("", { title: "目標" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateGoal", () => {
+  it("目標を部分更新できる", async () => {
+    const created = await createGoal(memberId, { title: "更新前" });
+    if (!created.success) throw new Error(created.error);
+    const result = await updateGoal(created.data.id, { title: "更新後" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.title).toBe("更新後");
+    }
+  });
+
+  it("ステータスをCOMPLETEDにすると進捗が自動的に100になる", async () => {
+    const created = await createGoal(memberId, { title: "目標", progress: 50 });
+    if (!created.success) throw new Error(created.error);
+    const result = await updateGoal(created.data.id, { status: "COMPLETED" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.progress).toBe(100);
+    }
+  });
+
+  it("ステータスCOMPLETEDでprogress指定ありの場合は指定値を使う", async () => {
+    const created = await createGoal(memberId, { title: "目標" });
+    if (!created.success) throw new Error(created.error);
+    const result = await updateGoal(created.data.id, { status: "COMPLETED", progress: 80 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.progress).toBe(80);
+    }
+  });
+
+  it("IDが空の場合はエラーを返す", async () => {
+    const result = await updateGoal("", { title: "テスト" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateGoalProgress", () => {
+  it("進捗を更新できる", async () => {
+    const created = await createGoal(memberId, { title: "目標" });
+    if (!created.success) throw new Error(created.error);
+    const result = await updateGoalProgress(created.data.id, 60);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.progress).toBe(60);
+      expect(result.data.status).toBe("IN_PROGRESS");
+    }
+  });
+
+  it("100%到達時に自動的にCOMPLETEDになる", async () => {
+    const created = await createGoal(memberId, { title: "目標" });
+    if (!created.success) throw new Error(created.error);
+    const result = await updateGoalProgress(created.data.id, 100);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.status).toBe("COMPLETED");
+    }
+  });
+
+  it("IDが空の場合はエラーを返す", async () => {
+    const result = await updateGoalProgress("", 50);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("deleteGoal", () => {
+  it("目標を削除できる", async () => {
+    const created = await createGoal(memberId, { title: "削除テスト" });
+    if (!created.success) throw new Error(created.error);
+    const result = await deleteGoal(created.data.id);
+    expect(result.success).toBe(true);
+    const remaining = await getGoals(memberId);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("IDが空の場合はエラーを返す", async () => {
+    const result = await deleteGoal("");
+    expect(result.success).toBe(false);
+  });
+
+  it("存在しないIDの場合はエラーを返す", async () => {
+    const result = await deleteGoal("non-existent-id");
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/actions/goal-actions.ts
+++ b/src/lib/actions/goal-actions.ts
@@ -1,0 +1,104 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import type { Goal, GoalStatus } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type { CreateGoalInput, UpdateGoalInput } from "@/lib/validations/goal";
+import {
+  createGoalSchema,
+  updateGoalProgressSchema,
+  updateGoalSchema,
+} from "@/lib/validations/goal";
+
+import { type ActionResult, runAction } from "./types";
+
+/** メンバーの目標一覧を取得 */
+export async function getGoals(memberId: string): Promise<Goal[]> {
+  return prisma.goal.findMany({
+    where: { memberId },
+    orderBy: [{ status: "asc" }, { updatedAt: "desc" }],
+  });
+}
+
+/** メンバーの進行中目標を取得（準備画面向け） */
+export async function getActiveGoals(memberId: string): Promise<Goal[]> {
+  return prisma.goal.findMany({
+    where: { memberId, status: "IN_PROGRESS" },
+    orderBy: [{ dueDate: "asc" }, { updatedAt: "desc" }],
+  });
+}
+
+/** 目標を作成 */
+export async function createGoal(
+  memberId: string,
+  input: CreateGoalInput,
+): Promise<ActionResult<Goal>> {
+  return runAction(async () => {
+    if (!memberId) throw new Error("メンバーIDが指定されていません");
+    const validated = createGoalSchema.parse(input);
+    const dueDate = validated.dueDate ? new Date(validated.dueDate) : null;
+    const result = await prisma.goal.create({
+      data: {
+        memberId,
+        title: validated.title,
+        description: validated.description,
+        progress: validated.progress,
+        status: validated.status,
+        dueDate,
+      },
+    });
+    revalidatePath("/", "layout");
+    return result;
+  });
+}
+
+/** 目標を更新 */
+export async function updateGoal(id: string, input: UpdateGoalInput): Promise<ActionResult<Goal>> {
+  return runAction(async () => {
+    if (!id) throw new Error("目標IDが指定されていません");
+    const validated = updateGoalSchema.parse(input);
+    const data: Record<string, unknown> = {};
+    if (validated.title !== undefined) data.title = validated.title;
+    if (validated.description !== undefined) data.description = validated.description;
+    if (validated.progress !== undefined) data.progress = validated.progress;
+    if (validated.status !== undefined) data.status = validated.status;
+    if (validated.dueDate !== undefined) {
+      data.dueDate = validated.dueDate ? new Date(validated.dueDate) : null;
+    }
+    if (validated.status === "COMPLETED" && validated.progress === undefined) {
+      data.progress = 100;
+    }
+    const result = await prisma.goal.update({ where: { id }, data });
+    revalidatePath("/", "layout");
+    return result;
+  });
+}
+
+/** 目標の進捗を更新 */
+export async function updateGoalProgress(
+  id: string,
+  progress: number,
+): Promise<ActionResult<Goal>> {
+  return runAction(async () => {
+    if (!id) throw new Error("目標IDが指定されていません");
+    const { progress: validatedProgress } = updateGoalProgressSchema.parse({ progress });
+    const data: { progress: number; status?: GoalStatus } = { progress: validatedProgress };
+    if (validatedProgress === 100) {
+      data.status = "COMPLETED";
+    }
+    const result = await prisma.goal.update({ where: { id }, data });
+    revalidatePath("/", "layout");
+    return result;
+  });
+}
+
+/** 目標を削除 */
+export async function deleteGoal(id: string): Promise<ActionResult<Goal>> {
+  return runAction(async () => {
+    if (!id) throw new Error("目標IDが指定されていません");
+    const result = await prisma.goal.delete({ where: { id } });
+    revalidatePath("/", "layout");
+    return result;
+  });
+}

--- a/src/lib/validations/__tests__/goal.test.ts
+++ b/src/lib/validations/__tests__/goal.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { createGoalSchema, goalStatus, updateGoalProgressSchema, updateGoalSchema } from "../goal";
+
+describe("goalStatus", () => {
+  it("有効なステータスを受け付ける", () => {
+    for (const status of ["IN_PROGRESS", "COMPLETED", "CANCELLED"]) {
+      const result = goalStatus.safeParse(status);
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("無効なステータスを拒否する", () => {
+    const result = goalStatus.safeParse("INVALID");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("createGoalSchema", () => {
+  it("有効な入力を受け付ける", () => {
+    const result = createGoalSchema.safeParse({
+      title: "TypeScript習得",
+      description: "型システムの理解を深める",
+      progress: 30,
+      dueDate: "2026-06-01",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("タイトル空文字を拒否する", () => {
+    const result = createGoalSchema.safeParse({ title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("進捗が0未満を拒否する", () => {
+    const result = createGoalSchema.safeParse({ title: "目標", progress: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("進捗が100超を拒否する", () => {
+    const result = createGoalSchema.safeParse({ title: "目標", progress: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it("description・progress・dueDateは省略可能", () => {
+    const result = createGoalSchema.safeParse({ title: "目標" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.description).toBe("");
+      expect(result.data.progress).toBe(0);
+      expect(result.data.status).toBe("IN_PROGRESS");
+    }
+  });
+
+  it("小数の進捗を拒否する", () => {
+    const result = createGoalSchema.safeParse({ title: "目標", progress: 33.3 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateGoalSchema", () => {
+  it("部分更新を受け付ける", () => {
+    const result = updateGoalSchema.safeParse({ progress: 50 });
+    expect(result.success).toBe(true);
+  });
+
+  it("全フィールド更新を受け付ける", () => {
+    const result = updateGoalSchema.safeParse({
+      title: "更新後",
+      description: "詳細",
+      progress: 80,
+      status: "COMPLETED",
+      dueDate: "2026-12-31",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("空オブジェクトを受け付ける", () => {
+    const result = updateGoalSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("updateGoalProgressSchema", () => {
+  it("有効な進捗を受け付ける", () => {
+    const result = updateGoalProgressSchema.safeParse({ progress: 50 });
+    expect(result.success).toBe(true);
+  });
+
+  it("小数を拒否する", () => {
+    const result = updateGoalProgressSchema.safeParse({ progress: 33.3 });
+    expect(result.success).toBe(false);
+  });
+
+  it("0を受け付ける", () => {
+    const result = updateGoalProgressSchema.safeParse({ progress: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("100を受け付ける", () => {
+    const result = updateGoalProgressSchema.safeParse({ progress: 100 });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/validations/goal.ts
+++ b/src/lib/validations/goal.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const goalStatus = z.enum(["IN_PROGRESS", "COMPLETED", "CANCELLED"]);
+
+export const createGoalSchema = z.object({
+  title: z.string().min(1, "目標のタイトルは必須です"),
+  description: z.string().default(""),
+  progress: z
+    .number()
+    .int("進捗は整数で入力してください")
+    .min(0, "進捗は0以上で入力してください")
+    .max(100, "進捗は100以下で入力してください")
+    .default(0),
+  status: goalStatus.default("IN_PROGRESS"),
+  dueDate: z.string().optional(),
+});
+
+export const updateGoalSchema = z.object({
+  title: z.string().min(1, "目標のタイトルは必須です").optional(),
+  description: z.string().optional(),
+  progress: z
+    .number()
+    .int("進捗は整数で入力してください")
+    .min(0, "進捗は0以上で入力してください")
+    .max(100, "進捗は100以下で入力してください")
+    .optional(),
+  status: goalStatus.optional(),
+  dueDate: z.string().optional(),
+});
+
+export const updateGoalProgressSchema = z.object({
+  progress: z
+    .number()
+    .int("進捗は整数で入力してください")
+    .min(0, "進捗は0以上で入力してください")
+    .max(100, "進捗は100以下で入力してください"),
+});
+
+export type GoalStatusType = z.infer<typeof goalStatus>;
+export type CreateGoalInput = z.input<typeof createGoalSchema>;
+export type UpdateGoalInput = z.input<typeof updateGoalSchema>;
+export type UpdateGoalProgressInput = z.input<typeof updateGoalProgressSchema>;


### PR DESCRIPTION
## 概要

issue #226 の対応。メンバーごとに成長目標（OKR・MBO・個人目標など）を設定・記録し、1on1のトピックとして自動的に引き継ぐ機能を追加する。目標のタイトル・説明・期限・進捗状況（0〜100%）を管理でき、ミーティング準備画面で進行中の目標を表示する。

## 変更内容

### 新規ファイル
- `prisma/migrations/20260225153543_add_goal/migration.sql` — Goal テーブル追加マイグレーション
- `src/lib/validations/goal.ts` — Goal 用 Zod バリデーションスキーマ（create/update/progress）
- `src/lib/validations/__tests__/goal.test.ts` — バリデーションスキーマのテスト（15件）
- `src/lib/actions/goal-actions.ts` — Goal Server Actions（getGoals, getActiveGoals, createGoal, updateGoal, updateGoalProgress, deleteGoal）
- `src/lib/actions/__tests__/goal-actions.test.ts` — Server Actions のテスト（17件）
- `src/components/goal/goal-progress-bar.tsx` — 進捗バーコンポーネント（アクセシビリティ対応）
- `src/components/goal/goal-card.tsx` — 目標カードコンポーネント（ステータスバッジ・進捗スライダー・編集/削除）
- `src/components/goal/goal-form-dialog.tsx` — 目標作成・編集ダイアログ
- `src/components/goal/goal-list.tsx` — 目標一覧コンポーネント（フィルタリング・空状態対応）
- `src/components/goal/__tests__/goal-progress-bar.test.tsx` — プログレスバーのテスト（8件）
- `src/components/goal/__tests__/goal-list.test.tsx` — 目標一覧のテスト（6件）
- `src/components/meeting/prepare-goals-section.tsx` — 準備画面の目標表示セクション
- `src/components/ui/slider.tsx` — shadcn/ui Slider コンポーネント

### 変更ファイル
- `prisma/schema.prisma` — Goal モデル・GoalStatus enum・Member リレーション追加
- `src/components/member/member-detail-tab-nav.tsx` — 「目標」タブを追加
- `src/app/members/[id]/page.tsx` — 目標タブのルーティングとデータ取得を追加
- `src/app/members/[id]/meetings/prepare/page.tsx` — 進行中目標のデータ取得を追加
- `src/components/meeting/meeting-prepare.tsx` — 進行中の目標セクションを左カラムに追加
- `src/components/member/__tests__/member-detail-tab-nav.test.tsx` — タブ数・目標タブURLのテスト追加

## 機能

- **目標 CRUD**: タイトル・説明・期限・進捗（0-100%）・ステータス（進行中/完了/キャンセル）で目標を管理
- **目標タブ**: メンバー詳細画面の4番目のタブとして「目標」を表示。フィルタリング（全件/進行中/完了/キャンセル）対応
- **進捗スライダー**: カード上で直接スライダーを操作して進捗を更新。100%到達時に自動的に完了ステータスに遷移
- **準備画面統合**: ミーティング準備画面の左カラムに進行中の目標を表示し、1on1での目標レビューをスムーズに支援
- **自動完了**: ステータスを「完了」に変更すると進捗が自動的に100%に設定される

## テスト計画

- [x] `npm test` — 145ファイル 1508テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] メンバー詳細画面で「目標」タブが表示されることを確認
- [ ] 目標の作成・編集・削除が正常に動作することを確認
- [ ] 進捗スライダーで進捗を更新できることを確認
- [ ] 100%到達時にステータスが自動的に「完了」に遷移することを確認
- [ ] ミーティング準備画面に進行中の目標が表示されることを確認
- [ ] フィルタリング（すべて/進行中/完了/キャンセル）が正常に動作することを確認

Closes #226