### PR TITLE
feat: OS修飾キー表記の動的切り替えを実装 (issue #232)

### DIFF
--- a/src/components/layout/__tests__/shortcut-help-dialog.test.tsx
+++ b/src/components/layout/__tests__/shortcut-help-dialog.test.tsx
@@ -7,6 +7,7 @@ import { ShortcutHelpDialog } from "../shortcut-help-dialog";
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe("ShortcutHelpDialog", () => {
@@ -66,6 +67,38 @@ describe("ShortcutHelpDialog", () => {
       render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
 
       expect(screen.getByText("グローバル")).toBeDefined();
+    });
+  });
+
+  describe("OS 別修飾キー表記", () => {
+    it("Mac 環境では ⌘ K が表示される", () => {
+      vi.spyOn(window.navigator, "platform", "get").mockReturnValue("MacIntel");
+
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      const kbdElements = screen.getAllByRole("term");
+      const searchKbd = kbdElements.find((el) => el.textContent === "⌘ K");
+      expect(searchKbd).toBeDefined();
+    });
+
+    it("Windows 環境では Ctrl K が表示される", () => {
+      vi.spyOn(window.navigator, "platform", "get").mockReturnValue("Win32");
+
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      const kbdElements = screen.getAllByRole("term");
+      const searchKbd = kbdElements.find((el) => el.textContent === "Ctrl K");
+      expect(searchKbd).toBeDefined();
+    });
+
+    it("Linux 環境では Ctrl K が表示される", () => {
+      vi.spyOn(window.navigator, "platform", "get").mockReturnValue("Linux x86_64");
+
+      render(<ShortcutHelpDialog open={true} onClose={() => {}} />);
+
+      const kbdElements = screen.getAllByRole("term");
+      const searchKbd = kbdElements.find((el) => el.textContent === "Ctrl K");
+      expect(searchKbd).toBeDefined();
     });
   });
 

--- a/src/components/layout/shortcut-help-dialog.tsx
+++ b/src/components/layout/shortcut-help-dialog.tsx
@@ -7,7 +7,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { KEYBOARD_SHORTCUTS, type ShortcutContext } from "@/hooks/use-keyboard-shortcuts";
+import {
+  getModifierKey,
+  KEYBOARD_SHORTCUTS,
+  type ShortcutContext,
+} from "@/hooks/use-keyboard-shortcuts";
 
 type Props = {
   readonly open: boolean;
@@ -32,6 +36,9 @@ function ShortcutRow({ keyLabel, description }: { keyLabel: string; description:
 }
 
 export function ShortcutHelpDialog({ open, onClose, context }: Props) {
+  const modifierKey = getModifierKey();
+  const formatKey = (key: string) => key.replace("⌘", modifierKey);
+
   const globalShortcuts = KEYBOARD_SHORTCUTS.filter((s) => s.context === "global");
   const recordingShortcuts = KEYBOARD_SHORTCUTS.filter((s) => s.context === "recording");
 
@@ -52,7 +59,7 @@ export function ShortcutHelpDialog({ open, onClose, context }: Props) {
             </p>
             <dl className="space-y-3">
               {globalShortcuts.map(({ key, description }) => (
-                <ShortcutRow key={key} keyLabel={key} description={description} />
+                <ShortcutRow key={key} keyLabel={formatKey(key)} description={description} />
               ))}
             </dl>
           </section>
@@ -68,7 +75,7 @@ export function ShortcutHelpDialog({ open, onClose, context }: Props) {
               </p>
               <dl className="space-y-3">
                 {recordingShortcuts.map(({ key, description }) => (
-                  <ShortcutRow key={key} keyLabel={key} description={description} />
+                  <ShortcutRow key={key} keyLabel={formatKey(key)} description={description} />
                 ))}
               </dl>
             </section>

--- a/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
+++ b/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
@@ -2,7 +2,11 @@ import { fireEvent } from "@testing-library/dom";
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { KEYBOARD_SHORTCUTS, useKeyboardShortcuts } from "../use-keyboard-shortcuts";
+import {
+  getModifierKey,
+  KEYBOARD_SHORTCUTS,
+  useKeyboardShortcuts,
+} from "../use-keyboard-shortcuts";
 
 const defaultCallbacks = () => ({
   onNewMember: vi.fn(),
@@ -12,6 +16,39 @@ const defaultCallbacks = () => ({
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("getModifierKey", () => {
+  it("Mac 環境では ⌘ を返す", () => {
+    vi.spyOn(window.navigator, "platform", "get").mockReturnValue("MacIntel");
+
+    expect(getModifierKey()).toBe("⌘");
+  });
+
+  it("iPhone 環境では ⌘ を返す", () => {
+    vi.spyOn(window.navigator, "platform", "get").mockReturnValue("iPhone");
+
+    expect(getModifierKey()).toBe("⌘");
+  });
+
+  it("iPad 環境では ⌘ を返す", () => {
+    vi.spyOn(window.navigator, "platform", "get").mockReturnValue("iPad");
+
+    expect(getModifierKey()).toBe("⌘");
+  });
+
+  it("Windows 環境では Ctrl を返す", () => {
+    vi.spyOn(window.navigator, "platform", "get").mockReturnValue("Win32");
+
+    expect(getModifierKey()).toBe("Ctrl");
+  });
+
+  it("Linux 環境では Ctrl を返す", () => {
+    vi.spyOn(window.navigator, "platform", "get").mockReturnValue("Linux x86_64");
+
+    expect(getModifierKey()).toBe("Ctrl");
+  });
 });
 
 describe("KEYBOARD_SHORTCUTS 定数", () => {

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -22,6 +22,11 @@ export const KEYBOARD_SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
   { key: "Esc", description: "ダイアログを閉じる", context: "global" },
 ];
 
+export function getModifierKey(): string {
+  if (typeof window === "undefined") return "⌘";
+  return /Mac|iPod|iPhone|iPad/.test(window.navigator.platform) ? "⌘" : "Ctrl";
+}
+
 type ShortcutCallbacks = {
   readonly onNewMember: () => void;
   readonly onNewMeeting: () => void;


### PR DESCRIPTION
## 概要

issue #232 の対応。キーボードショートカット一覧ヘルプパネルで、OS（Mac/Windows/Linux）に応じて修飾キー表記を動的に切り替える。Mac では `⌘`、それ以外では `Ctrl` を表示する。

## 変更内容

### 変更ファイル
- `src/hooks/use-keyboard-shortcuts.ts` — `getModifierKey()` 関数を追加・エクスポート（SSR 安全、Mac → `⌘` / それ以外 → `Ctrl`）
- `src/components/layout/shortcut-help-dialog.tsx` — `getModifierKey()` を使用してキーラベルの `⌘` を動的置換
- `src/hooks/__tests__/use-keyboard-shortcuts.test.ts` — `getModifierKey()` の OS 別テスト 5 件を追加
- `src/components/layout/__tests__/shortcut-help-dialog.test.tsx` — OS 別修飾キー表示テスト 3 件を追加

## 機能

- **`getModifierKey()` ユーティリティ**: `window.navigator.platform` でOS判定し、Mac/iPhone/iPad → `⌘`、Windows/Linux → `Ctrl` を返す。SSR 時は `⌘` をデフォルト返す。
- **動的キーラベル変換**: `ShortcutHelpDialog` 内で `formatKey()` により `⌘` を OS に応じたキー表記に変換してレンダリング。

## テスト計画

- [x] `npm test` — 151 ファイル 1622 テスト全パス（+8 テスト追加）
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [ ] Mac 環境で `?` キー押下 → ヘルプパネルに `⌘ K` が表示されることを確認
- [ ] Windows/Linux 環境で `?` キー押下 → ヘルプパネルに `Ctrl K` が表示されることを確認

Closes #232