### PR TITLE
feat: 期限切れアクションアイテムのブラウザ通知リマインダーを追加する (issue #230)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Noto_Sans_JP } from "next/font/google";
 
 import { KeyboardShortcutProvider } from "@/components/layout/keyboard-shortcut-provider";
 import { Sidebar } from "@/components/layout/sidebar";
+import { NotificationInitializer } from "@/components/notification/notification-initializer";
 import { Providers } from "@/components/providers";
 import { Toaster } from "@/components/ui/sonner";
 import { prisma } from "@/lib/prisma";
@@ -62,6 +63,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           </main>
           <Toaster />
           <KeyboardShortcutProvider members={members} />
+          <NotificationInitializer />
         </Providers>
       </body>
     </html>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+import { Breadcrumb } from "@/components/layout/breadcrumb";
+import { NotificationSettings } from "@/components/notification/notification-settings";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function SettingsPage() {
+  return (
+    <div className="animate-fade-in-up">
+      <Breadcrumb items={[{ label: "ダッシュボード", href: "/" }, { label: "設定" }]} />
+      <h1 className="text-2xl font-semibold tracking-tight mb-6 text-foreground">設定</h1>
+
+      <div className="space-y-6 max-w-2xl">
+        <NotificationSettings />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>テンプレート管理</CardTitle>
+            <CardDescription>カスタムミーティングテンプレートを管理します。</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link
+              href="/settings/templates"
+              className="text-sm text-primary underline underline-offset-4 hover:no-underline"
+            >
+              テンプレート管理ページへ →
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -39,7 +39,7 @@ const navItems = [
   { href: "/tasks", label: "マイタスク", icon: ClipboardCheck },
   { href: "/actions", label: "アクション一覧", icon: ListChecks },
   { href: "/analytics", label: "ミーティング分析", icon: BarChart2 },
-  { href: "/settings/templates", label: "テンプレート管理", icon: Settings },
+  { href: "/settings", label: "設定", icon: Settings },
 ];
 
 function NavLinks({

--- a/src/components/notification/notification-initializer.tsx
+++ b/src/components/notification/notification-initializer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useNotifications } from "@/hooks/use-notifications";
+
+export function NotificationInitializer() {
+  const { isSupported, isEnabled, permission, requestPermission, checkAndNotify } =
+    useNotifications();
+
+  useEffect(() => {
+    if (!isSupported) return;
+
+    // 初回起動時に通知許可をリクエスト（まだ許可/拒否していない場合のみ）
+    if (permission === "default") {
+      requestPermission();
+      return;
+    }
+
+    // 通知が有効かつ許可済みの場合はチェックを実行
+    if (isEnabled && permission === "granted") {
+      checkAndNotify();
+    }
+  }, [isSupported, isEnabled, permission, requestPermission, checkAndNotify]);
+
+  return null;
+}

--- a/src/components/notification/notification-settings.tsx
+++ b/src/components/notification/notification-settings.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Bell, BellOff, BellRing } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { useNotifications } from "@/hooks/use-notifications";
+
+const PERMISSION_LABELS: Record<
+  string,
+  { label: string; variant: "default" | "secondary" | "destructive" }
+> = {
+  granted: { label: "許可済み", variant: "default" },
+  denied: { label: "拒否済み", variant: "destructive" },
+  default: { label: "未設定", variant: "secondary" },
+};
+
+export function NotificationSettings() {
+  const { isSupported, permission, isEnabled, setEnabled, requestPermission } = useNotifications();
+
+  if (!isSupported) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <BellOff className="h-5 w-5" />
+            ブラウザ通知
+          </CardTitle>
+          <CardDescription>このブラウザはWeb通知に対応していません。</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const permissionInfo = PERMISSION_LABELS[permission] ?? PERMISSION_LABELS.default;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <BellRing className="h-5 w-5" />
+          ブラウザ通知
+        </CardTitle>
+        <CardDescription>
+          期限当日・前日のアクションアイテムをブラウザ通知でお知らせします。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">通知の許可状態</span>
+          <Badge variant={permissionInfo.variant}>{permissionInfo.label}</Badge>
+        </div>
+
+        {permission === "denied" && (
+          <p className="text-sm text-muted-foreground rounded-md bg-muted p-3">
+            通知が拒否されています。ブラウザのサイト設定から通知を許可してください。
+          </p>
+        )}
+
+        {permission === "default" && (
+          <button
+            type="button"
+            onClick={requestPermission}
+            className="text-sm text-primary underline underline-offset-4 hover:no-underline"
+          >
+            通知を許可する
+          </button>
+        )}
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Bell className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">リマインダー通知</span>
+          </div>
+          <Switch
+            checked={isEnabled && permission === "granted"}
+            disabled={permission !== "granted"}
+            onCheckedChange={setEnabled}
+            aria-label="リマインダー通知を有効にする"
+          />
+        </div>
+
+        {permission === "granted" && isEnabled && (
+          <p className="text-sm text-muted-foreground">
+            期限当日・前日のアクションアイテムを1日1回お知らせします。
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Switch as SwitchPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/hooks/__tests__/use-notifications.test.ts
+++ b/src/hooks/__tests__/use-notifications.test.ts
@@ -1,0 +1,259 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useNotifications } from "../use-notifications";
+
+// Server Action のモック
+vi.mock("@/lib/actions/reminder-actions", () => ({
+  getActionItemsDueSoon: vi.fn(),
+}));
+
+const STORAGE_KEY = "nudge:notifications-enabled";
+const LAST_NOTIFIED_KEY = "nudge:last-notified-date";
+
+describe("useNotifications", () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    // モックのデフォルト実装を再設定
+    const { getActionItemsDueSoon } = await import("@/lib/actions/reminder-actions");
+    vi.mocked(getActionItemsDueSoon).mockResolvedValue([]);
+    // Notification コンストラクタのモック
+    vi.stubGlobal(
+      "Notification",
+      Object.assign(
+        vi.fn().mockImplementation(() => ({
+          onclick: null,
+        })),
+        {
+          permission: "default",
+          requestPermission: vi.fn().mockResolvedValue("granted"),
+        },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("isSupported", () => {
+    it("Notification API が利用可能な場合は true を返す", () => {
+      vi.stubGlobal("Notification", {
+        permission: "default",
+        requestPermission: vi.fn().mockResolvedValue("granted"),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it("Notification API が存在しない場合は false を返す", () => {
+      vi.stubGlobal("Notification", undefined);
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.isSupported).toBe(false);
+    });
+  });
+
+  describe("permission", () => {
+    it("Notification.permission の状態を返す（default）", () => {
+      vi.stubGlobal("Notification", {
+        permission: "default",
+        requestPermission: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.permission).toBe("default");
+    });
+
+    it("Notification.permission の状態を返す（granted）", () => {
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.permission).toBe("granted");
+    });
+
+    it("Notification API が未サポートの場合は denied を返す", () => {
+      vi.stubGlobal("Notification", undefined);
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.permission).toBe("denied");
+    });
+  });
+
+  describe("isEnabled", () => {
+    it("localStorage に設定がない場合はデフォルト false を返す", () => {
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.isEnabled).toBe(false);
+    });
+
+    it("localStorage に true が保存されている場合は true を返す", () => {
+      localStorage.setItem(STORAGE_KEY, "true");
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.isEnabled).toBe(true);
+    });
+
+    it("localStorage に false が保存されている場合は false を返す", () => {
+      localStorage.setItem(STORAGE_KEY, "false");
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.isEnabled).toBe(false);
+    });
+  });
+
+  describe("setEnabled", () => {
+    it("true に設定すると localStorage に保存される", async () => {
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.setEnabled(true);
+      });
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+      expect(result.current.isEnabled).toBe(true);
+    });
+
+    it("false に設定すると localStorage に保存される", async () => {
+      localStorage.setItem(STORAGE_KEY, "true");
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.setEnabled(false);
+      });
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBe("false");
+      expect(result.current.isEnabled).toBe(false);
+    });
+  });
+
+  describe("requestPermission", () => {
+    it("許可が取得された場合は permission が granted に更新される", async () => {
+      const mockRequestPermission = vi.fn().mockResolvedValue("granted");
+      vi.stubGlobal("Notification", {
+        permission: "default",
+        requestPermission: mockRequestPermission,
+      });
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        await result.current.requestPermission();
+      });
+
+      expect(mockRequestPermission).toHaveBeenCalled();
+    });
+
+    it("Notification API が未サポートの場合は何もしない", async () => {
+      vi.stubGlobal("Notification", undefined);
+
+      const { result } = renderHook(() => useNotifications());
+
+      // エラーが発生しないことを確認
+      await act(async () => {
+        await result.current.requestPermission();
+      });
+    });
+  });
+
+  describe("checkAndNotify", () => {
+    it("通知が無効の場合は Server Action を呼ばない", async () => {
+      const { getActionItemsDueSoon } = await import("@/lib/actions/reminder-actions");
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+      localStorage.setItem(STORAGE_KEY, "false");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        await result.current.checkAndNotify();
+      });
+
+      expect(getActionItemsDueSoon).not.toHaveBeenCalled();
+    });
+
+    it("通知許可がない場合は Server Action を呼ばない", async () => {
+      const { getActionItemsDueSoon } = await import("@/lib/actions/reminder-actions");
+      vi.stubGlobal("Notification", {
+        permission: "default",
+        requestPermission: vi.fn(),
+      });
+      localStorage.setItem(STORAGE_KEY, "true");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        await result.current.checkAndNotify();
+      });
+
+      expect(getActionItemsDueSoon).not.toHaveBeenCalled();
+    });
+
+    it("通知有効かつ許可済みの場合、同日は1回のみ通知する（lastNotifiedAt チェック）", async () => {
+      const { getActionItemsDueSoon } = await import("@/lib/actions/reminder-actions");
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+      localStorage.setItem(STORAGE_KEY, "true");
+
+      // 今日の日付を保存
+      const today = new Date().toDateString();
+      localStorage.setItem(LAST_NOTIFIED_KEY, today);
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        await result.current.checkAndNotify();
+      });
+
+      expect(getActionItemsDueSoon).not.toHaveBeenCalled();
+    });
+
+    it("通知有効・許可済み・未通知の場合は Server Action を呼ぶ", async () => {
+      const { getActionItemsDueSoon } = await import("@/lib/actions/reminder-actions");
+      vi.stubGlobal("Notification", {
+        permission: "granted",
+        requestPermission: vi.fn(),
+      });
+      localStorage.setItem(STORAGE_KEY, "true");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        await result.current.checkAndNotify();
+      });
+
+      expect(getActionItemsDueSoon).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { getActionItemsDueSoon } from "@/lib/actions/reminder-actions";
+
+const STORAGE_KEY = "nudge:notifications-enabled";
+const LAST_NOTIFIED_KEY = "nudge:last-notified-date";
+
+type NotificationPermission = "default" | "denied" | "granted";
+
+type UseNotificationsReturn = {
+  isSupported: boolean;
+  permission: NotificationPermission;
+  isEnabled: boolean;
+  setEnabled: (value: boolean) => void;
+  requestPermission: () => Promise<void>;
+  checkAndNotify: () => Promise<void>;
+};
+
+function readEnabledFromStorage(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function isNotifiedToday(): boolean {
+  try {
+    return localStorage.getItem(LAST_NOTIFIED_KEY) === new Date().toDateString();
+  } catch {
+    return false;
+  }
+}
+
+function markNotifiedToday(): void {
+  try {
+    localStorage.setItem(LAST_NOTIFIED_KEY, new Date().toDateString());
+  } catch {
+    // localStorage が使えない環境では何もしない
+  }
+}
+
+function getNotificationPermission(): NotificationPermission {
+  if (typeof window === "undefined" || !window.Notification) return "denied";
+  return window.Notification.permission as NotificationPermission;
+}
+
+export function useNotifications(): UseNotificationsReturn {
+  const isSupported =
+    typeof window !== "undefined" &&
+    typeof window.Notification !== "undefined" &&
+    window.Notification !== null;
+
+  const [permission, setPermission] = useState<NotificationPermission>(() =>
+    getNotificationPermission(),
+  );
+  const [isEnabled, setIsEnabled] = useState<boolean>(() => readEnabledFromStorage());
+
+  const setEnabled = useCallback((value: boolean) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(value));
+    } catch {
+      // localStorage が使えない環境では状態のみ更新
+    }
+    setIsEnabled(value);
+  }, []);
+
+  const requestPermission = useCallback(async () => {
+    if (!isSupported || !window.Notification) return;
+    const result = await window.Notification.requestPermission();
+    setPermission(result as NotificationPermission);
+  }, [isSupported]);
+
+  const checkAndNotify = useCallback(async () => {
+    if (!isEnabled || permission !== "granted") return;
+    if (isNotifiedToday()) return;
+
+    const items = await getActionItemsDueSoon();
+    markNotifiedToday();
+
+    if (items.length === 0) return;
+
+    const overdueCount = items.filter((item) => item.isOverdue).length;
+    const dueTodayCount = items.filter((item) => !item.isOverdue).length;
+
+    const lines: string[] = [];
+    if (overdueCount > 0) lines.push(`期限切れ: ${overdueCount}件`);
+    if (dueTodayCount > 0) lines.push(`期限間近: ${dueTodayCount}件`);
+
+    const notification = new window.Notification("Nudge - アクションアイテムの期限", {
+      body: lines.join("\n"),
+      icon: "/favicon.ico",
+      tag: "nudge-action-reminder",
+    });
+
+    notification.onclick = () => {
+      window.focus();
+      window.location.href = "/actions";
+    };
+  }, [isEnabled, permission]);
+
+  return {
+    isSupported,
+    permission,
+    isEnabled,
+    setEnabled,
+    requestPermission,
+    checkAndNotify,
+  };
+}

