### PR TITLE
feat: メンバータイムラインにゴール達成エントリと期間フィルタを追加 (issue #276)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -18,7 +18,7 @@ import {
 import { MemberNoteTab } from "@/components/member/member-note-tab";
 import { MemberQuickActions } from "@/components/member/member-quick-actions";
 import { MemberStatsBar } from "@/components/member/member-stats-bar";
-import { MemberTimeline } from "@/components/member/member-timeline";
+import { MemberTimelineWrapper } from "@/components/member/member-timeline-wrapper";
 import { MoodTrendChart } from "@/components/member/mood-trend-chart";
 import { AvatarInitial } from "@/components/ui/avatar-initial";
 import { Button } from "@/components/ui/button";
@@ -129,7 +129,7 @@ export default async function MemberDetailPage({ params, searchParams }: Props) 
         <MemberDetailTabNav memberId={id} currentTab={currentTab} />
 
         {currentTab === "timeline" && timeline !== null && (
-          <MemberTimeline entries={timeline} memberId={id} />
+          <MemberTimelineWrapper entries={timeline} memberId={id} />
         )}
 
         {currentTab === "history" && meetingsPage !== null && (

--- a/src/components/member/__tests__/member-timeline-wrapper.test.tsx
+++ b/src/components/member/__tests__/member-timeline-wrapper.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { MemberTimelineEntry } from "@/lib/types";
+
+import { MemberTimelineWrapper } from "../member-timeline-wrapper";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+const memberId = "member-1";
+
+function generateEntries(): MemberTimelineEntry[] {
+  const now = new Date();
+  // 最近のエントリ（30日以内）
+  const recentEntries: MemberTimelineEntry[] = Array.from({ length: 3 }, (_, i) => ({
+    type: "meeting" as const,
+    id: `recent-meeting-${i}`,
+    date: new Date(now.getTime() - i * 7 * 24 * 60 * 60 * 1000),
+    mood: null,
+    topicCount: 1,
+    actionCount: 1,
+  }));
+
+  // 古いエントリ（120日前）
+  const oldEntries: MemberTimelineEntry[] = [
+    {
+      type: "meeting" as const,
+      id: "old-meeting-1",
+      date: new Date(now.getTime() - 120 * 24 * 60 * 60 * 1000),
+      mood: null,
+      topicCount: 2,
+      actionCount: 0,
+    },
+    {
+      type: "goal_completed" as const,
+      id: "old-goal-1",
+      title: "古いゴール達成",
+      completedAt: new Date(now.getTime() - 120 * 24 * 60 * 60 * 1000),
+      memberId,
+    },
+  ];
+
+  return [...recentEntries, ...oldEntries];
+}
+
+describe("MemberTimelineWrapper", () => {
+  it("デフォルトで全エントリを表示する", () => {
+    const entries = generateEntries();
+    render(<MemberTimelineWrapper entries={entries} memberId={memberId} />);
+    // 5件（threshold以上）なのでタイムラインが表示される
+    expect(screen.queryByText("まだ活動の記録がありません")).toBeNull();
+  });
+
+  it("期間フィルタが表示される", () => {
+    const entries = generateEntries();
+    render(<MemberTimelineWrapper entries={entries} memberId={memberId} />);
+    expect(screen.getByLabelText("期間フィルタ")).toBeDefined();
+  });
+
+  it("デフォルトで「全期間」が選択されている", () => {
+    const entries = generateEntries();
+    render(<MemberTimelineWrapper entries={entries} memberId={memberId} />);
+    expect(screen.getByText("全期間")).toBeDefined();
+  });
+});

--- a/src/components/member/__tests__/member-timeline.test.tsx
+++ b/src/components/member/__tests__/member-timeline.test.tsx
@@ -53,6 +53,14 @@ const overdueEntry: MemberTimelineEntry = {
   meetingId: "meeting-extra",
 };
 
+const goalCompletedEntry: MemberTimelineEntry = {
+  type: "goal_completed",
+  id: "goal-1",
+  title: "TypeScript 習得",
+  completedAt: new Date("2026-01-15T00:00:00Z"),
+  memberId: "member-1",
+};
+
 function generateEntries(count: number): MemberTimelineEntry[] {
   return Array.from({ length: count }, (_, i) => ({
     type: "meeting" as const,
@@ -101,6 +109,28 @@ describe("MemberTimeline", () => {
       <MemberTimeline entries={generateEntries(4).concat(overdueEntry)} memberId={memberId} />,
     );
     expect(screen.getByText("期限切れアクション")).toBeDefined();
+  });
+
+  it("ゴール達成エントリのタイトルを表示する", () => {
+    render(
+      <MemberTimeline
+        entries={generateEntries(4).concat(goalCompletedEntry)}
+        memberId={memberId}
+      />,
+    );
+    expect(screen.getByText("TypeScript 習得")).toBeDefined();
+  });
+
+  it("ゴール達成エントリのリンク先が正しい", () => {
+    render(
+      <MemberTimeline
+        entries={generateEntries(4).concat(goalCompletedEntry)}
+        memberId={memberId}
+      />,
+    );
+    const links = screen.getAllByRole("link");
+    const goalLink = links.find((l) => l.getAttribute("href") === `/members/${memberId}?tab=goals`);
+    expect(goalLink).toBeDefined();
   });
 
   it("タイムラインエントリにリンクが設定されている", () => {

--- a/src/components/member/__tests__/timeline-period-filter.test.tsx
+++ b/src/components/member/__tests__/timeline-period-filter.test.tsx
@@ -1,0 +1,31 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TimelinePeriodFilter } from "../timeline-period-filter";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TimelinePeriodFilter", () => {
+  it("デフォルトで「全期間」が選択されている", () => {
+    render(<TimelinePeriodFilter value="all" onChange={vi.fn()} />);
+    expect(screen.getByText("全期間")).toBeDefined();
+  });
+
+  it("「直近3ヶ月」を値に設定すると表示される", () => {
+    render(<TimelinePeriodFilter value="3months" onChange={vi.fn()} />);
+    expect(screen.getByText("直近3ヶ月")).toBeDefined();
+  });
+
+  it("「直近1ヶ月」を値に設定すると表示される", () => {
+    render(<TimelinePeriodFilter value="1month" onChange={vi.fn()} />);
+    expect(screen.getByText("直近1ヶ月")).toBeDefined();
+  });
+
+  it("aria-label が設定されている", () => {
+    render(<TimelinePeriodFilter value="all" onChange={vi.fn()} />);
+    expect(screen.getByLabelText("期間フィルタ")).toBeDefined();
+  });
+});

--- a/src/components/member/member-timeline-wrapper.tsx
+++ b/src/components/member/member-timeline-wrapper.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { MemberTimelineEntry } from "@/lib/types";
+
+import { MemberTimeline } from "./member-timeline";
+import { type TimelinePeriod, TimelinePeriodFilter } from "./timeline-period-filter";
+
+type Props = {
+  readonly entries: MemberTimelineEntry[];
+  readonly memberId: string;
+};
+
+function getEntryDate(entry: MemberTimelineEntry): Date {
+  if (entry.type === "meeting") return entry.date;
+  if (entry.type === "action_completed") return entry.completedAt;
+  if (entry.type === "goal_completed") return entry.completedAt;
+  return entry.dueDate;
+}
+
+function filterByPeriod(
+  entries: readonly MemberTimelineEntry[],
+  period: TimelinePeriod,
+): MemberTimelineEntry[] {
+  if (period === "all") return [...entries];
+  const now = new Date();
+  const days = period === "1month" ? 30 : 90;
+  const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  return entries.filter((entry) => getEntryDate(entry) >= cutoff);
+}
+
+export function MemberTimelineWrapper({ entries, memberId }: Props) {
+  const [period, setPeriod] = useState<TimelinePeriod>("all");
+
+  const filteredEntries = useMemo(() => filterByPeriod(entries, period), [entries, period]);
+
+  return (
+    <div>
+      <div className="flex justify-end mb-4">
+        <TimelinePeriodFilter value={period} onChange={setPeriod} />
+      </div>
+      <MemberTimeline entries={filteredEntries} memberId={memberId} />
+    </div>
+  );
+}

--- a/src/components/member/member-timeline.tsx
+++ b/src/components/member/member-timeline.tsx
@@ -1,4 +1,4 @@
-import { Activity, AlertTriangle, Calendar, CheckCircle2 } from "lucide-react";
+import { Activity, AlertTriangle, Calendar, CheckCircle2, Target } from "lucide-react";
 import Link from "next/link";
 
 import { EmptyState } from "@/components/ui/empty-state";
@@ -79,6 +79,26 @@ function ActionOverdueContent({
   );
 }
 
+function GoalCompletedContent({
+  entry,
+}: {
+  entry: Extract<MemberTimelineEntry, { type: "goal_completed" }>;
+}) {
+  return (
+    <Link
+      href={`/members/${entry.memberId}?tab=goals`}
+      className="block group rounded-lg border border-purple-200 bg-purple-50 px-4 py-3 hover:bg-purple-100 transition-colors dark:border-purple-800 dark:bg-purple-900/20 dark:hover:bg-purple-900/30"
+    >
+      <p className="text-sm font-medium text-foreground group-hover:text-purple-700 dark:group-hover:text-purple-400">
+        {entry.title}
+      </p>
+      <p className="mt-1 text-sm text-purple-600 dark:text-purple-400">
+        達成日: {formatDate(entry.completedAt)}
+      </p>
+    </Link>
+  );
+}
+
 const ENTRY_STYLES = {
   meeting: {
     icon: Calendar,
@@ -91,6 +111,10 @@ const ENTRY_STYLES = {
   action_overdue: {
     icon: AlertTriangle,
     iconClass: "text-destructive bg-destructive/10",
+  },
+  goal_completed: {
+    icon: Target,
+    iconClass: "text-purple-600 bg-purple-100 dark:bg-purple-900/30",
   },
 } as const;
 
@@ -132,6 +156,7 @@ export function MemberTimeline({ entries, memberId }: Props) {
                 {entry.type === "action_overdue" && (
                   <ActionOverdueContent entry={entry} memberId={memberId} />
                 )}
+                {entry.type === "goal_completed" && <GoalCompletedContent entry={entry} />}
               </div>
             </li>
           );

--- a/src/components/member/timeline-period-filter.tsx
+++ b/src/components/member/timeline-period-filter.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export type TimelinePeriod = "1month" | "3months" | "all";
+
+const PERIOD_OPTIONS: { value: TimelinePeriod; label: string }[] = [
+  { value: "all", label: "全期間" },
+  { value: "3months", label: "直近3ヶ月" },
+  { value: "1month", label: "直近1ヶ月" },
+];
+
+type Props = {
+  readonly value: TimelinePeriod;
+  readonly onChange: (value: TimelinePeriod) => void;
+};
+
+export function TimelinePeriodFilter({ value, onChange }: Props) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as TimelinePeriod)}>
+      <SelectTrigger className="w-[140px]" aria-label="期間フィルタ">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {PERIOD_OPTIONS.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/lib/actions/__tests__/member-actions.test.ts
+++ b/src/lib/actions/__tests__/member-actions.test.ts
@@ -337,6 +337,48 @@ describe("getMemberTimeline", () => {
     }
   });
 
+  it("includes goal_completed entries for COMPLETED goals", async () => {
+    const memberResult = await createMember({ name: "Goal Member" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    // ゴールを作成して COMPLETED にする
+    const goal = await prisma.goal.create({
+      data: {
+        memberId: memberResult.data.id,
+        title: "Completed Goal",
+        status: "COMPLETED",
+        progress: 100,
+      },
+    });
+
+    const entries = await getMemberTimeline(memberResult.data.id);
+    const goalEntries = entries.filter((e) => e.type === "goal_completed");
+    expect(goalEntries).toHaveLength(1);
+    if (goalEntries[0].type === "goal_completed") {
+      expect(goalEntries[0].title).toBe("Completed Goal");
+      expect(goalEntries[0].memberId).toBe(memberResult.data.id);
+      expect(goalEntries[0].id).toBe(goal.id);
+    }
+  });
+
+  it("does not include IN_PROGRESS goals in timeline", async () => {
+    const memberResult = await createMember({ name: "Active Goal Member" });
+    if (!memberResult.success) throw new Error(memberResult.error);
+
+    await prisma.goal.create({
+      data: {
+        memberId: memberResult.data.id,
+        title: "In Progress Goal",
+        status: "IN_PROGRESS",
+        progress: 50,
+      },
+    });
+
+    const entries = await getMemberTimeline(memberResult.data.id);
+    const goalEntries = entries.filter((e) => e.type === "goal_completed");
+    expect(goalEntries).toHaveLength(0);
+  });
+
   it("does not include non-overdue pending actions", async () => {
     const memberResult = await createMember({ name: "Future Action" });
     if (!memberResult.success) throw new Error(memberResult.error);

--- a/src/lib/actions/member-actions.ts
+++ b/src/lib/actions/member-actions.ts
@@ -105,7 +105,7 @@ export async function getMemberMeetings(
 export async function getMemberTimeline(memberId: string): Promise<MemberTimelineEntry[]> {
   if (!memberId) return [];
   const now = new Date();
-  const [meetings, completedActions, overdueActions] = await Promise.all([
+  const [meetings, completedActions, overdueActions, completedGoals] = await Promise.all([
     prisma.meeting.findMany({
       where: { memberId },
       orderBy: { date: "desc" },
@@ -128,6 +128,9 @@ export async function getMemberTimeline(memberId: string): Promise<MemberTimelin
         dueDate: { lt: now },
       },
       include: { meeting: { select: { id: true } } },
+    }),
+    prisma.goal.findMany({
+      where: { memberId, status: "COMPLETED" },
     }),
   ]);
 
@@ -164,12 +167,22 @@ export async function getMemberTimeline(memberId: string): Promise<MemberTimelin
           meetingId: a.meeting!.id,
         }),
       ),
+    ...completedGoals.map(
+      (g): MemberTimelineEntry => ({
+        type: "goal_completed",
+        id: g.id,
+        title: g.title,
+        completedAt: g.updatedAt,
+        memberId: g.memberId,
+      }),
+    ),
   ];
 
   return entries.sort((a, b) => {
     const getDate = (e: MemberTimelineEntry): Date => {
       if (e.type === "meeting") return e.date;
       if (e.type === "action_completed") return e.completedAt;
+      if (e.type === "goal_completed") return e.completedAt;
       return e.dueDate;
     };
     return getDate(b).getTime() - getDate(a).getTime();

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -32,6 +32,7 @@ export type {
   ActionCompletedEntry,
   ActionItemWithMeeting,
   ActionOverdueEntry,
+  GoalCompletedEntry,
   MeetingsPage,
   MeetingTimelineEntry,
   MeetingWithRelations,

--- a/src/lib/types/member.ts
+++ b/src/lib/types/member.ts
@@ -72,6 +72,21 @@ export type ActionOverdueEntry = {
 };
 
 /**
+ * タイムラインエントリ（ゴール達成）
+ */
+export type GoalCompletedEntry = {
+  type: "goal_completed";
+  id: string;
+  title: string;
+  completedAt: Date;
+  memberId: string;
+};
+
+/**
  * メンバータイムラインエントリ（ユニオン型）
  */
-export type MemberTimelineEntry = MeetingTimelineEntry | ActionCompletedEntry | ActionOverdueEntry;
+export type MemberTimelineEntry =
+  | MeetingTimelineEntry
+  | ActionCompletedEntry
+  | ActionOverdueEntry
+  | GoalCompletedEntry;


### PR DESCRIPTION
## 概要

issue #276 の対応。メンバー詳細ページのタイムラインビューに**ゴール達成イベント**の表示と**期間フィルタ**を追加し、メンバーの成長や課題の推移をより把握しやすくする。

## 変更内容

### 新規ファイル
- `src/lib/types/member.ts` — `GoalCompletedEntry` 型を追加
- `src/components/member/timeline-period-filter.tsx` — 期間フィルタ Select コンポーネント（全期間/直近3ヶ月/直近1ヶ月）
- `src/components/member/member-timeline-wrapper.tsx` — フィルタ状態管理 + MemberTimeline 統合の Client Component
- `src/components/member/__tests__/timeline-period-filter.test.tsx` — TimelinePeriodFilter テスト（4件）
- `src/components/member/__tests__/member-timeline-wrapper.test.tsx` — MemberTimelineWrapper テスト（3件）

### 変更ファイル
- `src/lib/types/member.ts` — `GoalCompletedEntry` 型追加、`MemberTimelineEntry` ユニオン拡張
- `src/lib/types/index.ts` — `GoalCompletedEntry` エクスポート追加
- `src/lib/actions/member-actions.ts` — `getMemberTimeline` に COMPLETED ゴール取得クエリ追加、ソートヘルパー更新
- `src/components/member/member-timeline.tsx` — `GoalCompletedContent` コンポーネント追加（紫色 Target アイコン）、`ENTRY_STYLES` に `goal_completed` 追加
- `src/app/members/[id]/page.tsx` — `MemberTimeline` → `MemberTimelineWrapper` に差し替え
- `src/lib/actions/__tests__/member-actions.test.ts` — ゴール達成エントリのテスト2件追加
- `src/components/member/__tests__/member-timeline.test.tsx` — ゴール達成エントリ表示・リンクテスト2件追加

## 機能

- **ゴール達成エントリ**: COMPLETED ステータスのゴールをタイムラインに紫色の Target アイコンで表示。リンク先は `/members/{id}?tab=goals`
- **期間フィルタ**: 「全期間」「直近3ヶ月」「直近1ヶ月」で絞り込み可能な Select コンポーネント

## テスト計画

- [x] `npm test` — 171ファイル 1864テスト全パス
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npx tsc --noEmit` — 型チェック通過（pre-commit hook で確認済み）
- [ ] メンバー詳細ページのタイムラインタブでゴール達成イベントが紫アイコンで表示されること
- [ ] 期間フィルタで絞り込みが動作すること
- [ ] ゴール達成エントリのリンクが `/members/{id}?tab=goals` に遷移すること

Closes #276