### PR TITLE
feat: カスタムテンプレートのインポート/エクスポート機能を追加する (issue #229)

### DIFF
--- a/src/components/meeting/__tests__/template-management.test.tsx
+++ b/src/components/meeting/__tests__/template-management.test.tsx
@@ -8,6 +8,20 @@ vi.mock("@/lib/actions/template-actions", () => ({
   deleteTemplate: vi.fn().mockResolvedValue({ success: true }),
   createTemplate: vi.fn().mockResolvedValue({ success: true, data: {} }),
   updateTemplate: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  exportTemplates: vi.fn().mockResolvedValue({
+    success: true,
+    data: { version: 1, exportedAt: "2026-01-01T00:00:00.000Z", templates: [] },
+  }),
+  previewImport: vi
+    .fn()
+    .mockResolvedValue({ success: true, data: { templates: [], duplicateNames: [] } }),
+  importTemplates: vi
+    .fn()
+    .mockResolvedValue({ success: true, data: { created: 1, updated: 0, skipped: 0 } }),
+}));
+
+vi.mock("@/lib/template-io", () => ({
+  downloadTemplatesAsJson: vi.fn(),
 }));
 
 vi.mock("sonner", () => ({
@@ -131,5 +145,21 @@ describe("TemplateManagement", () => {
     expect(
       screen.getByText("1on1 準備画面で使えるオリジナルテンプレートを作成できます"),
     ).toBeDefined();
+  });
+
+  it("「エクスポート」ボタンを表示する", () => {
+    render(<TemplateManagement templates={mockTemplates} />);
+    expect(screen.getByRole("button", { name: /テンプレートをエクスポート/ })).toBeDefined();
+  });
+
+  it("テンプレートがない場合、エクスポートボタンは無効化される", () => {
+    render(<TemplateManagement templates={[]} />);
+    const exportBtn = screen.getByRole("button", { name: /テンプレートをエクスポート/ });
+    expect((exportBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("「インポート」ボタンを表示する", () => {
+    render(<TemplateManagement templates={[]} />);
+    expect(screen.getByRole("button", { name: /テンプレートをインポート/ })).toBeDefined();
   });
 });

--- a/src/components/meeting/template-import-dialog.tsx
+++ b/src/components/meeting/template-import-dialog.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { Upload } from "lucide-react";
+import { useRef, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { importTemplates, previewImport } from "@/lib/actions/template-actions";
+import { readTemplateFile } from "@/lib/template-io";
+import type { TemplateExportFile, TemplateExportItem } from "@/lib/validations/template-schema";
+
+type Step = "select" | "preview" | "importing";
+
+type PreviewState = {
+  templates: TemplateExportItem[];
+  duplicateNames: string[];
+  overwriteNames: Set<string>;
+};
+
+type Props = {
+  trigger: React.ReactNode;
+};
+
+export function TemplateImportDialog({ trigger }: Props) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<Step>("select");
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+  const [parsedFile, setParsedFile] = useState<TemplateExportFile | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  function reset() {
+    setStep("select");
+    setError(null);
+    setPreview(null);
+    setParsedFile(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) reset();
+  }
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+
+    try {
+      const data = await readTemplateFile(file);
+      setParsedFile(data);
+
+      const result = await previewImport(data);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      setPreview({
+        templates: result.data.templates,
+        duplicateNames: result.data.duplicateNames,
+        overwriteNames: new Set(result.data.duplicateNames),
+      });
+      setStep("preview");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "ファイルの読み込みに失敗しました");
+    }
+  }
+
+  function toggleOverwrite(name: string) {
+    if (!preview) return;
+    setPreview((prev) => {
+      if (!prev) return prev;
+      const next = new Set(prev.overwriteNames);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return { ...prev, overwriteNames: next };
+    });
+  }
+
+  function handleImport() {
+    if (!parsedFile || !preview) return;
+    startTransition(async () => {
+      const result = await importTemplates(parsedFile, Array.from(preview.overwriteNames));
+      if (result.success) {
+        const { created, updated, skipped } = result.data;
+        const parts: string[] = [];
+        if (created > 0) parts.push(`${created}件を新規作成`);
+        if (updated > 0) parts.push(`${updated}件を更新`);
+        if (skipped > 0) parts.push(`${skipped}件をスキップ`);
+        toast.success(`インポート完了: ${parts.join("、")}`);
+        setOpen(false);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  const newCount = preview
+    ? preview.templates.filter((t) => !preview.duplicateNames.includes(t.name)).length
+    : 0;
+  const duplicateCount = preview ? preview.duplicateNames.length : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>テンプレートをインポート</DialogTitle>
+          <DialogDescription>
+            NudgeでエクスポートしたテンプレートのJSONファイルを読み込みます。
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === "select" && (
+          <div className="flex flex-col gap-4">
+            <div
+              className="border-2 border-dashed rounded-lg p-8 text-center cursor-pointer hover:border-primary/50 transition-colors"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload className="w-8 h-8 mx-auto mb-2 text-muted-foreground" />
+              <p className="text-sm font-medium">JSONファイルを選択</p>
+              <p className="text-xs text-muted-foreground mt-1">クリックしてファイルを選択</p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                onChange={handleFileChange}
+                aria-label="インポートするJSONファイルを選択"
+              />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+        )}
+
+        {step === "preview" && preview && (
+          <div className="flex flex-col gap-4">
+            <div className="flex gap-2 flex-wrap">
+              {newCount > 0 && <Badge variant="secondary">{newCount}件を新規作成</Badge>}
+              {duplicateCount > 0 && <Badge variant="outline">{duplicateCount}件が重複</Badge>}
+            </div>
+
+            <div className="max-h-64 overflow-y-auto flex flex-col gap-2">
+              {preview.templates.map((t) => {
+                const isDuplicate = preview.duplicateNames.includes(t.name);
+                return (
+                  <div key={t.name} className="flex items-start gap-3 border rounded p-3">
+                    {isDuplicate ? (
+                      <Checkbox
+                        id={`overwrite-${t.name}`}
+                        checked={preview.overwriteNames.has(t.name)}
+                        onCheckedChange={() => toggleOverwrite(t.name)}
+                        className="mt-0.5"
+                      />
+                    ) : (
+                      <div className="w-4 h-4 mt-0.5 rounded-sm border border-primary bg-primary flex items-center justify-center">
+                        <svg
+                          className="w-3 h-3 text-primary-foreground"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={3}
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <Label
+                        htmlFor={isDuplicate ? `overwrite-${t.name}` : undefined}
+                        className="font-medium text-sm cursor-pointer"
+                      >
+                        {t.name}
+                        {isDuplicate && (
+                          <span className="ml-2 text-xs text-amber-600 font-normal">
+                            (既存のテンプレートを上書き)
+                          </span>
+                        )}
+                      </Label>
+                      {t.description && (
+                        <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                          {t.description}
+                        </p>
+                      )}
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        トピック {t.topics.length}件
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {duplicateCount > 0 && (
+              <p className="text-xs text-muted-foreground">
+                ※
+                チェックを付けた既存テンプレートは説明・トピックが上書きされます（名前は変更されません）
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter showCloseButton>
+          {step === "preview" && (
+            <Button onClick={handleImport} disabled={isPending}>
+              {isPending ? "インポート中..." : "インポート実行"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/meeting/template-management.tsx
+++ b/src/components/meeting/template-management.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Edit2, Plus, Trash2 } from "lucide-react";
+import { Download, Edit2, Plus, Trash2, Upload } from "lucide-react";
 import { useTransition } from "react";
 import { toast } from "sonner";
 
@@ -19,9 +19,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { MeetingTemplate } from "@/generated/prisma/client";
-import { deleteTemplate } from "@/lib/actions/template-actions";
+import { deleteTemplate, exportTemplates } from "@/lib/actions/template-actions";
+import { downloadTemplatesAsJson } from "@/lib/template-io";
 
 import { TemplateFormDialog } from "./template-form-dialog";
+import { TemplateImportDialog } from "./template-import-dialog";
 
 const categoryLabels: Record<string, string> = {
   WORK_PROGRESS: "業務進捗",
@@ -129,23 +131,57 @@ type Props = {
 };
 
 export function TemplateManagement({ templates }: Props) {
+  const [isExporting, startExportTransition] = useTransition();
+
+  function handleExport() {
+    startExportTransition(async () => {
+      const result = await exportTemplates();
+      if (result.success) {
+        downloadTemplatesAsJson(result.data);
+        toast.success("テンプレートをエクスポートしました");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
         <div>
           <h2 className="text-lg font-semibold tracking-tight">カスタムテンプレート</h2>
           <p className="text-sm text-muted-foreground mt-0.5">
             1on1 準備画面で使えるオリジナルテンプレートを作成できます
           </p>
         </div>
-        <TemplateFormDialog
-          trigger={
-            <Button size="sm">
-              <Plus className="w-4 h-4 mr-1" />
-              新規作成
-            </Button>
-          }
-        />
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExport}
+            disabled={isExporting || templates.length === 0}
+            aria-label="テンプレートをエクスポート"
+          >
+            <Download className="w-4 h-4 mr-1" />
+            エクスポート
+          </Button>
+          <TemplateImportDialog
+            trigger={
+              <Button variant="outline" size="sm" aria-label="テンプレートをインポート">
+                <Upload className="w-4 h-4 mr-1" />
+                インポート
+              </Button>
+            }
+          />
+          <TemplateFormDialog
+            trigger={
+              <Button size="sm">
+                <Plus className="w-4 h-4 mr-1" />
+                新規作成
+              </Button>
+            }
+          />
+        </div>
       </div>
 
       {templates.length === 0 ? (

--- a/src/lib/__tests__/template-io.test.ts
+++ b/src/lib/__tests__/template-io.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { downloadTemplatesAsJson, readTemplateFile } from "../template-io";
+
+describe("downloadTemplatesAsJson", () => {
+  it("JSON ファイルのダウンロードをトリガーする", () => {
+    const createObjectURLMock = vi.fn().mockReturnValue("blob:test");
+    const revokeObjectURLMock = vi.fn();
+    const clickMock = vi.fn();
+    const appendChildMock = vi.fn();
+    const removeChildMock = vi.fn();
+
+    Object.defineProperty(globalThis, "URL", {
+      value: { createObjectURL: createObjectURLMock, revokeObjectURL: revokeObjectURLMock },
+      writable: true,
+    });
+
+    const anchorEl = {
+      href: "",
+      download: "",
+      click: clickMock,
+    } as unknown as HTMLAnchorElement;
+
+    vi.spyOn(document, "createElement").mockReturnValueOnce(anchorEl);
+    vi.spyOn(document.body, "appendChild").mockImplementation(appendChildMock);
+    vi.spyOn(document.body, "removeChild").mockImplementation(removeChildMock);
+
+    const data = {
+      version: 1 as const,
+      exportedAt: "2026-01-01T00:00:00.000Z",
+      templates: [{ name: "テスト", description: "", topics: [] }],
+    };
+
+    downloadTemplatesAsJson(data);
+
+    expect(createObjectURLMock).toHaveBeenCalledOnce();
+    expect(clickMock).toHaveBeenCalledOnce();
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:test");
+    expect(anchorEl.download).toMatch(/nudge-templates-\d{4}-\d{2}-\d{2}\.json/);
+  });
+});
+
+describe("readTemplateFile", () => {
+  function makeFile(content: string, name = "templates.json"): File {
+    return new File([content], name, { type: "application/json" });
+  }
+
+  it("有効な JSON ファイルを読み込める", async () => {
+    const data = {
+      version: 1,
+      exportedAt: "2026-01-01T00:00:00.000Z",
+      templates: [
+        {
+          name: "週次レビュー",
+          description: "説明",
+          topics: [{ category: "WORK_PROGRESS", title: "進捗" }],
+        },
+      ],
+    };
+    const file = makeFile(JSON.stringify(data));
+    const result = await readTemplateFile(file);
+    expect(result.version).toBe(1);
+    expect(result.templates).toHaveLength(1);
+    expect(result.templates[0].name).toBe("週次レビュー");
+  });
+
+  it("JSON でないファイルはエラーをスローする", async () => {
+    const file = makeFile("これはJSONではありません");
+    await expect(readTemplateFile(file)).rejects.toThrow("JSONの解析に失敗しました");
+  });
+
+  it("スキーマが不正な JSON はエラーをスローする", async () => {
+    const file = makeFile(JSON.stringify({ version: 2, exportedAt: "2026-01-01", templates: [] }));
+    await expect(readTemplateFile(file)).rejects.toThrow("無効なファイル形式です");
+  });
+
+  it("templates が空配列の場合はバリデーションエラー", async () => {
+    const file = makeFile(
+      JSON.stringify({ version: 1, exportedAt: "2026-01-01T00:00:00.000Z", templates: [] }),
+    );
+    await expect(readTemplateFile(file)).rejects.toThrow("無効なファイル形式です");
+  });
+
+  it("templates 内のトピックカテゴリが不正な場合はエラー", async () => {
+    const data = {
+      version: 1,
+      exportedAt: "2026-01-01T00:00:00.000Z",
+      templates: [
+        { name: "テスト", description: "", topics: [{ category: "INVALID", title: "タイトル" }] },
+      ],
+    };
+    const file = makeFile(JSON.stringify(data));
+    await expect(readTemplateFile(file)).rejects.toThrow("無効なファイル形式です");
+  });
+});

--- a/src/lib/actions/__tests__/template-actions.test.ts
+++ b/src/lib/actions/__tests__/template-actions.test.ts
@@ -5,7 +5,10 @@ import { prisma } from "@/lib/prisma";
 import {
   createTemplate,
   deleteTemplate,
+  exportTemplates,
   getCustomTemplates,
+  importTemplates,
+  previewImport,
   updateTemplate,
 } from "../template-actions";
 
@@ -158,6 +161,159 @@ describe("deleteTemplate", () => {
 
   it("IDが空の場合はエラーを返す", async () => {
     const result = await deleteTemplate("");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("exportTemplates", () => {
+  it("カスタムテンプレートをエクスポートできる", async () => {
+    await createTemplate({
+      name: "エクスポートテスト",
+      description: "説明",
+      topics: [{ category: "WORK_PROGRESS", title: "進捗" }],
+    });
+    const result = await exportTemplates();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe(1);
+      expect(typeof result.data.exportedAt).toBe("string");
+      expect(result.data.templates).toHaveLength(1);
+      expect(result.data.templates[0].name).toBe("エクスポートテスト");
+      expect(result.data.templates[0].description).toBe("説明");
+    }
+  });
+
+  it("デフォルトテンプレートはエクスポートに含まれない", async () => {
+    await prisma.meetingTemplate.create({
+      data: { name: "デフォルト", topics: [], isDefault: true },
+    });
+    await createTemplate({ name: "カスタム", topics: [] });
+    const result = await exportTemplates();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.templates).toHaveLength(1);
+      expect(result.data.templates[0].name).toBe("カスタム");
+    }
+  });
+
+  it("テンプレートがない場合でも空配列で返せる", async () => {
+    const result = await exportTemplates();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.templates).toHaveLength(0);
+    }
+  });
+});
+
+describe("previewImport", () => {
+  const validImportData = {
+    version: 1,
+    exportedAt: "2026-01-01T00:00:00.000Z",
+    templates: [
+      { name: "新規テンプレート", description: "説明", topics: [] },
+      { name: "重複テンプレート", description: "", topics: [] },
+    ],
+  };
+
+  it("重複なしの場合 duplicateNames が空", async () => {
+    const result = await previewImport(validImportData);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.duplicateNames).toHaveLength(0);
+      expect(result.data.templates).toHaveLength(2);
+    }
+  });
+
+  it("既存テンプレートと名前が重複する場合 duplicateNames に含まれる", async () => {
+    await createTemplate({ name: "重複テンプレート", topics: [] });
+    const result = await previewImport(validImportData);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.duplicateNames).toContain("重複テンプレート");
+      expect(result.data.duplicateNames).not.toContain("新規テンプレート");
+    }
+  });
+
+  it("不正なデータはエラーを返す", async () => {
+    const result = await previewImport({ invalid: "data" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("importTemplates", () => {
+  const makeImportData = (templates: Array<{ name: string; description?: string }>) => ({
+    version: 1 as const,
+    exportedAt: "2026-01-01T00:00:00.000Z",
+    templates: templates.map((t) => ({
+      name: t.name,
+      description: t.description ?? "",
+      topics: [],
+    })),
+  });
+
+  it("新規テンプレートを作成できる", async () => {
+    const result = await importTemplates(makeImportData([{ name: "新規A" }]), []);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.created).toBe(1);
+      expect(result.data.updated).toBe(0);
+      expect(result.data.skipped).toBe(0);
+    }
+    const all = await getCustomTemplates();
+    expect(all.some((t) => t.name === "新規A")).toBe(true);
+  });
+
+  it("重複テンプレートはデフォルトでスキップされる", async () => {
+    await createTemplate({ name: "既存テンプレート", description: "旧説明", topics: [] });
+    const result = await importTemplates(
+      makeImportData([{ name: "既存テンプレート", description: "新説明" }]),
+      [],
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.skipped).toBe(1);
+      expect(result.data.updated).toBe(0);
+    }
+    const all = await getCustomTemplates();
+    expect(all.find((t) => t.name === "既存テンプレート")?.description).toBe("旧説明");
+  });
+
+  it("overwriteNames に含まれる場合は上書き更新される", async () => {
+    await createTemplate({ name: "上書き対象", description: "旧説明", topics: [] });
+    const result = await importTemplates(
+      makeImportData([{ name: "上書き対象", description: "新説明" }]),
+      ["上書き対象"],
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.updated).toBe(1);
+      expect(result.data.skipped).toBe(0);
+    }
+    const all = await getCustomTemplates();
+    expect(all.find((t) => t.name === "上書き対象")?.description).toBe("新説明");
+  });
+
+  it("新規・更新・スキップが混在する場合を正しく処理する", async () => {
+    await createTemplate({ name: "スキップ対象", topics: [] });
+    await createTemplate({ name: "更新対象", description: "旧", topics: [] });
+    const result = await importTemplates(
+      makeImportData([
+        { name: "新規X" },
+        { name: "スキップ対象" },
+        { name: "更新対象", description: "新" },
+      ]),
+      ["更新対象"],
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.created).toBe(1);
+      expect(result.data.updated).toBe(1);
+      expect(result.data.skipped).toBe(1);
+    }
+  });
+
+  it("不正なデータはエラーを返す", async () => {
+    const result = await importTemplates({ invalid: "data" }, []);
     expect(result.success).toBe(false);
   });
 });

--- a/src/lib/actions/template-actions.ts
+++ b/src/lib/actions/template-actions.ts
@@ -4,8 +4,17 @@ import { revalidatePath } from "next/cache";
 
 import type { MeetingTemplate } from "@/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
-import type { CreateTemplateInput, UpdateTemplateInput } from "@/lib/validations/template-schema";
-import { createTemplateSchema, updateTemplateSchema } from "@/lib/validations/template-schema";
+import type {
+  CreateTemplateInput,
+  TemplateExportFile,
+  TemplateExportItem,
+  UpdateTemplateInput,
+} from "@/lib/validations/template-schema";
+import {
+  createTemplateSchema,
+  templateExportFileSchema,
+  updateTemplateSchema,
+} from "@/lib/validations/template-schema";
 
 import { type ActionResult, runAction } from "./types";
 
@@ -69,5 +78,84 @@ export async function deleteTemplate(id: string): Promise<ActionResult<MeetingTe
     revalidatePath("/settings/templates");
     revalidatePath("/", "layout");
     return result;
+  });
+}
+
+export type ImportResult = {
+  created: number;
+  updated: number;
+  skipped: number;
+};
+
+export type ImportPreview = {
+  templates: TemplateExportItem[];
+  duplicateNames: string[];
+};
+
+export async function exportTemplates(): Promise<ActionResult<TemplateExportFile>> {
+  return runAction(async () => {
+    const templates = await prisma.meetingTemplate.findMany({
+      where: { isDefault: false },
+      orderBy: { createdAt: "asc" },
+    });
+    const items: TemplateExportItem[] = templates.map((t) => ({
+      name: t.name,
+      description: t.description,
+      topics: Array.isArray(t.topics) ? (t.topics as TemplateExportItem["topics"]) : [],
+    }));
+    return {
+      version: 1 as const,
+      exportedAt: new Date().toISOString(),
+      templates: items,
+    };
+  });
+}
+
+export async function previewImport(rawData: unknown): Promise<ActionResult<ImportPreview>> {
+  return runAction(async () => {
+    const parsed = templateExportFileSchema.parse(rawData);
+    const names = parsed.templates.map((t) => t.name);
+    const existing = await prisma.meetingTemplate.findMany({
+      where: { name: { in: names } },
+      select: { name: true },
+    });
+    const duplicateNames = existing.map((e) => e.name);
+    return { templates: parsed.templates, duplicateNames };
+  });
+}
+
+export async function importTemplates(
+  rawData: unknown,
+  overwriteNames: string[],
+): Promise<ActionResult<ImportResult>> {
+  return runAction(async () => {
+    const parsed = templateExportFileSchema.parse(rawData);
+    let created = 0;
+    let updated = 0;
+    let skipped = 0;
+
+    for (const item of parsed.templates) {
+      const existing = await prisma.meetingTemplate.findUnique({ where: { name: item.name } });
+      if (existing) {
+        if (overwriteNames.includes(item.name)) {
+          await prisma.meetingTemplate.update({
+            where: { id: existing.id },
+            data: { description: item.description, topics: item.topics },
+          });
+          updated++;
+        } else {
+          skipped++;
+        }
+      } else {
+        await prisma.meetingTemplate.create({
+          data: { name: item.name, description: item.description, topics: item.topics },
+        });
+        created++;
+      }
+    }
+
+    revalidatePath("/settings/templates");
+    revalidatePath("/", "layout");
+    return { created, updated, skipped };
   });
 }

--- a/src/lib/template-io.ts
+++ b/src/lib/template-io.ts
@@ -1,0 +1,50 @@
+import type { TemplateExportFile } from "@/lib/validations/template-schema";
+import { templateExportFileSchema } from "@/lib/validations/template-schema";
+
+export type { TemplateExportFile };
+
+export function downloadTemplatesAsJson(data: TemplateExportFile): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `nudge-templates-${new Date().toISOString().slice(0, 10)}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export async function readTemplateFile(file: File): Promise<TemplateExportFile> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const text = e.target?.result;
+        if (typeof text !== "string") {
+          reject(new Error("ファイルの読み込みに失敗しました"));
+          return;
+        }
+        let json: unknown;
+        try {
+          json = JSON.parse(text);
+        } catch {
+          reject(new Error("JSONの解析に失敗しました。有効なJSONファイルを選択してください"));
+          return;
+        }
+        const result = templateExportFileSchema.safeParse(json);
+        if (!result.success) {
+          reject(
+            new Error("無効なファイル形式です。Nudgeでエクスポートしたファイルを選択してください"),
+          );
+          return;
+        }
+        resolve(result.data);
+      } catch {
+        reject(new Error("ファイルの読み込みに失敗しました"));
+      }
+    };
+    reader.onerror = () => reject(new Error("ファイルの読み込みに失敗しました"));
+    reader.readAsText(file, "utf-8");
+  });
+}

--- a/src/lib/validations/__tests__/template-schema.test.ts
+++ b/src/lib/validations/__tests__/template-schema.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { templateExportFileSchema, templateExportItemSchema } from "../template-schema";
+
+describe("templateExportItemSchema", () => {
+  it("有効なテンプレートアイテムをパースできる", () => {
+    const result = templateExportItemSchema.safeParse({
+      name: "週次レビュー",
+      description: "説明",
+      topics: [{ category: "WORK_PROGRESS", title: "進捗確認" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("name が空はエラー", () => {
+    const result = templateExportItemSchema.safeParse({ name: "", topics: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("name が 100 文字超はエラー", () => {
+    const result = templateExportItemSchema.safeParse({ name: "a".repeat(101), topics: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("description が省略された場合はデフォルト空文字", () => {
+    const result = templateExportItemSchema.safeParse({ name: "テスト", topics: [] });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.description).toBe("");
+  });
+
+  it("topics が省略された場合はデフォルト空配列", () => {
+    const result = templateExportItemSchema.safeParse({ name: "テスト" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.topics).toEqual([]);
+  });
+
+  it("無効なトピックカテゴリはエラー", () => {
+    const result = templateExportItemSchema.safeParse({
+      name: "テスト",
+      topics: [{ category: "INVALID_CATEGORY", title: "タイトル" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("templateExportFileSchema", () => {
+  const validFile = {
+    version: 1,
+    exportedAt: "2026-01-01T00:00:00.000Z",
+    templates: [{ name: "テスト", description: "", topics: [] }],
+  };
+
+  it("有効なエクスポートファイルをパースできる", () => {
+    const result = templateExportFileSchema.safeParse(validFile);
+    expect(result.success).toBe(true);
+  });
+
+  it("version が 1 以外はエラー", () => {
+    const result = templateExportFileSchema.safeParse({ ...validFile, version: 2 });
+    expect(result.success).toBe(false);
+  });
+
+  it("templates が空配列はエラー", () => {
+    const result = templateExportFileSchema.safeParse({ ...validFile, templates: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("exportedAt がない場合はエラー", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { exportedAt: _, ...rest } = validFile;
+    const result = templateExportFileSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("templates 内の不正なアイテムはエラー", () => {
+    const result = templateExportFileSchema.safeParse({
+      ...validFile,
+      templates: [{ name: "", topics: [] }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("複数テンプレートを含めてパースできる", () => {
+    const result = templateExportFileSchema.safeParse({
+      ...validFile,
+      templates: [
+        { name: "テンプレートA", topics: [] },
+        { name: "テンプレートB", topics: [{ category: "CAREER", title: "キャリア" }] },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.templates).toHaveLength(2);
+  });
+});

--- a/src/lib/validations/template-schema.ts
+++ b/src/lib/validations/template-schema.ts
@@ -28,3 +28,22 @@ export const updateTemplateSchema = z.object({
 export type CreateTemplateInput = z.input<typeof createTemplateSchema>;
 export type UpdateTemplateInput = z.input<typeof updateTemplateSchema>;
 export type TemplateTopicInput = z.infer<typeof templateTopicSchema>;
+
+// エクスポート/インポート用スキーマ
+export const templateExportItemSchema = z.object({
+  name: z
+    .string()
+    .min(1, "テンプレート名は必須です")
+    .max(100, "テンプレート名は100文字以内で入力してください"),
+  description: z.string().max(500, "説明は500文字以内で入力してください").default(""),
+  topics: z.array(templateTopicSchema).default([]),
+});
+
+export const templateExportFileSchema = z.object({
+  version: z.literal(1),
+  exportedAt: z.string(),
+  templates: z.array(templateExportItemSchema).min(1, "テンプレートが含まれていません"),
+});
+
+export type TemplateExportItem = z.infer<typeof templateExportItemSchema>;
+export type TemplateExportFile = z.infer<typeof templateExportFileSchema>;


### PR DESCRIPTION
## 概要

issue #229 の対応。テンプレート管理画面からカスタムテンプレートを JSON 形式でエクスポート・インポートできる機能を追加する。デバイス移行時やチーム内でのテンプレート共有を可能にする。

## 変更内容

### 新規ファイル
- `src/components/meeting/template-import-dialog.tsx` — インポートダイアログ（ファイル選択 → プレビュー → 重複確認 → 実行）
- `src/lib/template-io.ts` — クライアントユーティリティ（downloadTemplatesAsJson / readTemplateFile）
- `src/lib/__tests__/template-io.test.ts` — template-io のユニットテスト
- `src/lib/validations/__tests__/template-schema.test.ts` — エクスポート/インポートスキーマのテスト

### 変更ファイル
- `src/lib/validations/template-schema.ts` — `templateExportItemSchema` / `templateExportFileSchema` を追加
- `src/lib/actions/template-actions.ts` — `exportTemplates` / `previewImport` / `importTemplates` Server Actions を追加
- `src/components/meeting/template-management.tsx` — エクスポート・インポートボタンを追加
- `src/lib/actions/__tests__/template-actions.test.ts` — export/import アクションのテストを追加
- `src/components/meeting/__tests__/template-management.test.tsx` — ボタン表示テストを追加

## 機能

- **エクスポート**: テンプレートがある場合にのみ有効化。JSON ファイル（`nudge-templates-YYYY-MM-DD.json`）としてダウンロード
- **インポート**: JSON ファイルを選択 → 追加/重複件数をプレビュー → 重複テンプレートは上書きするか個別に選択 → 実行
- **バリデーション**: Zod による厳格なスキーマ検証（version, exportedAt, templates 構造）。不正ファイルは即エラー表示
- **エクスポート JSON 形式**: `{ version: 1, exportedAt: ISO8601, templates: [{ name, description, topics }] }`

## テスト計画

- [x] `npm test` — 149 ファイル 1583 テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] テンプレート管理画面でエクスポートボタンが表示される（テンプレートあり: 有効、なし: 無効）
- [ ] エクスポートで JSON ファイルがダウンロードされる
- [ ] インポートで有効な JSON ファイルを読み込める
- [ ] インポートで不正なファイルを弾いてエラーメッセージが表示される
- [ ] インポート時に重複テンプレートのチェックボックスが表示される
- [ ] 上書きなしでインポートすると既存テンプレートは更新されない
- [ ] 上書きありでインポートすると説明・トピックが更新される

Closes #229