--- a/src/lib/actions/__tests__/reminder-actions.test.ts
+++ b/src/lib/actions/__tests__/reminder-actions.test.ts
@@ -5,7 +5,7 @@ import { cleanDatabase } from "@/test-utils";
 
 import { createMeeting } from "../meeting-actions";
 import { createMember } from "../member-actions";
-import { getOverdueReminders } from "../reminder-actions";
+import { getActionItemsDueSoon, getOverdueReminders } from "../reminder-actions";
 
 beforeEach(async () => {
   await cleanDatabase();
@@ -156,6 +156,164 @@ describe("getOverdueReminders", () => {
       memberName: expect.any(String),
       meetingIntervalDays: expect.any(Number),
       daysSinceLastMeeting: expect.any(Number),
+    });
+  });
+});
+
+describe("getActionItemsDueSoon", () => {
+  it("アクションアイテムがない場合は空配列を返す", async () => {
+    const result = await getActionItemsDueSoon();
+    expect(result).toEqual([]);
+  });
+
+  it("期限なしのアクションアイテムは含まない", async () => {
+    const memberResult = await createMember({ name: "テストメンバー" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [{ title: "期限なしタスク", description: "" }],
+    });
+
+    const result = await getActionItemsDueSoon();
+    expect(result).toEqual([]);
+  });
+
+  it("完了済みアクションアイテムは含まない", async () => {
+    const memberResult = await createMember({ name: "テストメンバー" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const meetingResult = await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [{ title: "完了済みタスク", description: "", dueDate: today.toISOString() }],
+    });
+    if (!meetingResult.success) throw new Error(meetingResult.error);
+
+    // 完了済みにする
+    await prisma.actionItem.updateMany({
+      where: { meetingId: meetingResult.data.id },
+      data: { status: "DONE" },
+    });
+
+    const result = await getActionItemsDueSoon();
+    expect(result).toEqual([]);
+  });
+
+  it("期限が今日のアクションアイテムを返す", async () => {
+    const memberResult = await createMember({ name: "田中太郎" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [{ title: "今日締め切りタスク", description: "", dueDate: today.toISOString() }],
+    });
+
+    const result = await getActionItemsDueSoon();
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("今日締め切りタスク");
+    expect(result[0].memberName).toBe("田中太郎");
+    expect(result[0].isOverdue).toBe(false);
+  });
+
+  it("期限が明日のアクションアイテムを返す", async () => {
+    const memberResult = await createMember({ name: "鈴木次郎" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(12, 0, 0, 0);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [
+        { title: "明日締め切りタスク", description: "", dueDate: tomorrow.toISOString() },
+      ],
+    });
+
+    const result = await getActionItemsDueSoon();
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("明日締め切りタスク");
+    expect(result[0].memberName).toBe("鈴木次郎");
+    expect(result[0].isOverdue).toBe(false);
+  });
+
+  it("期限切れ（昨日以前）のアクションアイテムを返す（isOverdue=true）", async () => {
+    const memberResult = await createMember({ name: "佐藤三郎" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(12, 0, 0, 0);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [{ title: "期限切れタスク", description: "", dueDate: yesterday.toISOString() }],
+    });
+
+    const result = await getActionItemsDueSoon();
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("期限切れタスク");
+    expect(result[0].isOverdue).toBe(true);
+  });
+
+  it("期限が2日以上先のアクションアイテムは含まない", async () => {
+    const memberResult = await createMember({ name: "テストメンバー" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const dayAfterTomorrow = new Date();
+    dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [
+        { title: "将来のタスク", description: "", dueDate: dayAfterTomorrow.toISOString() },
+      ],
+    });
+
+    const result = await getActionItemsDueSoon();
+    expect(result).toEqual([]);
+  });
+
+  it("返り値の型が正しい", async () => {
+    const memberResult = await createMember({ name: "型チェックメンバー" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+
+    await createMeeting({
+      memberId: memberResult.data.id,
+      date: new Date().toISOString(),
+      topics: [],
+      actionItems: [{ title: "型チェックタスク", description: "", dueDate: today.toISOString() }],
+    });
+
+    const result = await getActionItemsDueSoon();
+    expect(result[0]).toMatchObject({
+      id: expect.any(String),
+      title: expect.any(String),
+      dueDate: expect.any(Date),
+      memberId: expect.any(String),
+      memberName: expect.any(String),
+      isOverdue: expect.any(Boolean),
     });
   });
 });

--- a/src/lib/actions/reminder-actions.ts
+++ b/src/lib/actions/reminder-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import type { OverdueReminder } from "@/lib/types";
+import type { ActionItemDueSoon, OverdueReminder } from "@/lib/types";
 
 export async function getOverdueReminders(): Promise<OverdueReminder[]> {
   const now = new Date();
@@ -55,4 +55,46 @@ export async function getOverdueReminders(): Promise<OverdueReminder[]> {
     if (b.daysSinceLastMeeting === null) return -1;
     return b.daysSinceLastMeeting - a.daysSinceLastMeeting;
   });
+}
+
+/**
+ * 期限が今日・明日・期限切れの未完了アクションアイテムを取得する（ブラウザ通知用）
+ */
+export async function getActionItemsDueSoon(): Promise<ActionItemDueSoon[]> {
+  const now = new Date();
+
+  // 今日の開始（00:00:00）
+  const todayStart = new Date(now);
+  todayStart.setHours(0, 0, 0, 0);
+
+  // 明日の終了（翌日 23:59:59.999）
+  const tomorrowEnd = new Date(todayStart);
+  tomorrowEnd.setDate(tomorrowEnd.getDate() + 2);
+  tomorrowEnd.setMilliseconds(tomorrowEnd.getMilliseconds() - 1);
+
+  const items = await prisma.actionItem.findMany({
+    where: {
+      status: { not: "DONE" },
+      dueDate: { lte: tomorrowEnd },
+    },
+    select: {
+      id: true,
+      title: true,
+      dueDate: true,
+      memberId: true,
+      member: { select: { name: true } },
+    },
+    orderBy: { dueDate: "asc" },
+  });
+
+  return items
+    .filter((item): item is typeof item & { dueDate: Date } => item.dueDate !== null)
+    .map((item) => ({
+      id: item.id,
+      title: item.title,
+      dueDate: item.dueDate,
+      memberId: item.memberId,
+      memberName: item.member.name,
+      isOverdue: item.dueDate < todayStart,
+    }));
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -34,7 +34,7 @@ export type {
   MemberTimelineEntry,
   MemberWithStats,
 } from "./member";
-export type { OverdueReminder } from "./reminder";
+export type { ActionItemDueSoon, OverdueReminder } from "./reminder";
 export type {
   ActionItemSearchResult,
   MemberSearchResult,

--- a/src/lib/types/reminder.ts
+++ b/src/lib/types/reminder.ts
@@ -7,3 +7,15 @@ export type OverdueReminder = {
   meetingIntervalDays: number;
   daysSinceLastMeeting: number | null;
 };
+
+/**
+ * 期限が近い・期限切れのアクションアイテム（ブラウザ通知用）
+ */
+export type ActionItemDueSoon = {
+  id: string;
+  title: string;
+  dueDate: Date;
+  memberId: string;
+  memberName: string;
+  isOverdue: boolean;
+};


### PR DESCRIPTION
## 概要

issue #230 の対応。Web Notifications API を使用して、期限当日・前日・期限切れのアクションアイテムをブラウザ通知でお知らせする機能を追加する。通知の有効/無効は設定ページで管理でき、通知を拒否してもアプリは正常に動作する。

## 変更内容

### 新規ファイル
- `src/app/settings/page.tsx` — 設定メインページ（通知設定 + テンプレート管理へのリンク）
- `src/components/notification/notification-initializer.tsx` — ルートレイアウトに組み込む通知初期化コンポーネント
- `src/components/notification/notification-settings.tsx` — 通知設定 UI（許可状態バッジ・有効/無効トグル）
- `src/components/ui/switch.tsx` — shadcn/ui Switch コンポーネント（新規追加）
- `src/hooks/use-notifications.ts` — 通知管理カスタムフック
- `src/hooks/__tests__/use-notifications.test.ts` — フックのユニットテスト（16件）

### 変更ファイル
- `src/app/layout.tsx` — `NotificationInitializer` を追加
- `src/components/layout/sidebar.tsx` — 設定リンクを `/settings/templates` → `/settings` に変更
- `src/lib/actions/reminder-actions.ts` — `getActionItemsDueSoon()` Server Action を追加
- `src/lib/actions/__tests__/reminder-actions.test.ts` — `getActionItemsDueSoon` テスト 8件追加
- `src/lib/types/reminder.ts` — `ActionItemDueSoon` 型を追加
- `src/lib/types/index.ts` — 型のエクスポートを追加

## 機能

- **ブラウザ通知**: 期限当日・前日・期限切れの未完了アクションアイテムを1日1回通知
- **許可リクエスト**: アプリ初回起動時に通知許可を自動リクエスト
- **設定ページ**: `/settings` で通知の有効/無効を切り替え、許可状態を確認
- **通知クリック**: クリックで `/actions` ページに遷移
- **重複防止**: `localStorage` の `lastNotifiedAt` で同日重複通知を防止
- **フォールバック**: 通知拒否・非対応ブラウザでもアプリが正常動作

## テスト計画

- [x] `npm test` — 148ファイル 1575テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] ブラウザで通知許可ダイアログが表示されることを確認
- [ ] 設定ページ（`/settings`）で通知トグルの切り替えを確認
- [ ] 期限当日・前日のアクションアイテムがある状態で通知が表示されることを確認
- [ ] 通知クリックで `/actions` に遷移することを確認
- [ ] 通知を拒否した状態でアプリが正常動作することを確認

Closes #230